### PR TITLE
Bump ecmarkdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkup",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -734,9 +734,9 @@
       }
     },
     "ecmarkdown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.0.1.tgz",
-      "integrity": "sha512-Fey6+oJ7jd3csflBdbQlQtL5qmpx1a9mJqNH/N+bpinYA2RxWbKeZ1W5rZtoPEvATFE7sooXX9GAskuCA+5aZg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.0.2.tgz",
+      "integrity": "sha512-SYMAz8dwLVHz4ggUypzcohIzqL1DNRrvWhPNU8vk4/QcAChlIyWyBZuxg/YTskdMnT3sRUADr61kV9MOjfeRfA==",
       "requires": {
         "escape-html": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "3.22.0",
+	"version": "3.23.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	"dependencies": {
 		"bluebird": "^3.7.2",
 		"chalk": "^1.1.3",
-		"ecmarkdown": "5.0.1",
+		"ecmarkdown": "^5.0.2",
 		"eslint": "^6.8.0",
 		"grammarkdown": "^2.2.0",
 		"highlight.js": "^9.17.1",


### PR DESCRIPTION
Minor because of the inclusion of https://github.com/tc39/ecmarkup/pull/210.

Contains version bump commit, so please **rebase**, not squash.