### PR TITLE
ecmarkdown preserves trailing whitespace; do not copy it

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,12 +7,11 @@ import * as fs from 'fs';
 
 /*@internal*/
 export function emdTextNode(spec: Spec, node: Node) {
-  // emd strips starting and ending spaces which we want to preserve
+  // emd strips starting spaces which we want to preserve
   const startSpace = node.textContent!.match(/^\s*/)![0];
-  const endSpace = node.textContent!.match(/\s*$/)![0];
 
   const template = spec.doc.createElement('template');
-  template.innerHTML = startSpace + emd.fragment(node.textContent!) + endSpace;
+  template.innerHTML = startSpace + emd.fragment(node.textContent!);
 
   replaceTextNode(node, template.content);
 }

--- a/test/baselines/reference/autolinking.html
+++ b/test/baselines/reference/autolinking.html
@@ -19,8 +19,8 @@
   <p><emu-xref href="#sec-foo" id="_ref_4"><a href="#sec-foo">extra spaces</a></emu-xref> in a dfn should be narrowed to one space.</p>
   <p><emu-xref href="#sec-foo" id="_ref_5"><a href="#sec-foo">%Percent%</a></emu-xref> should autolink.</p>
   <p>Vars to dfns should be vars not dfns: <var>Lowercase</var>.</p>
-  <p>Also, no autolinks in  <a href="#">anchors: Lowercase</a>.</p>
-  <p>Similarly, no autolinks for  <sub>[Await]</sub>.</p>
+  <p>Also, no autolinks in <a href="#">anchors: Lowercase</a>.</p>
+  <p>Similarly, no autolinks for <sub>[Await]</sub>.</p>
 </emu-clause>
 <p><emu-xref href="#sec-array-constructor"><a href="https://tc39.es/ecma262/#sec-array-constructor">%Array%</a></emu-xref> and <emu-xref href="#sec-properties-of-the-array-prototype-object"><a href="https://tc39.es/ecma262/#sec-properties-of-the-array-prototype-object">%ArrayPrototype%</a></emu-xref> outside of clauses is ok.</p>
 </div></body>

--- a/test/baselines/reference/boilerplate-address.html
+++ b/test/baselines/reference/boilerplate-address.html
@@ -8,7 +8,7 @@
 <p class="ECMAaddress">New York City, New York</p>
 <p class="ECMAaddress">Tel: 123-456-7890</p>
 <p class="ECMAaddress">Fax: 123-456-7890</p>
-<p class="ECMAaddress">Web:  <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
+<p class="ECMAaddress">Web: <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
 
       <h2>Copyright Notice</h2>
       <p>© 2018 Ecma International</p>

--- a/test/baselines/reference/boilerplate-all.html
+++ b/test/baselines/reference/boilerplate-all.html
@@ -8,7 +8,7 @@
 <p class="ECMAaddress">New York City, New York</p>
 <p class="ECMAaddress">Tel: 123-456-7890</p>
 <p class="ECMAaddress">Fax: 123-456-7890</p>
-<p class="ECMAaddress">Web:  <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
+<p class="ECMAaddress">Web: <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
 
       <h2>Copyright Notice</h2>
       <p>© 2018 Rick Waldron, Mid-World</p>

--- a/test/baselines/reference/boilerplate-copyright.html
+++ b/test/baselines/reference/boilerplate-copyright.html
@@ -8,7 +8,7 @@
 <p class="ECMAaddress">CH-1204 Geneva</p>
 <p class="ECMAaddress">Tel: +41 22 849 6000</p>
 <p class="ECMAaddress">Fax: +41 22 849 6001</p>
-<p class="ECMAaddress">Web:  <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
+<p class="ECMAaddress">Web: <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
 
       <h2>Copyright Notice</h2>
       <p>© 2018 Rick Waldron, Mid-World</p>

--- a/test/baselines/reference/boilerplate-license.html
+++ b/test/baselines/reference/boilerplate-license.html
@@ -8,7 +8,7 @@
 <p class="ECMAaddress">CH-1204 Geneva</p>
 <p class="ECMAaddress">Tel: +41 22 849 6000</p>
 <p class="ECMAaddress">Fax: +41 22 849 6001</p>
-<p class="ECMAaddress">Web:  <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
+<p class="ECMAaddress">Web: <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
 
       <h2>Copyright Notice</h2>
       <p>© 2018 Ecma International</p>

--- a/test/baselines/reference/copyright.html
+++ b/test/baselines/reference/copyright.html
@@ -9,7 +9,7 @@
 <p class="ECMAaddress">CH-1204 Geneva</p>
 <p class="ECMAaddress">Tel: +41 22 849 6000</p>
 <p class="ECMAaddress">Fax: +41 22 849 6001</p>
-<p class="ECMAaddress">Web:  <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
+<p class="ECMAaddress">Web: <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
 
       <h2>Copyright Notice</h2>
       <p>© 2014 Ecma International</p>

--- a/test/baselines/reference/dfn.html
+++ b/test/baselines/reference/dfn.html
@@ -8,9 +8,9 @@
 <emu-clause id="sec-dfn">
   <h1><span class="secnum">1</span> dfn</h1>
 
-  <p>The term  <dfn>dfn</dfn> means the dfn tag. Other mentions of dfn in this clause should not be auto-linked.</p>
+  <p>The term <dfn>dfn</dfn> means the dfn tag. Other mentions of dfn in this clause should not be auto-linked.</p>
 
-  <p>Terms with ids are called  <dfn id="identifiers">id dfns</dfn>. Since this dfn has an id, other occurences
+  <p>Terms with ids are called <dfn id="identifiers">id dfns</dfn>. Since this dfn has an id, other occurences
   of <emu-xref href="#identifiers" id="_ref_2"><a href="#identifiers">id dfns</a></emu-xref> may autolink.</p>
 
   <emu-clause id="sec-dfn-subclause">

--- a/test/baselines/reference/duplicate-ids.html
+++ b/test/baselines/reference/duplicate-ids.html
@@ -7,7 +7,6 @@
 
     <emu-example id="an-example" caption="An example"><figure><figcaption>Example (Informative): An example</figcaption>
       Multiple examples are numbered similar to notes
-    
     </figure></emu-example>
   </emu-clause>
 </emu-clause>
@@ -30,7 +29,6 @@
   </figure></emu-table>
   <emu-example id="an-example" caption="An example"><figure><figcaption>Example (Informative): An example</figcaption>
     Multiple examples are numbered similar to notes
-  
   </figure></emu-example>
 </emu-clause>
 </div></body>

--- a/test/baselines/reference/eqn.html
+++ b/test/baselines/reference/eqn.html
@@ -16,6 +16,6 @@
   <emu-alg><ol><li>Return <emu-xref aoid="Value" id="_ref_6"><a href="#sec-example">Value</a></emu-xref>(<var>val</var>);
   </li></ol></emu-alg>
 
-  <p>Inline eqns are a thing, for example  <emu-eqn class="inline"><emu-xref aoid="DateValue" id="_ref_7"><a href="#eqn-DateValue">DateValue</a></emu-xref>(n)</emu-eqn> or  <emu-eqn class="inline">1 + 1 = 2</emu-eqn></p>
+  <p>Inline eqns are a thing, for example <emu-eqn class="inline"><emu-xref aoid="DateValue" id="_ref_7"><a href="#eqn-DateValue">DateValue</a></emu-xref>(n)</emu-eqn> or <emu-eqn class="inline">1 + 1 = 2</emu-eqn></p>
 </emu-clause>
 </div></body>

--- a/test/baselines/reference/escaping.html
+++ b/test/baselines/reference/escaping.html
@@ -4,6 +4,6 @@
 <h1 class="first"><span class="secnum">1</span> blah</h1>
 <p>U+200C (ZERO WIDTH NON-JOINER) is abbreviated "&lt;ZWNJ&gt;"</p>
 <p>&lt;b&gt;also doesn't escape when <emu-val>emd</emu-val> and autolinks to <emu-xref aoid="ReturnIfAbrupt" id="_ref_1"><a href="https://tc39.es/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a></emu-xref> are present.</p>
-<p>Escpaing inside xref is preserved:  <emu-xref href="#blah" id="_ref_0"><a href="#blah">&lt;b&gt;</a></emu-xref>.</p>
+<p>Escpaing inside xref is preserved: <emu-xref href="#blah" id="_ref_0"><a href="#blah">&lt;b&gt;</a></emu-xref>.</p>
 </emu-clause>
 </div></body>

--- a/test/baselines/reference/example.html
+++ b/test/baselines/reference/example.html
@@ -3,26 +3,22 @@
 <p>Examples outside of clauses aren't processed specially.</p>
 <emu-example>
   This is an example.
-
 </emu-example>
 
 <emu-clause id="sec-example">
   <h1><span class="secnum">1</span> Example Section</h1>
   <emu-example><figure><figcaption>Example (Informative)</figcaption>
     Examples inside clauses are numbered and have captions. Captions are optional.
-  
   </figure></emu-example>
 
   <emu-clause id="sec-example-subclause">
     <h1><span class="secnum">1.1</span> Example Subclause</h1>
     <emu-example caption="An example"><figure><figcaption>Example 1 (Informative): An example</figcaption>
       Multiple examples are numbered similar to notes
-    
     </figure></emu-example>
 
     <emu-example caption="A second example"><figure><figcaption>Example 2 (Informative): A second example</figcaption>
       So this becomes example 2.
-    
     </figure></emu-example>
   </emu-clause>
 </emu-clause>

--- a/test/baselines/reference/figure.html
+++ b/test/baselines/reference/figure.html
@@ -3,13 +3,11 @@
 <link rel="stylesheet" href="css/elements.css">
 <emu-figure id="figure-1"><figure><figcaption>Figure 1</figcaption>
   this is a figure!
-
 </figure></emu-figure>
 
 <!-- deprecated: caption element -->
 <emu-figure id="figure-2" informative="" caption="Informative figure"><figure><figcaption>Figure 2 (Informative): Informative figure</figcaption>
   this is a figure!
-
 </figure></emu-figure>
 
 <emu-table id="table-1" caption="An example table"><figure><figcaption>Table 1: An example table</figcaption>
@@ -37,7 +35,6 @@
 <emu-figure id="figure-2" informative=""><figure><figcaption>Figure 3 (Informative): This is the caption</figcaption>
   
   this is a figure!
-
 </figure></emu-figure>
 
 <emu-table id="table-1"><figure><figcaption>Table 3: This is a table</figcaption>
@@ -53,7 +50,7 @@
   </tbody></table>
 </figure></emu-table>
 
-<emu-table id="table-2" informative=""><figure><figcaption>Table 4 (Informative): This is a  <b>second</b> table</figcaption>
+<emu-table id="table-2" informative=""><figure><figcaption>Table 4 (Informative): This is a <b>second</b> table</figcaption>
   
   <table>
     <tbody><tr><th>Column 1</th><th>Column 2</th></tr>

--- a/test/baselines/reference/grammar.html
+++ b/test/baselines/reference/grammar.html
@@ -18,7 +18,7 @@
     <emu-nt><a href="#prod-HTMLEntitiesExample">HTMLEntitiesExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="23da2165"><emu-gprose>This is technically a “production”</emu-gprose></emu-rhs>
 </emu-production></emu-grammar>
 
-<p>Can also have inline productions like  <emu-grammar><emu-production name="Atom" type="lexical" collapsed="" id="prod-Atom" class=" inline">
+<p>Can also have inline productions like <emu-grammar><emu-production name="Atom" type="lexical" collapsed="" id="prod-Atom" class=" inline">
     <emu-nt><a href="#prod-Atom">Atom</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="34eb148f"><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Disjunction">Disjunction</a></emu-nt><emu-t>)</emu-t></emu-rhs>
 </emu-production></emu-grammar>.</p>
 

--- a/test/baselines/reference/imports.html
+++ b/test/baselines/reference/imports.html
@@ -8,7 +8,6 @@
   <emu-import href="sub/import3.html"><emu-clause id="import3">
   <h1><span class="secnum">1.1</span> Import 3</h1>
   wtf??
-
 </emu-clause>
 </emu-import>
 </emu-clause>

--- a/test/baselines/reference/namespaces.html
+++ b/test/baselines/reference/namespaces.html
@@ -26,8 +26,8 @@
     </emu-clause>
 
     <p><emu-xref aoid="SomeAlg" id="_ref_2"><a href="#annex21">SomeAlg</a></emu-xref> does things.</p>
