### PR TITLE
lint: allow lines to end in <pre> tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkup",
-  "version": "3.21.1",
+  "version": "3.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "3.21.1",
+	"version": "3.22.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/rules/algorithm-line-endings.ts
+++ b/src/lint/rules/algorithm-line-endings.ts
@@ -106,6 +106,22 @@ export default function (report: (e: LintingError) => void, node: Element): Obse
         return;
       }
 
+      let hasSubsteps = node.sublist !== null;
+
+      // Special case: lines without substeps can end in `pre` tags.
+      if (last.name === 'opaqueTag' && /^\s*<pre>/.test(last.contents)) {
+        if (hasSubsteps) {
+          report({
+            ruleId,
+            nodeType,
+            line: node.contents[0].location!.start.line,
+            column: node.contents[0].location!.start.column,
+            message: `lines ending in <pre> tags must not have substeps`,
+          });
+        }
+        return;
+      }
+
       if (last.name !== 'text') {
         report({
           ruleId,
@@ -118,7 +134,6 @@ export default function (report: (e: LintingError) => void, node: Element): Obse
       }
 
       let initialText = first.name === 'text' ? first.contents : '';
-      let hasSubsteps = node.sublist !== null;
 
       if (/^(?:If |Else if)/.test(initialText)) {
         if (hasSubsteps) {

--- a/test/lint-algorithm-line-endings.js
+++ b/test/lint-algorithm-line-endings.js
@@ -69,6 +69,21 @@ describe('linting algorithms', function () {
       );
     });
 
+    it('pre', async function () {
+      await assertLint(
+        positioned`<emu-alg>
+            1. ${M}Let _constructorText_ be the source text
+            <pre><code class="javascript">constructor() {}</code></pre>
+              1. Foo.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'lines ending in <pre> tags must not have substeps',
+        }
+      );
+    });
+
     it('negative', async function () {
       await assertLintFree(`
         <emu-alg>
@@ -93,6 +108,9 @@ describe('linting algorithms', function () {
           1. Other.
           1. Other:
             1. Substep.
+          1. Let _constructorText_ be the source text
+          <pre><code class="javascript">constructor() {}</code></pre>
+          1. Set _constructor_ to ParseText(_constructorText_, |MethodDefinition[~Yield, ~Await]|).
         </emu-alg>
       `);
     });


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/2013#issuecomment-634169177.

Contains version bump commit (minor because of the inclusion of two new linting rules, in https://github.com/tc39/ecmarkup/pull/205 and https://github.com/tc39/ecmarkup/pull/207), so please **rebase**, not squash.