### PR TITLE
lint: add lint for algorithm line numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkup",
-  "version": "3.23.0",
+  "version": "3.24.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "3.23.0",
+	"version": "3.24.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -6,8 +6,9 @@ import { parseAlgorithm, visit } from 'ecmarkdown';
 
 import { getLocation } from './utils';
 import lintAlgorithmLineEndings from './rules/algorithm-line-endings';
+import lintAlgorithmStepNumbering from './rules/algorithm-step-numbering';
 
-let algorithmRules = [lintAlgorithmLineEndings];
+let algorithmRules = [lintAlgorithmLineEndings, lintAlgorithmStepNumbering];
 
 function composeObservers(...observers: Observer[]): Observer {
   return {
@@ -61,11 +62,14 @@ export function collectAlgorithmDiagnostics(
       lintingErrors.push({ line: trueLine, column: trueCol, ...others });
     };
 
-    let observer = composeObservers(...algorithmRules.map(f => f(reporter, element)));
-    let tree = parseAlgorithm(
-      sourceText.slice(location.startTag.endOffset, location.endTag.startOffset),
-      { trackPositions: true }
+    let algorithmSource = sourceText.slice(
+      location.startTag.endOffset,
+      location.endTag.startOffset
     );
+    let observer = composeObservers(
+      ...algorithmRules.map(f => f(reporter, element, algorithmSource))
+    );
+    let tree = parseAlgorithm(algorithmSource, { trackPositions: true });
     visit(tree, observer);
     algorithm.tree = tree;
   }

--- a/src/lint/rules/algorithm-step-numbering.ts
+++ b/src/lint/rules/algorithm-step-numbering.ts
@@ -1,0 +1,50 @@
+import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { LintingError } from '../algorithm-error-reporter-type';
+
+const ruleId = 'algorithm-step-numbering';
+
+/*
+Checks that step numbers are all `1`, with the exception of top-level lists whose first item is not `1`.
+*/
+export default function (
+  report: (e: LintingError) => void,
+  node: Element,
+  algorithmSource: string
+): Observer {
+  const nodeType = node.tagName;
+  let depth = -1;
+  let topLevelIsOne = false;
+  return {
+    enter(node: EcmarkdownNode) {
+      if (node.name === 'ol') {
+        ++depth;
+        if (depth === 0) {
+          topLevelIsOne = node.start === 1;
+        }
+      } else if (node.name === 'ordered-list-item') {
+        if (depth === 0 && !topLevelIsOne) {
+          return;
+        }
+        let itemSource = algorithmSource.slice(
+          node.location!.start.offset,
+          node.location!.end.offset
+        );
+        let match = itemSource.match(/^(\s*)(\d+\.) /)!;
+        if (match[2] !== '1.') {
+          report({
+            ruleId,
+            nodeType,
+            line: node.location!.start.line,
+            column: node.location!.start.column + match[1].length,
+            message: `expected step number to be "1." (found ${JSON.stringify(match[2])})`,
+          });
+        }
+      }
+    },
+    exit(node: EcmarkdownNode) {
+      if (node.name === 'ol') {
+        --depth;
+      }
+    },
+  };
+}

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -2,11 +2,12 @@
 
 let { assertLint, assertLintFree, lintLocationMarker: M, positioned } = require('./lint-helpers');
 
-const ruleId = 'algorithm-line-endings';
 const nodeType = 'EMU-ALG';
 
 describe('linting algorithms', function () {
   describe('line endings', function () {
+    const ruleId = 'algorithm-line-endings';
+
     it('simple', async function () {
       await assertLint(
         positioned`<emu-alg>
@@ -111,6 +112,99 @@ describe('linting algorithms', function () {
           1. Let _constructorText_ be the source text
           <pre><code class="javascript">constructor() {}</code></pre>
           1. Set _constructor_ to ParseText(_constructorText_, |MethodDefinition[~Yield, ~Await]|).
+        </emu-alg>
+      `);
+    });
+  });
+
+  describe('step numbering', function () {
+    const ruleId = 'algorithm-step-numbering';
+
+    it('simple', async function () {
+      await assertLint(
+        positioned`<emu-alg>
+          1. Step.
+          ${M}2. Step.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected step number to be "1." (found "2.")',
+        }
+      );
+      await assertLint(
+        positioned`<emu-alg>
+          1. Step.
+          1. Step.
+          ${M}2. Step.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected step number to be "1." (found "2.")',
+        }
+      );
+    });
+
+    it('nested', async function () {
+      await assertLint(
+        positioned`<emu-alg>
+          1. Step:
+            ${M}2. Substep.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected step number to be "1." (found "2.")',
+        }
+      );
+
+      await assertLint(
+        positioned`<emu-alg>
+          2. Step:
+            ${M}2. Substep.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected step number to be "1." (found "2.")',
+        }
+      );
+
+      await assertLint(
+        positioned`<emu-alg>
+          1. Step:
+            1. Substep.
+            ${M}2. Substep.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected step number to be "1." (found "2.")',
+        }
+      );
+    });
+
+    it('ten', async function () {
+      await assertLint(
+        positioned`<emu-alg>
+          1. Step.
+          ${M}10. Step.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected step number to be "1." (found "10.")',
+        }
+      );
+    });
+
+    it('negative', async function () {
+      await assertLintFree(`
+        <emu-alg>
+          2. Step.
+          3. Step.
+          40. Step.
         </emu-alg>
       `);
     });


### PR DESCRIPTION
This adds a linting rule which enforces that algorithm steps are all numbered as `1.`, except at the top level of an algorithm whose first item starts with some other number (which is used when providing an alternative definitions of a step which occurs elsewhere).

This rule is tripped 29 times on ECMA-262 master. I'l fix those as part of upstreaming this.

Contains version bump commit, so please **rebase**, not squash.