-    <p>Can still xref clauses inside of namespaces:  <emu-xref href="#annex11" id="_ref_0"><a href="#annex11">A.1</a></emu-xref>.</p>
-    <p>Can xref prods in namespaces:  <emu-xref href="#prod-annex-Foo" id="_ref_1"><a href="#prod-annex-Foo"><emu-nt>Foo</emu-nt></a></emu-xref>.</p>
+    <p>Can still xref clauses inside of namespaces: <emu-xref href="#annex11" id="_ref_0"><a href="#annex11">A.1</a></emu-xref>.</p>
+    <p>Can xref prods in namespaces: <emu-xref href="#prod-annex-Foo" id="_ref_1"><a href="#prod-annex-Foo"><emu-nt>Foo</emu-nt></a></emu-xref>.</p>
   </emu-clause>
 </emu-clause>
 <emu-annex id="annex1" namespace="annex">

--- a/test/baselines/reference/oldids.html
+++ b/test/baselines/reference/oldids.html
@@ -2,7 +2,7 @@
 <head><meta charset="utf-8"></head><body><div id="spec-container">
 <emu-clause id="c1" oldids="old1,old2">
   <span id="old2"></span><span id="old1"></span><h1 class="first"><span class="secnum">1</span> c1</h1>
-  <p>This is some  <dfn id="content" oldids="olddfn">content<span id="olddfn"></span></dfn> and such.</p>
+  <p>This is some <dfn id="content" oldids="olddfn">content<span id="olddfn"></span></dfn> and such.</p>
   <emu-clause id="c2" oldids="old3,old4">
     <span id="old4"></span><span id="old3"></span><h1><span class="secnum">1.1</span> c1.1</h1>
   </emu-clause>

--- a/test/baselines/reference/test.html
+++ b/test/baselines/reference/test.html
@@ -31,7 +31,6 @@
   <emu-import href="sub/import3.html"><emu-clause id="import3">
   <h1><span class="secnum">1.3.1</span> Import 3</h1>
   wtf??
-
 </emu-clause>
 </emu-import>
 </emu-clause>
@@ -72,7 +71,6 @@
 
   <p>
     Inline production:
-    
     <emu-production name="Identifier" type="lexical" collapsed="" id="prod-Identifier" class=" inline">
       <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt><emu-gmod>but not
       <emu-nt><a href="https://tc39.es/ecma262/#prod-ReservedWord">ReservedWord</a></emu-nt></emu-gmod></emu-rhs>
@@ -107,7 +105,7 @@
 
   <emu-production name="FooBar" params="Yeild" type="lexical" a="a" collapsed="">
     <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs></emu-production>
-  <p>Inline prodref:  <emu-production name="FooBar" params="Yeild" type="lexical" a="a" collapsed="" class=" inline">
+  <p>Inline prodref: <emu-production name="FooBar" params="Yeild" type="lexical" a="a" collapsed="" class=" inline">
     <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs></emu-production></p>
 
   <pre><code class="language-javascript hljs"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">test</span>(<span class="hljs-params"></span>) </span>{ };

--- a/test/baselines/reference/xref.html
+++ b/test/baselines/reference/xref.html
@@ -60,28 +60,23 @@
 
     <emu-example id="example-2" caption="Foo Caption"><figure><figcaption>Example 1 (Informative): Foo Caption</figcaption>
       This is an example
-    
     </figure></emu-example>
 
     <emu-example id="example-3" caption="Foo Caption"><figure><figcaption>Example 2 (Informative): Foo Caption</figcaption>
       This is an example
-    
     </figure></emu-example>
 
     <emu-note id="note-1"><span class="note"><a href="#note-1">Note</a></span><div class="note-contents">
       This is another note
-    
     </div></emu-note>
   </emu-clause>
 
   <emu-example id="example-1" caption="Foo Caption"><figure><figcaption>Example (Informative): Foo Caption</figcaption>
     This is an example
-  
   </figure></emu-example>
 
   <emu-note id="note-2"><span class="note"><a href="#note-2">Note</a></span><div class="note-contents">
     This is a note!
-  
   </div></emu-note>
 
   <emu-note id="editors-note" type="editor"><span class="note"><a href="#editors-note">Editor's Note</a></span><div class="note-contents">
@@ -92,7 +87,6 @@
 
   <emu-figure id="figure-1"><figure><figcaption>Figure 1</figcaption>
     this is a figure!
-  
   </figure></emu-figure>
 
   <emu-table id="table-1" caption="An example table"><figure><figcaption>Table 1: An example table</figcaption>


### PR DESCRIPTION
The only effect this has on ecma-262 master is to get rid of some doubled spaces and linebreaks..

<details>
<summary>first few hundred lines of the diff</summary>

