### PR TITLE
lint: forbid trailing whitespace

### DIFF
--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -30,6 +30,10 @@ let matchers = [
     pattern: /[Tt]he empty string/gu,
     message: 'Prefer "the empty String"',
   },
+  {
+    pattern: /[ \t]+\n/gu,
+    message: 'Trailing spaces are not allowed',
+  },
 ];
 
 export function collectSpellingDiagnostics(sourceText: string) {

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -81,6 +81,19 @@ describe('spelling', function () {
     );
   });
 
+  it('trailing whitespace', async function () {
+    await assertLint(
+      positioned`
+        <p>something</p>${M}  
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'text',
+        message: 'Trailing spaces are not allowed',
+      }
+    );
+  });
+
   it('negative', async function () {
     await assertLintFree(`
       <p>


### PR DESCRIPTION
This is not tripped on ECMA-262 master. Seems worth enforcing that it remain that way.