### PR TITLE
use files array instead of npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.vscode
-.editorconfig
-.eslintrc
-.gitignore
-.travis.yml
-lib/**/*.js.map
-src
-test
-deploy.sh

--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
 		"postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
 	},
 	"bin": "bin/ecmarkup.js",
+	"files": [
+		"/bin",
+		"/lib",
+		"/js",
+		"/css",
+		"/boilerplate",
+		"/ecma262biblio.json"
+	],
 	"repository": "tc39/ecmarkup",
 	"keywords": [
 		"ecmascript",


### PR DESCRIPTION
I hadn't been updating `.npmignore`, which meant we were including dotfiles like `.eslintignore`, which was silly.