```diff
diff --git a/out-ecmarkup-master-without-header.html b/out-tweak-without-header.html
index d785e83..f5d3582 100644
--- a/out-ecmarkup-master-without-header.html
+++ b/out-tweak-without-header.html
@@ -11,9 +11,8 @@
   <ul>
-    <li>GitHub Repository:  <a href="https://github.com/tc39/ecma262">https://github.com/tc39/ecma262</a></li>
-    <li>Issues:  <a href="https://github.com/tc39/ecma262/issues">All Issues</a>,  <a href="https://github.com/tc39/ecma262/issues/new">File a New Issue</a></li>
-    <li>Pull Requests:  <a href="https://github.com/tc39/ecma262/pulls">All Pull Requests</a>,  <a href="https://github.com/tc39/ecma262/pulls/new">Create a New Pull Request</a></li>
-    <li>Test Suite:  <a href="https://github.com/tc39/test262">Test262</a></li>
+    <li>GitHub Repository: <a href="https://github.com/tc39/ecma262">https://github.com/tc39/ecma262</a></li>
+    <li>Issues: <a href="https://github.com/tc39/ecma262/issues">All Issues</a>, <a href="https://github.com/tc39/ecma262/issues/new">File a New Issue</a></li>
+    <li>Pull Requests: <a href="https://github.com/tc39/ecma262/pulls">All Pull Requests</a>, <a href="https://github.com/tc39/ecma262/pulls/new">Create a New Pull Request</a></li>
+    <li>Test Suite: <a href="https://github.com/tc39/test262">Test262</a></li>
     <li>
       Editors:
-      
       <ul>
@@ -27,7 +26,6 @@
       Community:
-      
       <ul>
-        <li>Discourse:  <a href="https://es.discourse.group">https://es.discourse.group</a></li>
-        <li>IRC:  <a href="ircs://irc.freenode.net:6667">#tc39</a> on  <a href="https://freenode.net/kb/answer/chat">freenode</a></li>
-        <li>Mailing  <emu-not-ref>List</emu-not-ref> Archives:  <a href="https://esdiscuss.org">https://esdiscuss.org/</a></li>
+        <li>Discourse: <a href="https://es.discourse.group">https://es.discourse.group</a></li>
+        <li>IRC: <a href="ircs://irc.freenode.net:6667">#tc39</a> on <a href="https://freenode.net/kb/answer/chat">freenode</a></li>
+        <li>Mailing <emu-not-ref>List</emu-not-ref> Archives: <a href="https://esdiscuss.org">https://esdiscuss.org/</a></li>
       </ul>
@@ -35,5 +33,5 @@
   </ul>
-  <p>Refer to the  <emu-xref href="#sec-colophon" id="_ref_0"><a href="#sec-colophon">colophon</a></emu-xref> for more information on how this document is created.</p>
+  <p>Refer to the <emu-xref href="#sec-colophon" id="_ref_0"><a href="#sec-colophon">colophon</a></emu-xref> for more information on how this document is created.</p>
   <h1>About this Specification</h1>
-  <p>This document at  <a href=".">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any  <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the  <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
+  <p>This document at <a href=".">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
 </div>
@@ -59,3 +57,2 @@
     ECMA-262, Project Editor, 6<sup>th</sup> Edition
-  
   </p>
@@ -64,3 +61,2 @@
     ECMA-262, Project Editor, 7<sup>th</sup> through 10<sup>th</sup> Editions
-  
   </p>
@@ -69,3 +65,2 @@
     ECMA-262, Project Editor, 10<sup>th</sup> through 12<sup>th</sup> Editions
-  
   </p>
@@ -84,4 +79,4 @@
   <p>A conforming implementation of ECMAScript may provide additional types, values, objects, properties, and functions beyond those described in this specification. In particular, a conforming implementation of ECMAScript may provide properties not described in this specification, and values for those properties, for objects that are described in this specification.</p>
-  <p>A conforming implementation of ECMAScript may support program and regular expression syntax not described in this specification. In particular, a conforming implementation of ECMAScript may support program syntax that makes use of any “future reserved words” noted in subclause  <emu-xref href="#sec-keywords-and-reserved-words" id="_ref_1"><a href="#sec-keywords-and-reserved-words">11.6.2</a></emu-xref> of this specification.</p>
-  <p>A conforming implementation of ECMAScript must not implement any extension that is listed as a Forbidden Extension in subclause  <emu-xref href="#sec-forbidden-extensions" id="_ref_2"><a href="#sec-forbidden-extensions">16.1</a></emu-xref>.</p>
+  <p>A conforming implementation of ECMAScript may support program and regular expression syntax not described in this specification. In particular, a conforming implementation of ECMAScript may support program syntax that makes use of any “future reserved words” noted in subclause <emu-xref href="#sec-keywords-and-reserved-words" id="_ref_1"><a href="#sec-keywords-and-reserved-words">11.6.2</a></emu-xref> of this specification.</p>
+  <p>A conforming implementation of ECMAScript must not implement any extension that is listed as a Forbidden Extension in subclause <emu-xref href="#sec-forbidden-extensions" id="_ref_2"><a href="#sec-forbidden-extensions">16.1</a></emu-xref>.</p>
 </emu-clause>
@@ -91,9 +86,7 @@
   <p>The following referenced documents are indispensable for the application of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
-  <p>ISO/IEC 10646  <i>Information Technology — Universal Multiple-Octet Coded Character Set (UCS) plus Amendment 1:2005, Amendment 2:2006, Amendment 3:2008, and Amendment 4:2008</i>, plus additional amendments and corrigenda, or successor</p>
-  <p>ECMA-402,  <i>ECMAScript 2015 Internationalization API Specification</i>.
-    
+  <p>ISO/IEC 10646 <i>Information Technology — Universal Multiple-Octet Coded Character Set (UCS) plus Amendment 1:2005, Amendment 2:2006, Amendment 3:2008, and Amendment 4:2008</i>, plus additional amendments and corrigenda, or successor</p>
+  <p>ECMA-402, <i>ECMAScript 2015 Internationalization API Specification</i>.
     <br>
     <a href="https://ecma-international.org/publications/standards/Ecma-402.htm">https://ecma-international.org/publications/standards/Ecma-402.htm</a></p>
-  <p>ECMA-404,  <i>The JSON Data Interchange Format</i>.
-    
+  <p>ECMA-404, <i>The JSON Data Interchange Format</i>.
     <br>
@@ -106,9 +99,9 @@
   <p>ECMAScript is an object-oriented programming language for performing computations and manipulating computational objects within a host environment. ECMAScript as defined here is not intended to be computationally self-sufficient; indeed, there are no provisions in this specification for input of external data or output of computed results. Instead, it is expected that the computational environment of an ECMAScript program will provide not only the objects and other facilities described in this specification but also certain environment-specific objects, whose description and behaviour are beyond the scope of this specification except to indicate that they may provide certain properties that can be accessed and certain functions that can be called from an ECMAScript program.</p>
-  <p>ECMAScript was originally designed to be used as a scripting language, but has become widely used as a general-purpose programming language. A  <em>scripting language</em> is a programming language that is used to manipulate, customize, and automate the facilities of an existing system. In such systems, useful functionality is already available through a user interface, and the scripting language is a mechanism for exposing that functionality to program control. In this way, the existing system is said to provide a host environment of objects and facilities, which completes the capabilities of the scripting language. A scripting language is intended for use by both professional and non-professional programmers.</p>
-  <p>ECMAScript was originally designed to be a  <em>Web scripting language</em>, providing a mechanism to enliven Web pages in browsers and to perform server computation as part of a Web-based client-server architecture. ECMAScript is now used to provide core scripting capabilities for a variety of host environments. Therefore the core language is specified in this document apart from any particular host environment.</p>
+  <p>ECMAScript was originally designed to be used as a scripting language, but has become widely used as a general-purpose programming language. A <em>scripting language</em> is a programming language that is used to manipulate, customize, and automate the facilities of an existing system. In such systems, useful functionality is already available through a user interface, and the scripting language is a mechanism for exposing that functionality to program control. In this way, the existing system is said to provide a host environment of objects and facilities, which completes the capabilities of the scripting language. A scripting language is intended for use by both professional and non-professional programmers.</p>
+  <p>ECMAScript was originally designed to be a <em>Web scripting language</em>, providing a mechanism to enliven Web pages in browsers and to perform server computation as part of a Web-based client-server architecture. ECMAScript is now used to provide core scripting capabilities for a variety of host environments. Therefore the core language is specified in this document apart from any particular host environment.</p>
   <p>ECMAScript usage has moved beyond simple scripting and it is now used for the full spectrum of programming tasks in many different environments and scales. As the usage of ECMAScript has expanded, so have the features and facilities it provides. ECMAScript is now a fully featured general-purpose programming language.</p>
   <p>Some of the facilities of ECMAScript are similar to those used in other programming languages; in particular C, Java™, Self, and Scheme as described in:</p>
-  <p>ISO/IEC 9899:1996,  <i>Programming Languages — C</i>.</p>
-  <p>Gosling, James, Bill Joy and Guy Steele.  <i>The Java<sup>™</sup> Language Specification</i>. Addison Wesley Publishing Co., 1996.</p>
-  <p>Ungar, David, and Smith, Randall B. Self: The Power of Simplicity.  <i>OOPSLA '87 Conference Proceedings</i>, pp. 227-241, Orlando, FL, October 1987.</p>
+  <p>ISO/IEC 9899:1996, <i>Programming Languages — C</i>.</p>
+  <p>Gosling, James, Bill Joy and Guy Steele. <i>The Java<sup>™</sup> Language Specification</i>. Addison Wesley Publishing Co., 1996.</p>
+  <p>Ungar, David, and Smith, Randall B. Self: The Power of Simplicity. <i>OOPSLA '87 Conference Proceedings</i>, pp. 227-241, Orlando, FL, October 1987.</p>
   <p><i>IEEE Standard for the Scheme Programming Language</i>. IEEE Std 1178-1990.</p>
@@ -125,6 +118,6 @@
     <p>The following is an informal overview of ECMAScript—not all parts of the language are described. This overview is not part of the standard proper.</p>
-    <p>ECMAScript is object-based: basic language and host facilities are provided by objects, and an ECMAScript program is a cluster of communicating objects. In ECMAScript, an  <em>object</em> is a collection of zero or more  <em>properties</em> each with  <em>attributes</em> that determine how each property can be used—for example, when the Writable attribute for a property is set to <emu-val>false</emu-val>, any attempt by executed ECMAScript code to assign a different value to the property fails. Properties are containers that hold other objects,  <em>primitive values</em>, or  <em>functions</em>. A primitive value is a member of one of the following built-in types:  <b>Undefined</b>,  <b>Null</b>,  <b>Boolean</b>,  <b>Number</b>,  <b>BigInt</b>,  <b>String</b>, and  <b>Symbol;</b> an object is a member of the built-in type  <b>Object</b>; and a function is a callable object. A function that is associated with an object via a property is called a  <em>method</em>.</p>
-    <p>ECMAScript defines a collection of  <em>built-in objects</em> that round out the definition of ECMAScript entities. These built-in objects include the <emu-xref href="#sec-global-object" id="_ref_911"><a href="#sec-global-object">global object</a></emu-xref>; objects that are fundamental to the <emu-xref href="#sec-runtime-semantics" id="_ref_912"><a href="#sec-runtime-semantics">runtime semantics</a></emu-xref> of the language including <code>Object</code>, <code>Function</code>, <code>Boolean</code>, <code>Symbol</code>, and various <code>Error</code> objects; objects that represent and manipulate numeric values including <code>Math</code>, <code>Number</code>, and <code>Date</code>; the text processing objects <code>String</code> and <code>RegExp</code>; objects that are indexed collections of values including <code>Array</code> and nine different kinds of Typed Arrays whose elements all have a specific numeric data representation; keyed collections including <code>Map</code> and <code>Set</code> objects; objects supporting structured data including the <code>JSON</code> object, <code>ArrayBuffer</code>, <code>SharedArrayBuffer</code>, and <code>DataView</code>; objects supporting control abstractions including generator functions and <code>Promise</code> objects; and reflection objects including <code>Proxy</code> and <code>Reflect</code>.</p>
-    <p>ECMAScript also defines a set of built-in  <em>operators</em>. ECMAScript operators include various unary operations, multiplicative operators, additive operators, bitwise shift operators, relational operators, equality operators, binary bitwise operators, binary logical operators, assignment operators, and the comma operator.</p>
-    <p>Large ECMAScript programs are supported by  <em>modules</em> which allow a program to be divided into multiple sequences of statements and declarations. Each module explicitly identifies declarations it uses that need to be provided by other modules and which of its declarations are available for use by other modules.</p>
+    <p>ECMAScript is object-based: basic language and host facilities are provided by objects, and an ECMAScript program is a cluster of communicating objects. In ECMAScript, an <em>object</em> is a collection of zero or more <em>properties</em> each with <em>attributes</em> that determine how each property can be used—for example, when the Writable attribute for a property is set to <emu-val>false</emu-val>, any attempt by executed ECMAScript code to assign a different value to the property fails. Properties are containers that hold other objects, <em>primitive values</em>, or <em>functions</em>. A primitive value is a member of one of the following built-in types: <b>Undefined</b>, <b>Null</b>, <b>Boolean</b>, <b>Number</b>, <b>BigInt</b>, <b>String</b>, and <b>Symbol;</b> an object is a member of the built-in type <b>Object</b>; and a function is a callable object. A function that is associated with an object via a property is called a <em>method</em>.</p>
+    <p>ECMAScript defines a collection of <em>built-in objects</em> that round out the definition of ECMAScript entities. These built-in objects include the <emu-xref href="#sec-global-object" id="_ref_911"><a href="#sec-global-object">global object</a></emu-xref>; objects that are fundamental to the <emu-xref href="#sec-runtime-semantics" id="_ref_912"><a href="#sec-runtime-semantics">runtime semantics</a></emu-xref> of the language including <code>Object</code>, <code>Function</code>, <code>Boolean</code>, <code>Symbol</code>, and various <code>Error</code> objects; objects that represent and manipulate numeric values including <code>Math</code>, <code>Number</code>, and <code>Date</code>; the text processing objects <code>String</code> and <code>RegExp</code>; objects that are indexed collections of values including <code>Array</code> and nine different kinds of Typed Arrays whose elements all have a specific numeric data representation; keyed collections including <code>Map</code> and <code>Set</code> objects; objects supporting structured data including the <code>JSON</code> object, <code>ArrayBuffer</code>, <code>SharedArrayBuffer</code>, and <code>DataView</code>; objects supporting control abstractions including generator functions and <code>Promise</code> objects; and reflection objects including <code>Proxy</code> and <code>Reflect</code>.</p>
+    <p>ECMAScript also defines a set of built-in <em>operators</em>. ECMAScript operators include various unary operations, multiplicative operators, additive operators, bitwise shift operators, relational operators, equality operators, binary bitwise operators, binary logical operators, assignment operators, and the comma operator.</p>
+    <p>Large ECMAScript programs are supported by <em>modules</em> which allow a program to be divided into multiple sequences of statements and declarations. Each module explicitly identifies declarations it uses that need to be provided by other modules and which of its declarations are available for use by other modules.</p>
     <p>ECMAScript syntax intentionally resembles Java syntax. ECMAScript syntax is relaxed to enable it to serve as an easy-to-use scripting language. For example, a variable is not required to have its type declared nor are types associated with properties, and defined functions are not required to have their declarations appear textually before calls to them.</p>
@@ -133,4 +126,4 @@
       <h1><span class="secnum">4.2.1</span> Objects</h1>
-      <p>Even though ECMAScript includes syntax for class definitions, ECMAScript objects are not fundamentally class-based such as those in C++, Smalltalk, or Java. Instead objects may be created in various ways including via a literal notation or via  <em>constructors</em> which create objects and then execute code that initializes all or part of them by assigning initial values to their properties. Each <emu-xref href="#constructor" id="_ref_913"><a href="#constructor">constructor</a></emu-xref> is a function that has a property named <emu-val>"prototype"</emu-val> that is used to implement  <em>prototype-based inheritance</em> and  <em>shared properties</em>. Objects are created by using constructors in  <b>new</b> expressions; for example, <code>new Date(2009, 11)</code> creates a new Date object. Invoking a <emu-xref href="#constructor" id="_ref_914"><a href="#constructor">constructor</a></emu-xref> without using  <b>new</b> has consequences that depend on the <emu-xref href="#constructor" id="_ref_915"><a href="#constructor">constructor</a></emu-xref>. For example, <code>Date()</code> produces a string representation of the current date and time rather than an object.</p>
-      <p>Every object created by a <emu-xref href="#constructor" id="_ref_916"><a href="#constructor">constructor</a></emu-xref> has an implicit reference (called the object's  <em>prototype</em>) to the value of its <emu-xref href="#constructor" id="_ref_917"><a href="#constructor">constructor</a></emu-xref>'s <emu-val>"prototype"</emu-val> property. Furthermore, a prototype may have a non-null implicit reference to its prototype, and so on; this is called the  <em>prototype chain</em>. When a reference is made to a property in an object, that reference is to the property of that name in the first object in the prototype chain that contains a property of that name. In other words, first the object mentioned directly is examined for such a property; if that object contains the named property, that is the property to which the reference refers; if that object does not contain the named property, the prototype for that object is examined next; and so on.</p>
+      <p>Even though ECMAScript includes syntax for class definitions, ECMAScript objects are not fundamentally class-based such as those in C++, Smalltalk, or Java. Instead objects may be created in various ways including via a literal notation or via <em>constructors</em> which create objects and then execute code that initializes all or part of them by assigning initial values to their properties. Each <emu-xref href="#constructor" id="_ref_913"><a href="#constructor">constructor</a></emu-xref> is a function that has a property named <emu-val>"prototype"</emu-val> that is used to implement <em>prototype-based inheritance</em> and <em>shared properties</em>. Objects are created by using constructors in <b>new</b> expressions; for example, <code>new Date(2009, 11)</code> creates a new Date object. Invoking a <emu-xref href="#constructor" id="_ref_914"><a href="#constructor">constructor</a></emu-xref> without using <b>new</b> has consequences that depend on the <emu-xref href="#constructor" id="_ref_915"><a href="#constructor">constructor</a></emu-xref>. For example, <code>Date()</code> produces a string representation of the current date and time rather than an object.</p>
+      <p>Every object created by a <emu-xref href="#constructor" id="_ref_916"><a href="#constructor">constructor</a></emu-xref> has an implicit reference (called the object's <em>prototype</em>) to the value of its <emu-xref href="#constructor" id="_ref_917"><a href="#constructor">constructor</a></emu-xref>'s <emu-val>"prototype"</emu-val> property. Furthermore, a prototype may have a non-null implicit reference to its prototype, and so on; this is called the <em>prototype chain</em>. When a reference is made to a property in an object, that reference is to the property of that name in the first object in the prototype chain that contains a property of that name. In other words, first the object mentioned directly is examined for such a property; if that object contains the named property, that is the property to which the reference refers; if that object does not contain the named property, the prototype for that object is examined next; and so on.</p>
       <emu-figure id="figure-1" caption="Object/Prototype Relationships"><figure><figcaption>Figure 1: Object/Prototype Relationships</figcaption>
@@ -140,4 +133,4 @@
       <p>All objects that do not directly contain a particular property that their prototype contains share that property and its value. Figure 1 illustrates this:</p>
-      <p><b>CF</b> is a <emu-xref href="#constructor" id="_ref_918"><a href="#constructor">constructor</a></emu-xref> (and also an object). Five objects have been created by using <code>new</code> expressions:  <b>cf<sub>1</sub></b>,  <b>cf<sub>2</sub></b>,  <b>cf<sub>3</sub></b>,  <b>cf<sub>4</sub></b>, and  <b>cf<sub>5</sub></b>. Each of these objects contains properties named <emu-val>"q1"</emu-val> and <emu-val>"q2"</emu-val>. The dashed lines represent the implicit prototype relationship; so, for example,  <b>cf<sub>3</sub></b>'s prototype is  <b>CF<sub>p</sub></b>. The <emu-xref href="#constructor" id="_ref_919"><a href="#constructor">constructor</a></emu-xref>,  <b>CF</b>, has two properties itself, named <emu-val>"P1"</emu-val> and <emu-val>"P2"</emu-val>, which are not visible to  <b>CF<sub>p</sub></b>,  <b>cf<sub>1</sub></b>,  <b>cf<sub>2</sub></b>,  <b>cf<sub>3</sub></b>,  <b>cf<sub>4</sub></b>, or  <b>cf<sub>5</sub></b>. The property named <emu-val>"CFP1"</emu-val> in  <b>CF<sub>p</sub></b> is shared by  <b>cf<sub>1</sub></b>,  <b>cf<sub>2</sub></b>,  <b>cf<sub>3</sub></b>,  <b>cf<sub>4</sub></b>, and  <b>cf<sub>5</sub></b> (but not by  <b>CF</b>), as are any properties found in  <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named <emu-val>"q1"</emu-val>, <emu-val>"q2"</emu-val>, or <emu-val>"CFP1"</emu-val>. Notice that there is no implicit prototype link between  <b>CF</b> and  <b>CF<sub>p</sub></b>.</p>
-      <p>Unlike most class-based object languages, properties can be added to objects dynamically by assigning values to them. That is, constructors are not required to name or assign values to all or any of the constructed object's properties. In the above diagram, one could add a new shared property for  <b>cf<sub>1</sub></b>,  <b>cf<sub>2</sub></b>,  <b>cf<sub>3</sub></b>,  <b>cf<sub>4</sub></b>, and  <b>cf<sub>5</sub></b> by assigning a new value to the property in  <b>CF<sub>p</sub></b>.</p>
+      <p><b>CF</b> is a <emu-xref href="#constructor" id="_ref_918"><a href="#constructor">constructor</a></emu-xref> (and also an object). Five objects have been created by using <code>new</code> expressions: <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b>. Each of these objects contains properties named <emu-val>"q1"</emu-val> and <emu-val>"q2"</emu-val>. The dashed lines represent the implicit prototype relationship; so, for example, <b>cf<sub>3</sub></b>'s prototype is <b>CF<sub>p</sub></b>. The <emu-xref href="#constructor" id="_ref_919"><a href="#constructor">constructor</a></emu-xref>, <b>CF</b>, has two properties itself, named <emu-val>"P1"</emu-val> and <emu-val>"P2"</emu-val>, which are not visible to <b>CF<sub>p</sub></b>, <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, or <b>cf<sub>5</sub></b>. The property named <emu-val>"CFP1"</emu-val> in <b>CF<sub>p</sub></b> is shared by <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> (but not by <b>CF</b>), as are any properties found in <b>CF<sub>p</sub></b>'s implicit prototype chain that are not named <emu-val>"q1"</emu-val>, <emu-val>"q2"</emu-val>, or <emu-val>"CFP1"</emu-val>. Notice that there is no implicit prototype link between <b>CF</b> and <b>CF<sub>p</sub></b>.</p>
+      <p>Unlike most class-based object languages, properties can be added to objects dynamically by assigning values to them. That is, constructors are not required to name or assign values to all or any of the constructed object's properties. In the above diagram, one could add a new shared property for <b>cf<sub>1</sub></b>, <b>cf<sub>2</sub></b>, <b>cf<sub>3</sub></b>, <b>cf<sub>4</sub></b>, and <b>cf<sub>5</sub></b> by assigning a new value to the property in <b>CF<sub>p</sub></b>.</p>
       <p>Although ECMAScript objects are not inherently class-based, it is often convenient to define class-like abstractions based upon a common pattern of <emu-xref href="#constructor" id="_ref_920"><a href="#constructor">constructor</a></emu-xref> functions, prototype objects, and methods. The ECMAScript built-in objects themselves follow such a class-like pattern. Beginning with ECMAScript 2015, the ECMAScript language includes syntactic class definitions that permit programmers to concisely define objects that conform to the same class-like abstraction pattern used by the built-in objects.</p>
@@ -148,3 +141,3 @@
       <p>The ECMAScript Language recognizes the possibility that some users of the language may wish to restrict their usage of some features available in the language. They might do so in the interests of security, to avoid what they consider to be error-prone features, to get enhanced error checking, or for other reasons of their choosing. In support of this possibility, ECMAScript defines a strict variant of the language. The strict variant of the language excludes some specific syntactic and semantic features of the regular ECMAScript language and modifies the detailed semantics of some features. The strict variant also specifies additional error conditions that must be reported by throwing error exceptions in situations that are not specified as errors by the non-strict form of the language.</p>
-      <p>The strict variant of ECMAScript is commonly referred to as the  <em>strict mode</em> of the language. Strict mode selection and use of the strict mode syntax and semantics of ECMAScript is explicitly made at the level of individual ECMAScript source text units. Because strict mode is selected at the level of a syntactic source text unit, strict mode only imposes restrictions that have local effect within such a source text unit. Strict mode does not restrict or modify any aspect of the ECMAScript semantics that must operate consistently across multiple source text units. A complete ECMAScript program may be composed of both strict mode and non-strict mode ECMAScript source text units. In this case, strict mode only applies when actually executing code that is defined within a strict mode source text unit.</p>
+      <p>The strict variant of ECMAScript is commonly referred to as the <em>strict mode</em> of the language. Strict mode selection and use of the strict mode syntax and semantics of ECMAScript is explicitly made at the level of individual ECMAScript source text units. Because strict mode is selected at the level of a syntactic source text unit, strict mode only imposes restrictions that have local effect within such a source text unit. Strict mode does not restrict or modify any aspect of the ECMAScript semantics that must operate consistently across multiple source text units. A complete ECMAScript program may be composed of both strict mode and non-strict mode ECMAScript source text units. In this case, strict mode only applies when actually executing code that is defined within a strict mode source text unit.</p>
       <p>In order to conform to this specification, an ECMAScript implementation must implement both the full unrestricted ECMAScript language and the strict variant of the ECMAScript language as defined by this specification. In addition, an implementation must support the combination of unrestricted and strict mode source text units into a single composite program.</p>
@@ -159,3 +152,3 @@
       <h1><span class="secnum">4.3.1</span> type</h1>
-      <p>set of data values as defined in clause  <emu-xref href="#sec-ecmascript-data-types-and-values" id="_ref_3"><a href="#sec-ecmascript-data-types-and-values">6</a></emu-xref> of this specification</p>
+      <p>set of data values as defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values" id="_ref_3"><a href="#sec-ecmascript-data-types-and-values">6</a></emu-xref> of this specification</p>
     </emu-clause>
@@ -164,3 +157,3 @@
       <h1><span class="secnum">4.3.2</span> primitive value</h1>
-      <p>member of one of the types Undefined, Null, Boolean, Number, BigInt, Symbol, or String as defined in clause  <emu-xref href="#sec-ecmascript-data-types-and-values" id="_ref_4"><a href="#sec-ecmascript-data-types-and-values">6</a></emu-xref></p>
+      <p>member of one of the types Undefined, Null, Boolean, Number, BigInt, Symbol, or String as defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values" id="_ref_4"><a href="#sec-ecmascript-data-types-and-values">6</a></emu-xref></p>
       <emu-note><span class="note">Note</span><div class="note-contents">
@@ -190,3 +183,3 @@
       <emu-note><span class="note">Note</span><div class="note-contents">
-        <p>When a <emu-xref href="#constructor" id="_ref_923"><a href="#constructor">constructor</a></emu-xref> creates an object, that object implicitly references the <emu-xref href="#constructor" id="_ref_924"><a href="#constructor">constructor</a></emu-xref>'s <emu-val>"prototype"</emu-val> property for the purpose of resolving property references. The <emu-xref href="#constructor" id="_ref_925"><a href="#constructor">constructor</a></emu-xref>'s <emu-val>"prototype"</emu-val> property can be referenced by the program expression  <code><var>constructor</var>.prototype</code>, and properties added to an object's prototype are shared, through inheritance, by all objects sharing the prototype. Alternatively, a new object may be created with an explicitly specified prototype by using the <code>Object.create</code> built-in function.</p>
+        <p>When a <emu-xref href="#constructor" id="_ref_923"><a href="#constructor">constructor</a></emu-xref> creates an object, that object implicitly references the <emu-xref href="#constructor" id="_ref_924"><a href="#constructor">constructor</a></emu-xref>'s <emu-val>"prototype"</emu-val> property for the purpose of resolving property references. The <emu-xref href="#constructor" id="_ref_925"><a href="#constructor">constructor</a></emu-xref>'s <emu-val>"prototype"</emu-val> property can be referenced by the program expression <code><var>constructor</var>.prototype</code>, and properties added to an object's prototype are shared, through inheritance, by all objects sharing the prototype. Alternatively, a new object may be created with an explicitly specified prototype by using the <code>Object.create</code> built-in function.</p>
       </div></emu-note>
@@ -216,3 +209,3 @@
       <emu-note><span class="note">Note</span><div class="note-contents">
-        <p>Standard built-in objects are defined in this specification. An ECMAScript implementation may specify and supply additional kinds of built-in objects. A  <em>built-in <emu-xref href="#constructor" id="_ref_928"><a href="#constructor">constructor</a></emu-xref></em> is a built-in object that is also a <emu-xref href="#constructor" id="_ref_929"><a href="#constructor">constructor</a></emu-xref>.</p>
+        <p>Standard built-in objects are defined in this specification. An ECMAScript implementation may specify and supply additional kinds of built-in objects. A <em>built-in <emu-xref href="#constructor" id="_ref_928"><a href="#constructor">constructor</a></emu-xref></em> is a built-in object that is also a <emu-xref href="#constructor" id="_ref_929"><a href="#constructor">constructor</a></emu-xref>.</p>
       </div></emu-note>
@@ -418,5 +411,5 @@
       <h1><span class="secnum">5.1.1</span> Context-Free Grammars</h1>
-      <p>A  <em>context-free grammar</em> consists of a number of  <em>productions</em>. Each production has an abstract symbol called a  <em>nonterminal</em> as its  <em>left-hand side</em>, and a sequence of zero or more nonterminal and  <em>terminal</em> symbols as its  <em>right-hand side</em>. For each grammar, the terminal symbols are drawn from a specified alphabet.</p>
-      <p>A  <dfn>chain production</dfn> is a production that has exactly one nonterminal symbol on its right-hand side along with zero or more terminal symbols.</p>
-      <p>Starting from a sentence consisting of a single distinguished nonterminal, called the  <dfn>goal symbol</dfn>, a given context-free grammar specifies a  <em>language</em>, namely, the (perhaps infinite) set of possible sequences of terminal symbols that can result from repeatedly replacing any nonterminal in the sequence with a right-hand side of a production for which the nonterminal is the left-hand side.</p>
+      <p>A <em>context-free grammar</em> consists of a number of <em>productions</em>. Each production has an abstract symbol called a <em>nonterminal</em> as its <em>left-hand side</em>, and a sequence of zero or more nonterminal and <em>terminal</em> symbols as its <em>right-hand side</em>. For each grammar, the terminal symbols are drawn from a specified alphabet.</p>
+      <p>A <dfn>chain production</dfn> is a production that has exactly one nonterminal symbol on its right-hand side along with zero or more terminal symbols.</p>
+      <p>Starting from a sentence consisting of a single distinguished nonterminal, called the <dfn>goal symbol</dfn>, a given context-free grammar specifies a <em>language</em>, namely, the (perhaps infinite) set of possible sequences of terminal symbols that can result from repeatedly replacing any nonterminal in the sequence with a right-hand side of a production for which the nonterminal is the left-hand side.</p>
     </emu-clause>
@@ -425,5 +418,5 @@
       <h1><span class="secnum">5.1.2</span> The Lexical and RegExp Grammars</h1>
-      <p>A  <em>lexical grammar</em> for ECMAScript is given in clause  <emu-xref href="#sec-ecmascript-language-lexical-grammar" id="_ref_7"><a href="#sec-ecmascript-language-lexical-grammar">11</a></emu-xref>. This grammar has as its terminal symbols Unicode code points that conform to the rules for <emu-nt id="_ref_9693"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> defined in  <emu-xref href="#sec-source-text" id="_ref_8"><a href="#sec-source-text">10.1</a></emu-xref>. It defines a set of productions, starting from the <emu-xref href="#sec-context-free-grammars" id="_ref_953"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref> <emu-nt id="_ref_9694"><a href="#prod-InputElementDiv">InputElementDiv</a></emu-nt>, <emu-nt id="_ref_9695"><a href="#prod-InputElementTemplateTail">InputElementTemplateTail</a></emu-nt>, or <emu-nt id="_ref_9696"><a href="#prod-InputElementRegExp">InputElementRegExp</a></emu-nt>, or <emu-nt id="_ref_9697"><a href="#prod-InputElementRegExpOrTemplateTail">InputElementRegExpOrTemplateTail</a></emu-nt>, that describe how sequences of such code points are translated into a sequence of input elements.</p>
-      <p>Input elements other than white space and comments form the terminal symbols for the syntactic grammar for ECMAScript and are called ECMAScript  <em>tokens</em>. These tokens are the reserved words, identifiers, literals, and punctuators of the ECMAScript language. Moreover, line terminators, although not considered to be tokens, also become part of the stream of input elements and guide the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion" id="_ref_9"><a href="#sec-automatic-semicolon-insertion">11.9</a></emu-xref>). Simple white space and single-line comments are discarded and do not appear in the stream of input elements for the syntactic grammar. A <emu-nt id="_ref_9698"><a href="#prod-MultiLineComment">MultiLineComment</a></emu-nt> (that is, a comment of the form <code>/*</code>…<code>*/</code> regardless of whether it spans more than one line) is likewise simply discarded if it contains no line terminator; but if a <emu-nt id="_ref_9699"><a href="#prod-MultiLineComment">MultiLineComment</a></emu-nt> contains one or more line terminators, then it is replaced by a single line terminator, which becomes part of the stream of input elements for the syntactic grammar.</p>
-      <p>A  <em>RegExp grammar</em> for ECMAScript is given in  <emu-xref href="#sec-patterns" id="_ref_10"><a href="#sec-patterns">21.2.1</a></emu-xref>. This grammar also has as its terminal symbols the code points as defined by <emu-nt id="_ref_9700"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt>. It defines a set of productions, starting from the <emu-xref href="#sec-context-free-grammars" id="_ref_954"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref> <emu-nt id="_ref_9701"><a href="#prod-Pattern">Pattern</a></emu-nt>, that describe how sequences of code points are translated into regular expression patterns.</p>
+      <p>A <em>lexical grammar</em> for ECMAScript is given in clause <emu-xref href="#sec-ecmascript-language-lexical-grammar" id="_ref_7"><a href="#sec-ecmascript-language-lexical-grammar">11</a></emu-xref>. This grammar has as its terminal symbols Unicode code points that conform to the rules for <emu-nt id="_ref_9693"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> defined in <emu-xref href="#sec-source-text" id="_ref_8"><a href="#sec-source-text">10.1</a></emu-xref>. It defines a set of productions, starting from the <emu-xref href="#sec-context-free-grammars" id="_ref_953"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref> <emu-nt id="_ref_9694"><a href="#prod-InputElementDiv">InputElementDiv</a></emu-nt>, <emu-nt id="_ref_9695"><a href="#prod-InputElementTemplateTail">InputElementTemplateTail</a></emu-nt>, or <emu-nt id="_ref_9696"><a href="#prod-InputElementRegExp">InputElementRegExp</a></emu-nt>, or <emu-nt id="_ref_9697"><a href="#prod-InputElementRegExpOrTemplateTail">InputElementRegExpOrTemplateTail</a></emu-nt>, that describe how sequences of such code points are translated into a sequence of input elements.</p>
+      <p>Input elements other than white space and comments form the terminal symbols for the syntactic grammar for ECMAScript and are called ECMAScript <em>tokens</em>. These tokens are the reserved words, identifiers, literals, and punctuators of the ECMAScript language. Moreover, line terminators, although not considered to be tokens, also become part of the stream of input elements and guide the process of automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion" id="_ref_9"><a href="#sec-automatic-semicolon-insertion">11.9</a></emu-xref>). Simple white space and single-line comments are discarded and do not appear in the stream of input elements for the syntactic grammar. A <emu-nt id="_ref_9698"><a href="#prod-MultiLineComment">MultiLineComment</a></emu-nt> (that is, a comment of the form <code>/*</code>…<code>*/</code> regardless of whether it spans more than one line) is likewise simply discarded if it contains no line terminator; but if a <emu-nt id="_ref_9699"><a href="#prod-MultiLineComment">MultiLineComment</a></emu-nt> contains one or more line terminators, then it is replaced by a single line terminator, which becomes part of the stream of input elements for the syntactic grammar.</p>
+      <p>A <em>RegExp grammar</em> for ECMAScript is given in <emu-xref href="#sec-patterns" id="_ref_10"><a href="#sec-patterns">21.2.1</a></emu-xref>. This grammar also has as its terminal symbols the code points as defined by <emu-nt id="_ref_9700"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt>. It defines a set of productions, starting from the <emu-xref href="#sec-context-free-grammars" id="_ref_954"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref> <emu-nt id="_ref_9701"><a href="#prod-Pattern">Pattern</a></emu-nt>, that describe how sequences of code points are translated into regular expression patterns.</p>
       <p>Productions of the lexical and RegExp grammars are distinguished by having two colons “<b>::</b>” as separating punctuation. The lexical and RegExp grammars share some productions.</p>
@@ -433,3 +426,3 @@
       <h1><span class="secnum">5.1.3</span> The Numeric String Grammar</h1>
-      <p>Another grammar is used for translating Strings into numeric values. This grammar is similar to the part of the lexical grammar having to do with numeric literals and has as its terminal symbols <emu-nt id="_ref_9702"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt>. This grammar appears in  <emu-xref href="#sec-tonumber-applied-to-the-string-type" id="_ref_11"><a href="#sec-tonumber-applied-to-the-string-type">7.1.4.1</a></emu-xref>.</p>
+      <p>Another grammar is used for translating Strings into numeric values. This grammar is similar to the part of the lexical grammar having to do with numeric literals and has as its terminal symbols <emu-nt id="_ref_9702"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt>. This grammar appears in <emu-xref href="#sec-tonumber-applied-to-the-string-type" id="_ref_11"><a href="#sec-tonumber-applied-to-the-string-type">7.1.4.1</a></emu-xref>.</p>
       <p>Productions of the numeric string grammar are distinguished by having three colons “<b>:::</b>” as punctuation.</p>
@@ -439,6 +432,6 @@
       <h1><span class="secnum">5.1.4</span> The Syntactic Grammar</h1>
-      <p>The  <em>syntactic grammar</em> for ECMAScript is given in clauses 11, 12, 13, 14, and 15. This grammar has ECMAScript tokens defined by the lexical grammar as its terminal symbols (<emu-xref href="#sec-lexical-and-regexp-grammars" id="_ref_12"><a href="#sec-lexical-and-regexp-grammars">5.1.2</a></emu-xref>). It defines a set of productions, starting from two alternative goal symbols <emu-nt id="_ref_9703"><a href="#prod-Script">Script</a></emu-nt> and <emu-nt id="_ref_9704"><a href="#prod-Module">Module</a></emu-nt>, that describe how sequences of tokens form syntactically correct independent components of ECMAScript programs.</p>
+      <p>The <em>syntactic grammar</em> for ECMAScript is given in clauses 11, 12, 13, 14, and 15. This grammar has ECMAScript tokens defined by the lexical grammar as its terminal symbols (<emu-xref href="#sec-lexical-and-regexp-grammars" id="_ref_12"><a href="#sec-lexical-and-regexp-grammars">5.1.2</a></emu-xref>). It defines a set of productions, starting from two alternative goal symbols <emu-nt id="_ref_9703"><a href="#prod-Script">Script</a></emu-nt> and <emu-nt id="_ref_9704"><a href="#prod-Module">Module</a></emu-nt>, that describe how sequences of tokens form syntactically correct independent components of ECMAScript programs.</p>
       <p>When a stream of code points is to be parsed as an ECMAScript <emu-nt id="_ref_9705"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9706"><a href="#prod-Module">Module</a></emu-nt>, it is first converted to a stream of input elements by repeated application of the lexical grammar; this stream of input elements is then parsed by a single application of the syntactic grammar. The input stream is syntactically in error if the tokens in the stream of input elements cannot be parsed as a single instance of the goal nonterminal (<emu-nt id="_ref_9707"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9708"><a href="#prod-Module">Module</a></emu-nt>), with no tokens left over.</p>
-      <p>When a parse is successful, it constructs a  <em>parse tree</em>, a rooted tree structure in which each node is a  <dfn>Parse Node</dfn>. Each Parse Node is an  <em>instance</em> of a symbol in the grammar; it represents a span of the source text that can be derived from that symbol. The root node of the parse tree, representing the whole of the source text, is an instance of the parse's <emu-xref href="#sec-context-free-grammars" id="_ref_955"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref>. When a Parse Node is an instance of a nonterminal, it is also an instance of some production that has that nonterminal as its left-hand side. Moreover, it has zero or more  <em>children</em>, one for each symbol on the production's right-hand side: each child is a Parse Node that is an instance of the corresponding symbol.</p>
-      <p>New Parse Nodes are instantiated for each invocation of the parser and never reused between parses even of identical source text. Parse Nodes are considered  <dfn>the same Parse Node</dfn> if and only if they represent the same span of source text, are instances of the same grammar symbol, and resulted from the same parser invocation.</p>
+      <p>When a parse is successful, it constructs a <em>parse tree</em>, a rooted tree structure in which each node is a <dfn>Parse Node</dfn>. Each Parse Node is an <em>instance</em> of a symbol in the grammar; it represents a span of the source text that can be derived from that symbol. The root node of the parse tree, representing the whole of the source text, is an instance of the parse's <emu-xref href="#sec-context-free-grammars" id="_ref_955"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref>. When a Parse Node is an instance of a nonterminal, it is also an instance of some production that has that nonterminal as its left-hand side. Moreover, it has zero or more <em>children</em>, one for each symbol on the production's right-hand side: each child is a Parse Node that is an instance of the corresponding symbol.</p>
+      <p>New Parse Nodes are instantiated for each invocation of the parser and never reused between parses even of identical source text. Parse Nodes are considered <dfn>the same Parse Node</dfn> if and only if they represent the same span of source text, are instances of the same grammar symbol, and resulted from the same parser invocation.</p>
       <emu-note><span class="note">Note 1</span><div class="note-contents">
@@ -453,3 +446,3 @@
       <p>The syntactic grammar as presented in clauses 12, 13, 14 and 15 is not a complete account of which token sequences are accepted as a correct ECMAScript <emu-nt id="_ref_9709"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9710"><a href="#prod-Module">Module</a></emu-nt>. Certain additional token sequences are also accepted, namely, those that would be described by the grammar if only semicolons were added to the sequence in certain places (such as before line terminator characters). Furthermore, certain token sequences that are described by the grammar are not considered acceptable if a line terminator character appears in certain “awkward” places.</p>
-      <p>In certain cases, in order to avoid ambiguities, the syntactic grammar uses generalized productions that permit token sequences that do not form a valid ECMAScript <emu-nt id="_ref_9711"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9712"><a href="#prod-Module">Module</a></emu-nt>. For example, this technique is used for object literals and object destructuring patterns. In such cases a more restrictive  <em>supplemental grammar</em> is provided that further restricts the acceptable token sequences. Typically, an <emu-xref href="#early-error" id="_ref_956"><a href="#early-error">early error</a></emu-xref> rule will then define an error condition if "<var>P</var> is not  <dfn>covering</dfn> an <var>N</var>", where <var>P</var> is a Parse Node (an instance of the generalized production) and <var>N</var> is a nonterminal from the supplemental grammar. Here, the sequence of tokens originally matched by <var>P</var> is parsed again using <var>N</var> as the <emu-xref href="#sec-context-free-grammars" id="_ref_957"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref>. (If <var>N</var> takes grammatical parameters, then they are set to the same values used when <var>P</var> was originally parsed.) An error occurs if the sequence of tokens cannot be parsed as a single instance of <var>N</var>, with no tokens left over. Subsequently, algorithms access the result of the parse using a phrase of the form "the <var>N</var> that is  <dfn>covered</dfn> by <var>P</var>". This will always be a Parse Node (an instance of <var>N</var>, unique for a given <var>P</var>), since any parsing failure would have been detected by an <emu-xref href="#early-error" id="_ref_958"><a href="#early-error">early error</a></emu-xref> rule.</p>
+      <p>In certain cases, in order to avoid ambiguities, the syntactic grammar uses generalized productions that permit token sequences that do not form a valid ECMAScript <emu-nt id="_ref_9711"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9712"><a href="#prod-Module">Module</a></emu-nt>. For example, this technique is used for object literals and object destructuring patterns. In such cases a more restrictive <em>supplemental grammar</em> is provided that further restricts the acceptable token sequences. Typically, an <emu-xref href="#early-error" id="_ref_956"><a href="#early-error">early error</a></emu-xref> rule will then define an error condition if "<var>P</var> is not <dfn>covering</dfn> an <var>N</var>", where <var>P</var> is a Parse Node (an instance of the generalized production) and <var>N</var> is a nonterminal from the supplemental grammar. Here, the sequence of tokens originally matched by <var>P</var> is parsed again using <var>N</var> as the <emu-xref href="#sec-context-free-grammars" id="_ref_957"><a href="#sec-context-free-grammars">goal symbol</a></emu-xref>. (If <var>N</var> takes grammatical parameters, then they are set to the same values used when <var>P</var> was originally parsed.) An error occurs if the sequence of tokens cannot be parsed as a single instance of <var>N</var>, with no tokens left over. Subsequently, algorithms access the result of the parse using a phrase of the form "the <var>N</var> that is <dfn>covered</dfn> by <var>P</var>". This will always be a Parse Node (an instance of <var>N</var>, unique for a given <var>P</var>), since any parsing failure would have been detected by an <emu-xref href="#early-error" id="_ref_958"><a href="#early-error">early error</a></emu-xref> rule.</p>
     </emu-clause>
@@ -459,3 +452,3 @@
       <p>Terminal symbols are shown in <code>fixed width</code> font, both in the productions of the grammars and throughout this specification whenever the text directly refers to such a terminal symbol. These are to appear in a script exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin range, as opposed to any similar-looking code points from other Unicode ranges. A code point in a terminal symbol cannot be expressed by a <code>\</code> <emu-nt id="_ref_9713"><a href="#prod-UnicodeEscapeSequence">UnicodeEscapeSequence</a></emu-nt>.</p>
-      <p>Nonterminal symbols are shown in  <i>italic</i> type. The definition of a nonterminal (also called a “production”) is introduced by the name of the nonterminal being defined followed by one or more colons. (The number of colons indicates to which grammar the production belongs.) One or more alternative right-hand sides for the nonterminal then follow on succeeding lines. For example, the syntactic definition:</p>
+      <p>Nonterminal symbols are shown in <i>italic</i> type. The definition of a nonterminal (also called a “production”) is introduced by the name of the nonterminal being defined followed by one or more colons. (The number of colons indicates to which grammar the production belongs.) One or more alternative right-hand sides for the nonterminal then follow on succeeding lines. For example, the syntactic definition:</p>
       <emu-grammar type="example"><emu-production name="WhileStatement" id="prod-grammar-notation-WhileStatement">
@@ -572,3 +565,3 @@
 </emu-production></emu-grammar>
-      <p>If a right-hand side alternative is prefixed with “[+parameter]” that alternative is only available if the named parameter was used in referencing the production's nonterminal symbol. If a right-hand side alternative is prefixed with “[~parameter]” that alternative is only available if the named parameter was  <em>not</em> used in referencing the production's nonterminal symbol. This means that:</p>
+      <p>If a right-hand side alternative is prefixed with “[+parameter]” that alternative is only available if the named parameter was used in referencing the production's nonterminal symbol. If a right-hand side alternative is prefixed with “[~parameter]” that alternative is only available if the named parameter was <em>not</em> used in referencing the production's nonterminal symbol. This means that:</p>
       <emu-grammar type="example"><emu-production name="StatementList" params="Return">
@@ -631,3 +624,3 @@
       <p>Similarly, if the phrase “[lookahead ∈ <var>set</var>]” appears in the right-hand side of a production, it indicates that the production may only be used if the immediately following input token sequence is a member of the given <var>set</var>. If the <var>set</var> consists of a single terminal the phrase “[lookahead = <var>terminal</var>]” may be used.</p>
-      <p>If the phrase “[no <emu-nt id="_ref_9808"><a href="#prod-LineTerminator">LineTerminator</a></emu-nt> here]” appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is  <em>a restricted production</em>: it may not be used if a <emu-nt id="_ref_9809"><a href="#prod-LineTerminator">LineTerminator</a></emu-nt> occurs in the input stream at the indicated position. For example, the production:</p>
+      <p>If the phrase “[no <emu-nt id="_ref_9808"><a href="#prod-LineTerminator">LineTerminator</a></emu-nt> here]” appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a <emu-nt id="_ref_9809"><a href="#prod-LineTerminator">LineTerminator</a></emu-nt> occurs in the input stream at the indicated position. For example, the production:</p>
       <emu-grammar type="example"><emu-production name="ThrowStatement" id="prod-grammar-notation-ThrowStatement">
@@ -665,3 +658,3 @@
       <h1><span class="secnum">5.2.1</span> Abstract Operations</h1>
-      <p>In order to facilitate their use in multiple parts of this specification, some algorithms, called  <dfn>abstract operations</dfn>, are named and written in parameterized functional form so that they may be referenced by name from within other algorithms. Abstract operations are typically referenced using a functional application style such as OperationName(<var>arg1</var>, <var>arg2</var>). Some abstract operations are treated as polymorphically dispatched methods of class-like specification abstractions. Such method-like abstract operations are typically referenced using a method application style such as <var>someValue</var>.OperationName(<var>arg1</var>, <var>arg2</var>).</p>
+      <p>In order to facilitate their use in multiple parts of this specification, some algorithms, called <dfn>abstract operations</dfn>, are named and written in parameterized functional form so that they may be referenced by name from within other algorithms. Abstract operations are typically referenced using a functional application style such as OperationName(<var>arg1</var>, <var>arg2</var>). Some abstract operations are treated as polymorphically dispatched methods of class-like specification abstractions. Such method-like abstract operations are typically referenced using a method application style such as <var>someValue</var>.OperationName(<var>arg1</var>, <var>arg2</var>).</p>
     </emu-clause>
@@ -670,3 +663,3 @@
       <h1><span class="secnum">5.2.2</span> Syntax-Directed Operations</h1>
-      <p>A  <dfn>syntax-directed operation</dfn> is a named operation whose definition consists of algorithms, each of which is associated with one or more productions from one of the ECMAScript grammars. A production that has multiple alternative definitions will typically have a distinct algorithm for each alternative. When an algorithm is associated with a grammar production, it may reference the terminal and nonterminal symbols of the production alternative as if they were parameters of the algorithm. When used in this manner, nonterminal symbols refer to the actual alternative definition that is matched when parsing the source text. The  <dfn>source text matched by</dfn> a grammar production is the portion of the source text that starts at the beginning of the first terminal that participated in the match and ends at the end of the last terminal that participated in the match.</p>
+      <p>A <dfn>syntax-directed operation</dfn> is a named operation whose definition consists of algorithms, each of which is associated with one or more productions from one of the ECMAScript grammars. A production that has multiple alternative definitions will typically have a distinct algorithm for each alternative. When an algorithm is associated with a grammar production, it may reference the terminal and nonterminal symbols of the production alternative as if they were parameters of the algorithm. When used in this manner, nonterminal symbols refer to the actual alternative definition that is matched when parsing the source text. The <dfn>source text matched by</dfn> a grammar production is the portion of the source text that starts at the beginning of the first terminal that participated in the match and ends at the end of the last terminal that participated in the match.</p>
       <p>When an algorithm is associated with a production alternative, the alternative is typically shown without any “[ ]” grammar annotations. Such annotations should only affect the syntactic recognition of the alternative and have no effect on the associated semantics for the alternative.</p>
@@ -690,3 +683,3 @@
       <h1><span class="secnum">5.2.3</span> Runtime Semantics</h1>
-      <p>Algorithms which specify semantics that must be called at runtime are called  <dfn>runtime semantics</dfn>. Runtime semantics are defined by <emu-xref href="#sec-algorithm-conventions-abstract-operations" id="_ref_959"><a href="#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> or syntax-directed operations. Such algorithms always return a completion record.</p>
+      <p>Algorithms which specify semantics that must be called at runtime are called <dfn>runtime semantics</dfn>. Runtime semantics are defined by <emu-xref href="#sec-algorithm-conventions-abstract-operations" id="_ref_959"><a href="#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> or syntax-directed operations. Such algorithms always return a completion record.</p>
       <emu-clause id="sec-implicit-completion-values">
@@ -768,3 +761,3 @@
       <h1><span class="secnum">5.2.4</span> Static Semantics</h1>
-      <p>Context-free grammars are not sufficiently powerful to express all the rules that define whether a stream of input elements form a valid ECMAScript <emu-nt id="_ref_9825"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9826"><a href="#prod-Module">Module</a></emu-nt> that may be evaluated. In some situations additional rules are needed that may be expressed using either ECMAScript algorithm conventions or prose requirements. Such rules are always associated with a production of a grammar and are called the  <dfn>static semantics</dfn> of the production.</p>
+      <p>Context-free grammars are not sufficiently powerful to express all the rules that define whether a stream of input elements form a valid ECMAScript <emu-nt id="_ref_9825"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9826"><a href="#prod-Module">Module</a></emu-nt> that may be evaluated. In some situations additional rules are needed that may be expressed using either ECMAScript algorithm conventions or prose requirements. Such rules are always associated with a production of a grammar and are called the <dfn>static semantics</dfn> of the production.</p>
       <p>Static Semantic Rules have names and typically are defined using an algorithm. Named Static Semantic Rules are associated with grammar productions and a production that has multiple alternative definitions will typically have for each alternative a distinct algorithm for each applicable named static semantic rule.</p>
@@ -774,3 +767,3 @@
       <p>The above definition is explicitly over-ridden for specific productions.</p>
-      <p>A special kind of static semantic rule is an  <dfn id="early-error-rule">Early Error Rule</dfn>. <emu-xref href="#early-error" id="_ref_1001"><a href="#early-error">Early error</a></emu-xref> rules define <emu-xref href="#early-error" id="_ref_1002"><a href="#early-error">early error</a></emu-xref> conditions (see clause  <emu-xref href="#sec-error-handling-and-language-extensions" id="_ref_13"><a href="#sec-error-handling-and-language-extensions">16</a></emu-xref>) that are associated with specific grammar productions. Evaluation of most <emu-xref href="#early-error" id="_ref_1003"><a href="#early-error">early error</a></emu-xref> rules are not explicitly invoked within the algorithms of this specification. A conforming implementation must, prior to the first evaluation of a <emu-nt id="_ref_9827"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9828"><a href="#prod-Module">Module</a></emu-nt>, validate all of the <emu-xref href="#early-error" id="_ref_1004"><a href="#early-error">early error</a></emu-xref> rules of the productions used to parse that <emu-nt id="_ref_9829"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9830"><a href="#prod-Module">Module</a></emu-nt>. If any of the <emu-xref href="#early-error" id="_ref_1005"><a href="#early-error">early error</a></emu-xref> rules are violated the <emu-nt id="_ref_9831"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9832"><a href="#prod-Module">Module</a></emu-nt> is invalid and cannot be evaluated.</p>
+      <p>A special kind of static semantic rule is an <dfn id="early-error-rule">Early Error Rule</dfn>. <emu-xref href="#early-error" id="_ref_1001"><a href="#early-error">Early error</a></emu-xref> rules define <emu-xref href="#early-error" id="_ref_1002"><a href="#early-error">early error</a></emu-xref> conditions (see clause <emu-xref href="#sec-error-handling-and-language-extensions" id="_ref_13"><a href="#sec-error-handling-and-language-extensions">16</a></emu-xref>) that are associated with specific grammar productions. Evaluation of most <emu-xref href="#early-error" id="_ref_1003"><a href="#early-error">early error</a></emu-xref> rules are not explicitly invoked within the algorithms of this specification. A conforming implementation must, prior to the first evaluation of a <emu-nt id="_ref_9827"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9828"><a href="#prod-Module">Module</a></emu-nt>, validate all of the <emu-xref href="#early-error" id="_ref_1004"><a href="#early-error">early error</a></emu-xref> rules of the productions used to parse that <emu-nt id="_ref_9829"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9830"><a href="#prod-Module">Module</a></emu-nt>. If any of the <emu-xref href="#early-error" id="_ref_1005"><a href="#early-error">early error</a></emu-xref> rules are violated the <emu-nt id="_ref_9831"><a href="#prod-Script">Script</a></emu-nt> or <emu-nt id="_ref_9832"><a href="#prod-Module">Module</a></emu-nt> is invalid and cannot be evaluated.</p>
     </emu-clause>
@@ -784,4 +777,4 @@
 
-      <p>In the language of this specification, numerical values and operations (including addition, subtraction, negation, multiplication, division, and comparison) are distinguished among different numeric kinds using subscripts. The subscript  <sub><dfn id="𝔽">𝔽</dfn></sub> refers to Numbers, and the subscript  <sub><dfn id="ℝ">ℝ</dfn></sub> refers to mathematical values. A subscript is used following each numeric value and operation.</p>
-      <p>For brevity, the  <sub>𝔽</sub> subscript can be omitted on Number values—a numeric value with no subscript is interpreted to be a Number. An operation with no subscript is interpreted to be a Number operation, unless one of the parameters has a particular subscript, in which case the operation adopts that subscript. For example, 1<sub>ℝ</sub> + 2<sub>ℝ</sub> = 3<sub>ℝ</sub> is a statement about mathematical values, and 1 + 2 = 3 is a statement about Numbers.</p>
+      <p>In the language of this specification, numerical values and operations (including addition, subtraction, negation, multiplication, division, and comparison) are distinguished among different numeric kinds using subscripts. The subscript <sub><dfn id="𝔽">𝔽</dfn></sub> refers to Numbers, and the subscript <sub><dfn id="ℝ">ℝ</dfn></sub> refers to mathematical values. A subscript is used following each numeric value and operation.</p>
+      <p>For brevity, the <sub>𝔽</sub> subscript can be omitted on Number values—a numeric value with no subscript is interpreted to be a Number. An operation with no subscript is interpreted to be a Number operation, unless one of the parameters has a particular subscript, in which case the operation adopts that subscript. For example, 1<sub>ℝ</sub> + 2<sub>ℝ</sub> = 3<sub>ℝ</sub> is a statement about mathematical values, and 1 + 2 = 3 is a statement about Numbers.</p>
       <p>In general, when this specification refers to a numerical value, such as in the phrase, "the length of <var>y</var>" or "the <emu-xref href="#integer" id="_ref_1008"><a href="#integer">integer</a></emu-xref> represented by the four hexadecimal digits ...", without explicitly specifying a numeric kind, the phrase refers to a Number. Phrases which refer to a <emu-xref href="#mathematical-value" id="_ref_1009"><a href="#mathematical-value">mathematical value</a></emu-xref> are explicitly annotated as such; for example, "the <emu-xref href="#mathematical-value" id="_ref_1010"><a href="#mathematical-value">mathematical value</a></emu-xref> of the number of code points in ...".</p>
@@ -791,8 +784,8 @@
       <p>In certain contexts, an operation is specified which is generic between Numbers and mathematical values. In these cases, the subscript can be a variable; <var>t</var> is often used for this purpose, for example 5<sub><var>t</var></sub> × 10<sub><var>t</var></sub> = 50<sub><var>t</var></sub> for any <var>t</var> ranging over <emu-xref href="#ℝ" id="_ref_1012"><a href="#ℝ">ℝ</a></emu-xref> and <emu-xref href="#𝔽" id="_ref_1013"><a href="#𝔽">𝔽</a></emu-xref>, since the values involved are within the range where the semantics coincide.</p>
-      <p>Conversions between mathematical values and numbers are never implicit, and always explicit in this document. A conversion from a <emu-xref href="#mathematical-value" id="_ref_1014"><a href="#mathematical-value">mathematical value</a></emu-xref> to a Number is denoted as "the <emu-xref href="#number-value" id="_ref_1015"><a href="#number-value">Number value</a></emu-xref> for <var>x</var>", and is defined in  <emu-xref href="#sec-ecmascript-language-types-number-type" id="_ref_14"><a href="#sec-ecmascript-language-types-number-type">6.1.6.1</a></emu-xref>. A conversion from a Number to a <emu-xref href="#mathematical-value" id="_ref_1016"><a href="#mathematical-value">mathematical value</a></emu-xref> is denoted as "the  <dfn id="mathematical-value">mathematical value</dfn> of <var>x</var>", or <emu-xref href="#ℝ" id="_ref_1017"><a href="#ℝ">ℝ</a></emu-xref>(<var>x</var>). Note that the <emu-xref href="#mathematical-value" id="_ref_1018"><a href="#mathematical-value">mathematical value</a></emu-xref> of non-finite values is not defined, and the <emu-xref href="#mathematical-value" id="_ref_1019"><a href="#mathematical-value">mathematical value</a></emu-xref> of <emu-val>+0</emu-val> and <emu-val>-0</emu-val> is the <emu-xref href="#mathematical-value" id="_ref_1020"><a href="#mathematical-value">mathematical value</a></emu-xref> 0<sub>ℝ</sub>.</p>
-      <p>When the term  <dfn id="integer">integer</dfn> is used in this specification, it refers to a <emu-xref href="#number-value" id="_ref_1021"><a href="#number-value">Number value</a></emu-xref> whose <emu-xref href="#mathematical-value" id="_ref_1022"><a href="#mathematical-value">mathematical value</a></emu-xref> is in the set of integers, unless otherwise stated: when the term  <dfn id="mathematical integer">mathematical integer</dfn> is used in this specification, it refers to a <emu-xref href="#mathematical-value" id="_ref_1023"><a href="#mathematical-value">mathematical value</a></emu-xref> which is in the set of integers. As shorthand, <emu-xref href="#integer" id="_ref_1024"><a href="#integer">integer</a></emu-xref><sub><var>t</var></sub> can be used to refer to either of the two, as determined by <var>t</var>.</p>
-      <p>The mathematical function  <emu-eqn id="eqn-abs" aoid="abs" class="inline">abs<sub><var>t</var></sub>(<var>x</var>)</emu-eqn> produces the absolute value of <var>x</var>, which is  <emu-eqn class="inline">-<sub><var>t</var></sub><var>x</var></emu-eqn> if <var>x</var> &lt;<sub><var>t</var></sub> 0<sub><var>t</var></sub> and otherwise is <var>x</var> itself.</p>
-      <p>The mathematical function  <emu-eqn id="eqn-min" aoid="min" class="inline">min<sub><var>t</var></sub>(<var>x1</var>, <var>x2</var>, … , <var>xN</var>)</emu-eqn> produces the mathematically smallest of  <emu-eqn class="inline"><var>x1</var></emu-eqn> through  <emu-eqn class="inline"><var>xN</var></emu-eqn>. The mathematical function  <emu-eqn id="eqn-max" aoid="max" class="inline">max<sub><var>t</var></sub>(<var>x1</var>, <var>x2</var>, ..., <var>xN</var>)</emu-eqn> produces the mathematically largest of  <emu-eqn class="inline"><var>x1</var></emu-eqn> through  <emu-eqn class="inline"><var>xN</var></emu-eqn>. The domain and range of these mathematical functions include <emu-val>+∞</emu-val> and <emu-val>-∞</emu-val>.</p>
-      <p>The notation “<emu-eqn id="eqn-modulo" aoid="modulo" class="inline"><var>x</var> modulo<sub><var>t</var></sub> <var>y</var></emu-eqn>” (<var>y</var> must be finite and nonzero) computes a value <var>k</var> of the same sign as <var>y</var> (or zero) such that  <emu-eqn class="inline"><emu-xref aoid="abs" id="_ref_1025"><a href="#eqn-abs">abs</a></emu-xref><sub><var>t</var></sub>(<var>k</var>) &lt;<sub><var>t</var></sub> <emu-xref aoid="abs" id="_ref_1026"><a href="#eqn-abs">abs</a></emu-xref><sub><var>t</var></sub>(<var>y</var>) and <var>x</var>-<sub><var>t</var></sub><var>k</var> = <var>q</var> ×<sub><var>t</var></sub> <var>y</var></emu-eqn> for some <emu-xref href="#integer" id="_ref_1027"><a href="#integer">integer</a></emu-xref><sub><var>t</var></sub> <var>q</var>.</p>
-      <p>The mathematical function  <emu-eqn id="eqn-floor" aoid="floor" class="inline">floor<sub><var>t</var></sub>(<var>x</var>)</emu-eqn> produces the largest <emu-xref href="#integer" id="_ref_1028"><a href="#integer">integer</a></emu-xref><sub><var>t</var></sub> (closest to positive infinity) that is not larger than <var>x</var>.</p>
+      <p>Conversions between mathematical values and numbers are never implicit, and always explicit in this document. A conversion from a <emu-xref href="#mathematical-value" id="_ref_1014"><a href="#mathematical-value">mathematical value</a></emu-xref> to a Number is denoted as "the <emu-xref href="#number-value" id="_ref_1015"><a href="#number-value">Number value</a></emu-xref> for <var>x</var>", and is defined in <emu-xref href="#sec-ecmascript-language-types-number-type" id="_ref_14"><a href="#sec-ecmascript-language-types-number-type">6.1.6.1</a></emu-xref>. A conversion from a Number to a <emu-xref href="#mathematical-value" id="_ref_1016"><a href="#mathematical-value">mathematical value</a></emu-xref> is denoted as "the <dfn id="mathematical-value">mathematical value</dfn> of <var>x</var>", or <emu-xref href="#ℝ" id="_ref_1017"><a href="#ℝ">ℝ</a></emu-xref>(<var>x</var>). Note that the <emu-xref href="#mathematical-value" id="_ref_1018"><a href="#mathematical-value">mathematical value</a></emu-xref> of non-finite values is not defined, and the <emu-xref href="#mathematical-value" id="_ref_1019"><a href="#mathematical-value">mathematical value</a></emu-xref> of <emu-val>+0</emu-val> and <emu-val>-0</emu-val> is the <emu-xref href="#mathematical-value" id="_ref_1020"><a href="#mathematical-value">mathematical value</a></emu-xref> 0<sub>ℝ</sub>.</p>
+      <p>When the term <dfn id="integer">integer</dfn> is used in this specification, it refers to a <emu-xref href="#number-value" id="_ref_1021"><a href="#number-value">Number value</a></emu-xref> whose <emu-xref href="#mathematical-value" id="_ref_1022"><a href="#mathematical-value">mathematical value</a></emu-xref> is in the set of integers, unless otherwise stated: when the term <dfn id="mathematical integer">mathematical integer</dfn> is used in this specification, it refers to a <emu-xref href="#mathematical-value" id="_ref_1023"><a href="#mathematical-value">mathematical value</a></emu-xref> which is in the set of integers. As shorthand, <emu-xref href="#integer" id="_ref_1024"><a href="#integer">integer</a></emu-xref><sub><var>t</var></sub> can be used to refer to either of the two, as determined by <var>t</var>.</p>
+      <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs" class="inline">abs<sub><var>t</var></sub>(<var>x</var>)</emu-eqn> produces the absolute value of <var>x</var>, which is <emu-eqn class="inline">-<sub><var>t</var></sub><var>x</var></emu-eqn> if <var>x</var> &lt;<sub><var>t</var></sub> 0<sub><var>t</var></sub> and otherwise is <var>x</var> itself.</p>
+      <p>The mathematical function <emu-eqn id="eqn-min" aoid="min" class="inline">min<sub><var>t</var></sub>(<var>x1</var>, <var>x2</var>, … , <var>xN</var>)</emu-eqn> produces the mathematically smallest of <emu-eqn class="inline"><var>x1</var></emu-eqn> through <emu-eqn class="inline"><var>xN</var></emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max" class="inline">max<sub><var>t</var></sub>(<var>x1</var>, <var>x2</var>, ..., <var>xN</var>)</emu-eqn> produces the mathematically largest of <emu-eqn class="inline"><var>x1</var></emu-eqn> through <emu-eqn class="inline"><var>xN</var></emu-eqn>. The domain and range of these mathematical functions include <emu-val>+∞</emu-val> and <emu-val>-∞</emu-val>.</p>
+      <p>The notation “<emu-eqn id="eqn-modulo" aoid="modulo" class="inline"><var>x</var> modulo<sub><var>t</var></sub> <var>y</var></emu-eqn>” (<var>y</var> must be finite and nonzero) computes a value <var>k</var> of the same sign as <var>y</var> (or zero) such that <emu-eqn class="inline"><emu-xref aoid="abs" id="_ref_1025"><a href="#eqn-abs">abs</a></emu-xref><sub><var>t</var></sub>(<var>k</var>) &lt;<sub><var>t</var></sub> <emu-xref aoid="abs" id="_ref_1026"><a href="#eqn-abs">abs</a></emu-xref><sub><var>t</var></sub>(<var>y</var>) and <var>x</var>-<sub><var>t</var></sub><var>k</var> = <var>q</var> ×<sub><var>t</var></sub> <var>y</var></emu-eqn> for some <emu-xref href="#integer" id="_ref_1027"><a href="#integer">integer</a></emu-xref><sub><var>t</var></sub> <var>q</var>.</p>
+      <p>The mathematical function <emu-eqn id="eqn-floor" aoid="floor" class="inline">floor<sub><var>t</var></sub>(<var>x</var>)</emu-eqn> produces the largest <emu-xref href="#integer" id="_ref_1028"><a href="#integer">integer</a></emu-xref><sub><var>t</var></sub> (closest to positive infinity) that is not larger than <var>x</var>.</p>
       <emu-note><span class="note">Note</span><div class="note-contents">
@@ -812,3 +805,3 @@
   <p>Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further subclassified into ECMAScript language types and specification types.</p>
-  <p>Within this specification, the notation “Type(<var>x</var>)” is used as shorthand for “the  <dfn id="type">type</dfn> of <var>x</var>” where “type” refers to the ECMAScript language and specification types defined in this clause. When the term “empty” is used as if it was naming a value, it is equivalent to saying “no value of any type”.</p>
+  <p>Within this specification, the notation “Type(<var>x</var>)” is used as shorthand for “the <dfn id="type">type</dfn> of <var>x</var>” where “type” refers to the ECMAScript language and specification types defined in this clause. When the term “empty” is used as if it was naming a value, it is equivalent to saying “no value of any type”.</p>
 
@@ -816,3 +809,3 @@
     <h1><span class="secnum">6.1</span> ECMAScript Language Types</h1>
-    <p>An  <dfn>ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, BigInt, and Object. An  <dfn>ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
+    <p>An <dfn>ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, BigInt, and Object. An <dfn>ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
 
@@ -836,18 +829,15 @@
       <p>The String type is the set of all ordered sequences of zero or more 16-bit unsigned <emu-xref href="#integer" id="_ref_1032"><a href="#integer">integer</a></emu-xref> values (“elements”) up to a maximum length of 2<sup>53</sup> - 1 elements. The String type is generally used to represent textual data in a running ECMAScript program, in which case each element in the String is treated as a UTF-16 code unit value. Each element is regarded as occupying a position within the sequence. These positions are indexed with nonnegative integers. The first element (if any) is at index 0, the next element (if any) at index 1, and so on. The length of a String is the number of elements (i.e., 16-bit values) within it. The empty String has length zero and therefore contains no elements.</p>
-      <p>ECMAScript operations that do not interpret String contents apply no further semantics. Operations that do interpret String values treat each element as a single UTF-16 code unit. However, ECMAScript does not restrict the value of or relationships between these code units, so operations that further interpret String contents as sequences of Unicode code points encoded in UTF-16 must account for ill-formed subsequences. Such operations apply special treatment to every code unit with a numeric value in the inclusive range 0xD800 to 0xDBFF (defined by the Unicode Standard as a  <dfn id="leading-surrogate">leading surrogate</dfn>, or more formally as a  <dfn id="high-surrogate-code-unit">high-surrogate code unit</dfn>) and every code unit with a numeric value in the inclusive range 0xDC00 to 0xDFFF (defined as a  <dfn id="trailing-surrogate">trailing surrogate</dfn>, or more formally as a  <dfn id="low-surrogate-code-unit">low-surrogate code unit</dfn>) using the following rules:</p>
+      <p>ECMAScript operations that do not interpret String contents apply no further semantics. Operations that do interpret String values treat each element as a single UTF-16 code unit. However, ECMAScript does not restrict the value of or relationships between these code units, so operations that further interpret String contents as sequences of Unicode code points encoded in UTF-16 must account for ill-formed subsequences. Such operations apply special treatment to every code unit with a numeric value in the inclusive range 0xD800 to 0xDBFF (defined by the Unicode Standard as a <dfn id="leading-surrogate">leading surrogate</dfn>, or more formally as a <dfn id="high-surrogate-code-unit">high-surrogate code unit</dfn>) and every code unit with a numeric value in the inclusive range 0xDC00 to 0xDFFF (defined as a <dfn id="trailing-surrogate">trailing surrogate</dfn>, or more formally as a <dfn id="low-surrogate-code-unit">low-surrogate code unit</dfn>) using the following rules:</p>
       <ul>
         <li>
-          A code unit that is not a  <emu-xref href="#leading-surrogate" id="_ref_15"><a href="#leading-surrogate">leading surrogate</a></emu-xref> and not a  <emu-xref href="#trailing-surrogate" id="_ref_16"><a href="#trailing-surrogate">trailing surrogate</a></emu-xref> is interpreted as a code point with the same value.
-        
+          A code unit that is not a <emu-xref href="#leading-surrogate" id="_ref_15"><a href="#leading-surrogate">leading surrogate</a></emu-xref> and not a <emu-xref href="#trailing-surrogate" id="_ref_16"><a href="#trailing-surrogate">trailing surrogate</a></emu-xref> is interpreted as a code point with the same value.
         </li>
         <li>
-          A sequence of two code units, where the first code unit <var>c1</var> is a  <emu-xref href="#leading-surrogate" id="_ref_17"><a href="#leading-surrogate">leading surrogate</a></emu-xref> and the second code unit <var>c2</var> a  <emu-xref href="#trailing-surrogate" id="_ref_18"><a href="#trailing-surrogate">trailing surrogate</a></emu-xref>, is a  <dfn id="surrogate-pair">surrogate pair</dfn> and is interpreted as a code point with the value (<var>c1</var> - 0xD800) × 0x400 + (<var>c2</var> - 0xDC00) + 0x10000. (See  <emu-xref href="#sec-utf16decodesurrogatepair" id="_ref_19"><a href="#sec-utf16decodesurrogatepair">10.1.3</a></emu-xref>)
-        
+          A sequence of two code units, where the first code unit <var>c1</var> is a <emu-xref href="#leading-surrogate" id="_ref_17"><a href="#leading-surrogate">leading surrogate</a></emu-xref> and the second code unit <var>c2</var> a <emu-xref href="#trailing-surrogate" id="_ref_18"><a href="#trailing-surrogate">trailing surrogate</a></emu-xref>, is a <dfn id="surrogate-pair">surrogate pair</dfn> and is interpreted as a code point with the value (<var>c1</var> - 0xD800) × 0x400 + (<var>c2</var> - 0xDC00) + 0x10000. (See <emu-xref href="#sec-utf16decodesurrogatepair" id="_ref_19"><a href="#sec-utf16decodesurrogatepair">10.1.3</a></emu-xref>)
         </li>
         <li>
-          A code unit that is a  <emu-xref href="#leading-surrogate" id="_ref_20"><a href="#leading-surrogate">leading surrogate</a></emu-xref> or  <emu-xref href="#trailing-surrogate" id="_ref_21"><a href="#trailing-surrogate">trailing surrogate</a></emu-xref>, but is not part of a  <emu-xref href="#surrogate-pair" id="_ref_22"><a href="#surrogate-pair">surrogate pair</a></emu-xref>, is interpreted as a code point with the same value.
-        
+          A code unit that is a <emu-xref href="#leading-surrogate" id="_ref_20"><a href="#leading-surrogate">leading surrogate</a></emu-xref> or <emu-xref href="#trailing-surrogate" id="_ref_21"><a href="#trailing-surrogate">trailing surrogate</a></emu-xref>, but is not part of a <emu-xref href="#surrogate-pair" id="_ref_22"><a href="#surrogate-pair">surrogate pair</a></emu-xref>, is interpreted as a code point with the same value.
         </li>
       </ul>
-      <p>The function <code>String.prototype.normalize</code> (see  <emu-xref href="#sec-string.prototype.normalize" id="_ref_23"><a href="#sec-string.prototype.normalize">21.1.3.13</a></emu-xref>) can be used to explicitly normalize a String value. <code>String.prototype.localeCompare</code> (see  <emu-xref href="#sec-string.prototype.localecompare" id="_ref_24"><a href="#sec-string.prototype.localecompare">21.1.3.10</a></emu-xref>) internally normalizes String values, but no other operations implicitly normalize the strings upon which they operate. Only operations that are explicitly specified to be language or locale sensitive produce language-sensitive results.</p>
+      <p>The function <code>String.prototype.normalize</code> (see <emu-xref href="#sec-string.prototype.normalize" id="_ref_23"><a href="#sec-string.prototype.normalize">21.1.3.13</a></emu-xref>) can be used to explicitly normalize a String value. <code>String.prototype.localeCompare</code> (see <emu-xref href="#sec-string.prototype.localecompare" id="_ref_24"><a href="#sec-string.prototype.localecompare">21.1.3.10</a></emu-xref>) internally normalizes String values, but no other operations implicitly normalize the strings upon which they operate. Only operations that are explicitly specified to be language or locale sensitive produce language-sensitive results.</p>
       <emu-note><span class="note">Note</span><div class="note-contents">
@@ -855,3 +845,3 @@
       </div></emu-note>
-      <p>In this specification, the phrase "the  <dfn>string-concatenation</dfn> of <var>A</var>, <var>B</var>, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
+      <p>In this specification, the phrase "the <dfn>string-concatenation</dfn> of <var>A</var>, <var>B</var>, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
     </emu-clause>
@@ -867,3 +857,3 @@
         <p>Well-known symbols are built-in Symbol values that are explicitly referenced by algorithms of this specification. They are typically used as the keys of properties whose values serve as extension points of a specification algorithm. Unless otherwise specified, well-known symbols values are shared by all realms (<emu-xref href="#sec-code-realms" id="_ref_26"><a href="#sec-code-realms">8.2</a></emu-xref>).</p>
-        <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where “name” is one of the values listed in  <emu-xref href="#table-1" id="_ref_27"><a href="#table-1">Table 1</a></emu-xref>.</p>
+        <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where “name” is one of the values listed in <emu-xref href="#table-1" id="_ref_27"><a href="#table-1">Table 1</a></emu-xref>.</p>
         <emu-table id="table-1" caption="Well-known Symbols"><figure><figcaption>Table 1: Well-known Symbols</figcaption>
@@ -874,3 +864,2 @@
                 Specification Name
-              
               </th>
@@ -878,3 +867,2 @@
                 [[Description]]
-              
               </th>
@@ -882,3 +870,2 @@
                 Value and Purpose
-              
               </th>
@@ -888,3 +875,2 @@
                 @@asyncIterator
-              
               </td>
@@ -892,3 +878,2 @@
                 <emu-val>"Symbol.asyncIterator"</emu-val>
-              
               </td>
@@ -896,3 +881,2 @@
                 A method that returns the default AsyncIterator for an object. Called by the semantics of the <code>for</code>-<code>await</code>-<code>of</code> statement.
-              
               </td>
@@ -902,3 +886,2 @@
                 @@hasInstance
-              
               </td>
@@ -906,3 +889,2 @@
                 <emu-val>"Symbol.hasInstance"</emu-val>
-              
               </td>
@@ -910,3 +892,2 @@
                 A method that determines if a <emu-xref href="#constructor" id="_ref_1033"><a href="#constructor">constructor</a></emu-xref> object recognizes an object as one of the <emu-xref href="#constructor" id="_ref_1034"><a href="#constructor">constructor</a></emu-xref>'s instances. Called by the semantics of the <code>instanceof</code> operator.
-              
               </td>
@@ -916,3 +897,2 @@
                 @@isConcatSpreadable
-              
               </td>
@@ -920,7 +900,5 @@
                 <emu-val>"Symbol.isConcatSpreadable"</emu-val>
-              
               </td>
               <td>
-                A Boolean valued property that if true indicates that an object should be flattened to its array elements by  <emu-xref href="#sec-array.prototype.concat" id="_ref_28"><a href="#sec-array.prototype.concat"><code>Array.prototype.concat</code></a></emu-xref>.
-              
+                A Boolean valued property that if true indicates that an object should be flattened to its array elements by <emu-xref href="#sec-array.prototype.concat" id="_ref_28"><a href="#sec-array.prototype.concat"><code>Array.prototype.concat</code></a></emu-xref>.
               </td>
```
</details>