### PR TITLE
remove now-unnecessary special casing of grammar nodes in algorithms

### DIFF
--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -2,21 +2,12 @@ import type { Context } from './Context';
 
 import Builder from './Builder';
 import * as emd from 'ecmarkdown';
-import Grammar from './Grammar';
 
 /*@internal*/
 export default class Algorithm extends Builder {
   static enter(context: Context) {
     const { node } = context;
-    // Need to process emu-grammar elements first so emd doesn't trash the syntax inside emu-grammar nodes
-    const grammarNodes = node.querySelectorAll('emu-grammar');
-    for (let i = 0; i < grammarNodes.length; i++) {
-      let gn = grammarNodes[i];
-      context.node = gn as HTMLElement;
-      Grammar.enter(context);
-      Grammar.exit(context);
-      context.node = node;
-    }
+
     // replace spaces after !/? with &nbsp; to prevent bad line breaking
     const html = emd
       .algorithm(node.innerHTML)

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -8,10 +8,7 @@ const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/gi;
 
 /*@internal*/
 export default class Grammar extends Builder {
-  static enter({ spec, node, inAlg }: Context) {
-    // we process grammar nodes in algorithms separately (in Algorithm.ts)
-    if (inAlg) return;
-
+  static enter({ spec, node }: Context) {
     let content: string;
     let possiblyMalformed = true;
     if (spec.sourceText) {


### PR DESCRIPTION
As of #197 we are using a version of ecmarkdown which [knows to treat `emu-grammar` as opaque](https://github.com/tc39/ecmarkdown/blob/dc4f275581609f92a3a1bd52cc3fc1a5443a8edb/src/tokenizer.ts#L9), which means we don't need to handle grammar nodes in algorithms specially.

(The `inAlg` tracking is still used for the autolinker, though, so it has not been removed.)

This PR has no effect on the rending of ecma-262.