### PR TITLE
more robustly locate header

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -336,7 +336,7 @@ function findActiveClause(root, path) {
 
   while ($clause = clauses.nextNode()) {
     var rect = $clause.getBoundingClientRect();
-    var $header = $clause.children[0];
+    var $header = $clause.querySelector("h1");
     var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
 
     if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/1789. See [that issue](https://github.com/tc39/ecma262/issues/1789#issuecomment-557365767) for context.

The `querySelector` is guaranteed to succeed because every clause is [required](https://github.com/tc39/ecmarkup/blob/master/src/Clause.ts#L134-L136) to have a [header](https://github.com/tc39/ecmarkup/blob/b27317bc9a78f67a04b2ace5babd0ba05e930f68/src/H1.ts#L10).