### PR TITLE
support for replacement algorithms and for xrefs to steps

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -78,16 +78,43 @@ emu-const {
 emu-val {
   font-weight: bold;
 }
-emu-alg ol, emu-alg ol ol ol ol {
-    list-style-type: decimal;
+
+/* depth 1 */
+emu-alg ol,
+/* depth 4 */
+emu-alg ol ol ol ol,
+emu-alg ol.nested-thrice,
+emu-alg ol.nested-twice ol,
+emu-alg ol.nested-once ol ol {
+  list-style-type: decimal;
 }
 
-emu-alg ol ol, emu-alg ol ol ol ol ol {
-    list-style-type: lower-alpha;
+/* depth 2 */
+emu-alg ol ol,
+emu-alg ol.nested-once,
+/* depth 5 */
+emu-alg ol ol ol ol ol,
+emu-alg ol.nested-four-times,
+emu-alg ol.nested-thrice ol,
+emu-alg ol.nested-twice ol ol,
+emu-alg ol.nested-once ol ol ol {
+  list-style-type: lower-alpha;
 }
 
-emu-alg ol ol ol, ol ol ol ol ol ol {
-    list-style-type: lower-roman;
+/* depth 3 */
+emu-alg ol ol ol,
+emu-alg ol.nested-twice,
+emu-alg ol.nested-once ol,
+/* depth 6 */
+emu-alg ol ol ol ol ol ol,
+emu-alg ol.nested-lots,
+emu-alg ol.nested-four-times ol,
+emu-alg ol.nested-thrice ol ol,
+emu-alg ol.nested-twice ol ol ol,
+emu-alg ol.nested-once ol ol ol ol,
+/* depth 7+ */
+emu-alg ol.nested-lots ol {
+  list-style-type: lower-roman;
 }
 
 emu-eqn {

--- a/package-lock.json
+++ b/package-lock.json
@@ -734,9 +734,9 @@
       }
     },
     "ecmarkdown": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.0.2.tgz",
-      "integrity": "sha512-SYMAz8dwLVHz4ggUypzcohIzqL1DNRrvWhPNU8vk4/QcAChlIyWyBZuxg/YTskdMnT3sRUADr61kV9MOjfeRfA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.1.0.tgz",
+      "integrity": "sha512-v0CrpKQLmHdlwyljGQt+MkqI9YM1kcE3RUxrQKF7bagbfBt40Soyruo51J14QMh9ohnWj781Kz7jdP9mbgYoyg==",
       "requires": {
         "escape-html": "^1.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkup",
-  "version": "3.24.0",
+  "version": "3.25.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "3.24.0",
+	"version": "3.25.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	"dependencies": {
 		"bluebird": "^3.7.2",
 		"chalk": "^1.1.3",
-		"ecmarkdown": "^5.0.2",
+		"ecmarkdown": "^5.1.0",
 		"eslint": "^6.8.0",
 		"grammarkdown": "^2.2.0",
 		"highlight.js": "^9.17.1",

--- a/spec/index.html
+++ b/spec/index.html
@@ -5,17 +5,17 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/solarized_light.min.css">
 <title>Ecmarkup</title>
 <pre class=metadata>
-repository: https://github.com/bterlson/ecmarkup
+repository: https://github.com/tc39/ecmarkup
 assets: none
 copyright: false
 </pre>
 <emu-biblio href="./biblio.json"></emu-biblio>
 <emu-intro id="intro">
   <h1>Ecmarkup</h1>
-  <p><a href="https://github.com/bterlson/ecmarkup">Ecmarkup</a> is a number of custom elements and a toolchain suitable for specifying semantics for ECMAScript and other programming languages.</p>
+  <p><a href="https://github.com/tc39/ecmarkup">Ecmarkup</a> is a number of custom elements and a toolchain suitable for specifying semantics for ECMAScript and other programming languages.</p>
   <p>Ecmarkup offers the following conveniences (among many others):</p>
   <ul>
-    <li><a href="https://github.com/domenic/ecmarkdown">Ecmarkdown</a> syntax for paragraphs and algorithms</li>
+    <li><a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> syntax for paragraphs and algorithms</li>
     <li><a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for specifying grammar</li>
     <li>Terse markup for the authoring conventions used in ECMAScript specifications including clauses, notes, examples, figures, tables, and more.</li>
     <li>Easy cross-references by element ID to clauses, abstract operations, examples, figures, tables, and etc. in the current document, ES6, and other specs.</li>
@@ -24,7 +24,7 @@ copyright: false
     <li>Auto-links abstract operations and terms based on name with support for external bibliographies for cross-referencing between specs</li>
     <li>Source code syntax highlighting inside pre code blocks</li>
   </ul>
-  <p>This document is itself written using Ecmarkup. Its source can be viewed <a href="https://github.com/bterlson/ecmarkup/blob/master/spec/index.html">on github</a>.</p>
+  <p>This document is itself written using Ecmarkup. Its source can be viewed <a href="https://github.com/tc39/ecmarkup/blob/master/spec/index.html">on github</a>.</p>
 </emu-intro>
 
 <emu-clause id="getting-started">
@@ -93,7 +93,7 @@ ecmarkup spec.html out.html
     </table>
   </emu-table>
 
-  <p>There are also a number of elements and corresponding Ecmarkdown syntax to give inline styles to various parts of your document in accordance with ECMAScript conventions. More detail on Ecmarkdown syntax can be found <a href="https://github.com/domenic/ecmarkdown">on its readme</a>.</p>
+  <p>There are also a number of elements and corresponding Ecmarkdown syntax to give inline styles to various parts of your document in accordance with ECMAScript conventions. More detail on Ecmarkdown syntax can be found <a href="https://github.com/tc39/ecmarkdown">on its readme</a>.</p>
   <emu-table id="emd-overview">
     <emu-caption>Inline styles/conventions</emu-caption>
     <table>
@@ -198,6 +198,36 @@ toc: false
       1. let _recurse_ be the result of calling EmuAlgExample(`true`)
       2. Return the result of evaluating this |NonTerminalProduction|
   </emu-alg>
+
+  <h2>Replacement algorithms</h2>
+  <p>Algorithms may be specified to replace a labeled step, in which case the algorithm will adopt the numbering of that step. For example:</p>
+
+  <h3>Element</h3>
+  <pre><code class="language-html">
+    &lt;emu-alg>
+      1. Step.
+      1. Step 2.
+        1. [label="replace-me"] Replaced.
+          1. Substep.
+    &lt;/emu-alg>
+    &lt;p>The following is an alernative definition of step &lt;emu-xref href="#step-replace-me">&lt;/emu-xref>.&lt;/p>
+    &lt;emu-alg replaces-step="replace-me">
+      1. Replacement.
+        1. Substep.
+    &lt;/emu-alg>
+  </code></pre>
+  <h3>Result</h3>
+  <emu-alg>
+    1. Step.
+    1. Step 2.
+      1. [label="replace-me"] Replaced.
+        1. Substep.
+  </emu-alg>
+  <p>The following is an alernative definition of step <emu-xref href="#step-replace-me"></emu-xref>.</p>
+  <emu-alg replaces-step="replace-me">
+    1. Replacement.
+      1. Substep.
+  </emu-alg>
 </emu-clause>
 
 <emu-clause id="emu-eqn">
@@ -223,8 +253,8 @@ toc: false
 
 <emu-clause id="emu-xref">
   <h1>emu-xref</h1>
-  <p>Cross-reference another clause, production, note, example, or abstract operation. If the text content of this element is empty, a suitable default is used. The `title` attribute controls this default - when present, clauses are referred to using their title rather than number. This also applies to examples which are indexed first by their containing clause and then their example number.</p>
-  <p>Cross-references to an id check for clauses, productions, and examples in this order. For each type, the local document is consulted before looking for external sources including the default ES6 biblio.</p>
+  <p>Cross-reference another clause, production, note, example, abstract operation, or labeled step. If the text content of this element is empty, a suitable default is used. The `title` attribute controls this default - when present, clauses are referred to using their title rather than number. This also applies to examples which are indexed first by their containing clause and then their example number.</p>
+  <p>Cross-references to an id check for clauses, productions, examples, and steps in this order. For each type, the local document is consulted before looking for external sources including the default ES6 biblio.</p>
 
   <h2>Attributes</h2>
   <p><b>href:</b> Optional: URL of the target clause, production, or example to cross-reference.</p>
@@ -239,6 +269,8 @@ toc: false
     &lt;p>See &lt;emu-xref href="#emu-note" title>&lt;/emu-xref> for information on the emu-note element.&lt;/p>
     &lt;p>The &lt;emu-xref href="#emu-biblio">biblio element&lt;/emu-xref> supports xref to external specs.&lt;/p>
     &lt;p>&lt;emu-xref aoid="Get">&lt;/emu-xref> is an abstract operation from ES6&lt;/p>
+    &lt;p>&lt;emu-alg>1. [label="example-step-label"] Example labeled step.&lt;/emu-alg>&lt;/p>
+    &lt;p>You can reference step &lt;emu-xref href="#step-example-step-label">&lt;/emu-xref> like this&lt;/p>
   </code></pre>
 
   <b>Result</b>
@@ -246,6 +278,8 @@ toc: false
   <p>See <emu-xref href="#emu-note" title></emu-xref> for information on the emu-note element.</p>
   <p>The <emu-xref href="#emu-biblio">biblio element</emu-xref> will eventually support xref to external specs.</p>
   <p><emu-xref aoid="Get"></emu-xref> is an abstract operation from ES6</p>
+  <p><emu-alg>1. [label="example-step-label"] Example labeled step.</emu-alg></p>
+  <p>You can reference step <emu-xref href="#step-example-step-label"></emu-xref> like this</p>
 </emu-clause>
 
 <emu-clause id="emu-not-ref" namespace="emu-not-ref">

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -1,5 +1,7 @@
 import type { Context } from './Context';
+import type { StepBiblioEntry } from './Biblio';
 
+import { logWarning } from './utils';
 import Builder from './Builder';
 import * as emd from 'ecmarkdown';
 
@@ -9,22 +11,61 @@ export default class Algorithm extends Builder {
     context.inAlg = true;
     const { node } = context;
 
-    if ('ecmarkdownOut' in node) {
-      // i.e., we already parsed this during the lint phase
-      // @ts-ignore
-      node.innerHTML = node.ecmarkdownOut.replace(/((?:\s+|>)[!?])\s+(\w+\s*\()/g, '$1&nbsp;$2');
-      return;
-    }
+    // prettier-ignore
+    const rawHtml =
+      'ecmarkdownOut' in node
+        ? (node as any).ecmarkdownOut
+        : emd.algorithm(node.innerHTML);
 
     // replace spaces after !/? with &nbsp; to prevent bad line breaking
-    const html = emd
-      .algorithm(node.innerHTML)
-      .replace(/((?:\s+|>)[!?])\s+(\w+\s*\()/g, '$1&nbsp;$2');
+    const html = rawHtml.replace(/((?:\s+|>)[!?])\s+(\w+\s*\()/g, '$1&nbsp;$2');
     node.innerHTML = html;
+
+    let labeledStepEntries: StepBiblioEntry[] = [];
+    let replaces = node.getAttribute('replaces-step');
+    if (replaces) {
+      replaces = 'step-' + replaces;
+      context.spec.replacementAlgorithms.push({
+        element: node,
+        target: replaces,
+      });
+      context.spec.replacementAlgorithmToContainedLabeledStepEntries.set(node, labeledStepEntries);
+    }
+
+    let labeledSteps = Array.from(node.querySelectorAll('li[id]'));
+    if (replaces && labeledSteps.length > 0 && node.firstElementChild!.children.length > 1) {
+      logWarning(
+        'You should not label a step in a replacement algorithm which has multiple top-level steps because the resulting step number could be ambiguous.'
+      );
+    }
+
+    for (const step of labeledSteps) {
+      let entry: StepBiblioEntry = {
+        type: 'step',
+        id: step.id,
+        stepNumbers: getStepNumbers(step as Element),
+        referencingIds: [],
+      };
+      context.spec.biblio.add(entry);
+      if (replaces) {
+        // The biblio entries for labeled steps in replacement algorithms will be modified in-place by a subsequent pass
+        labeledStepEntries.push(entry);
+        context.spec.labeledStepsToBeRectified.add(step.id);
+      }
+    }
   }
 
   static exit(context: Context) {
     context.inAlg = false;
   }
   static elements = ['EMU-ALG'];
+}
+
+function getStepNumbers(item: Element) {
+  let counts = [];
+  while (item.parentElement?.tagName === 'OL') {
+    counts.unshift(1 + Array.from(item.parentElement.children).indexOf(item));
+    item = item.parentElement.parentElement!;
+  }
+  return counts;
 }

--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -149,6 +149,9 @@ export default class Biblio {
     entry.namespace = ns;
     env!.push(entry);
     if (entry.id) {
+      if ({}.hasOwnProperty.call(this, entry.id)) {
+        throw new Error('Duplicate biblio entry ' + JSON.stringify(entry.id) + '.');
+      }
       this._byId[entry.id] = entry;
     }
   }
@@ -263,12 +266,19 @@ export interface FigureBiblioEntry extends BiblioEntryBase {
   caption?: string;
 }
 
+export interface StepBiblioEntry extends BiblioEntryBase {
+  type: 'step';
+  id: string;
+  stepNumbers: number[];
+}
+
 export type BiblioEntry =
   | AlgorithmBiblioEntry
   | ProductionBiblioEntry
   | ClauseBiblioEntry
   | TermBiblioEntry
-  | FigureBiblioEntry;
+  | FigureBiblioEntry
+  | StepBiblioEntry;
 
 function dumpEnv(env: EnvRec) {
   console.log('## ' + env._namespace);
@@ -308,6 +318,8 @@ function getKey(item: BiblioEntry) {
     case 'example':
     case 'note':
       return item.caption;
+    case 'step':
+      return item.id;
     default:
       throw new Error("Can't get key for " + (<BiblioEntry>item).type);
   }

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -107,8 +107,13 @@ export default class Xref extends Builder {
         case 'term':
           buildTermLink(node, this.entry);
           break;
+        case 'step':
+          buildStepLink(node, this.entry);
+          break;
         default:
-          utils.logWarning('found unknown biblio entry (this is a bug, please file it)');
+          utils.logWarning(
+            `found unknown biblio entry ${this.entry.type} (this is a bug, please file it with ecmarkup)`
+          );
       }
     } else if (aoid) {
       this.entry = spec.biblio.byAoid(aoid, namespace);
@@ -196,6 +201,33 @@ function buildFigureLink(
   } else {
     xref.innerHTML = buildXrefLink(entry, xref.innerHTML);
   }
+}
+
+let decimalBullet = Array.from({ length: 100 }).map((a, i) => '' + (i + 1));
+let alphaBullet = Array.from({ length: 26 }).map((a, i) =>
+  String.fromCharCode('a'.charCodeAt(0) + i)
+);
+// prettier-ignore
+let romanBullet = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x', 'xi', 'xii', 'xiii', 'xiv', 'xv', 'xvi', 'xvii', 'xviii', 'xix', 'xx', 'xxi', 'xxii', 'xxiii', 'xxiv', 'xxv'];
+let bullets = [decimalBullet, alphaBullet, romanBullet, decimalBullet, alphaBullet, romanBullet];
+
+function buildStepLink(xref: Element, entry: Biblio.StepBiblioEntry) {
+  if (xref.innerHTML !== '') {
+    utils.logWarning('the contents of emu-xrefs to steps are ignored');
+  }
+
+  let stepBullets = entry.stepNumbers.map((s, i) => {
+    let applicable = bullets[Math.min(i, 5)];
+    if (s > applicable.length) {
+      utils.logWarning(
+        `ecmarkup does not know how to deal with step numbers as high as ${s}; if you need this, open an issue on ecmarkup`
+      );
+      return '?';
+    }
+    return applicable[s - 1];
+  });
+  let text = stepBullets.join('.');
+  xref.innerHTML = buildXrefLink(entry, text);
 }
 
 function buildXrefLink(entry: Biblio.BiblioEntry, contents: string | number | undefined | null) {

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -51,6 +51,10 @@ let matchers = [
     pattern: /\r/gu,
     message: 'Only Unix-style (LF) linebreaks are allowed',
   },
+  {
+    pattern: /(?<=\b[Ss]teps? )\d/gu,
+    message: 'Prefer using labeled steps and <emu-xref> tags over hardcoding step numbers',
+  },
 ];
 
 export function collectSpellingDiagnostics(sourceText: string) {

--- a/src/lint/rules/algorithm-step-numbering.ts
+++ b/src/lint/rules/algorithm-step-numbering.ts
@@ -4,7 +4,7 @@ import type { LintingError } from '../algorithm-error-reporter-type';
 const ruleId = 'algorithm-step-numbering';
 
 /*
-Checks that step numbers are all `1`, with the exception of top-level lists whose first item is not `1`.
+Checks that step numbers are all `1`.
 */
 export default function (
   report: (e: LintingError) => void,
@@ -12,19 +12,9 @@ export default function (
   algorithmSource: string
 ): Observer {
   const nodeType = node.tagName;
-  let depth = -1;
-  let topLevelIsOne = false;
   return {
     enter(node: EcmarkdownNode) {
-      if (node.name === 'ol') {
-        ++depth;
-        if (depth === 0) {
-          topLevelIsOne = node.start === 1;
-        }
-      } else if (node.name === 'ordered-list-item') {
-        if (depth === 0 && !topLevelIsOne) {
-          return;
-        }
+      if (node.name === 'ordered-list-item') {
         let itemSource = algorithmSource.slice(
           node.location!.start.offset,
           node.location!.end.offset
@@ -39,11 +29,6 @@ export default function (
             message: `expected step number to be "1." (found ${JSON.stringify(match[2])})`,
           });
         }
-      }
-    },
-    exit(node: EcmarkdownNode) {
-      if (node.name === 'ol') {
-        --depth;
       }
     },
   };

--- a/test/algorithm-replacements.html
+++ b/test/algorithm-replacements.html
@@ -1,0 +1,51 @@
+<pre class=metadata>
+toc: false
+copyright: false
+assets: none
+</pre>
+
+<emu-clause id=test>
+  <h1>Title</h1>
+
+  <p>You can refer to a step in a replacement algorithm before it occurs in text, like step <emu-xref href="#step-example"></emu-xref>.</p>
+
+  <p>You can similarly refer to a step in a replacement algorithm which itself which replaces a step in a replacement algorithm, like step <emu-xref href="#step-nested-example"></emu-xref>.</p>
+
+  <p>An algorithm can come before the step it replaces.</p>
+
+  <emu-alg replaces-step="to-be-replaced">
+    1. Two a:
+      1. Two a i:
+        1. Two a i one.
+        1. [label="example"] Two a i two.
+  </emu-alg>
+
+  <p>This is our sample algorithm.</p>
+  <emu-alg>
+    1. One.
+    1. Two:
+      1. [label="to-be-replaced"] Two a.
+  </emu-alg>
+
+  <p>An algorithm can also come after the step it replaces.</p>
+
+  <emu-alg replaces-step="to-be-replaced">
+    1. Two a:
+      1. Two a i:
+        1. Two a i one.
+        1. [label="example"] Two a i two.
+  </emu-alg>
+
+  <p>You can even replace steps in replacement algorithms.</p>
+
+  <emu-alg replaces-step="example">
+    1. Two a i two:
+      1. Two a i two a.
+      1. Two a i two b.
+      1. [label="nested-example"] Two a i two c:
+        1. Two a i two c i:
+          1. Two a i two c i i:
+            1. Two a i two c i i i.
+            1. Two a i two c i i ii.
+  </emu-alg>
+</emu-clause>

--- a/test/baselines/reference/algorithm-replacements.html
+++ b/test/baselines/reference/algorithm-replacements.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<head><meta charset="utf-8"></head><body><div id="spec-container">
+
+<emu-clause id="test">
+  <h1 class="first"><span class="secnum">1</span> Title</h1>
+
+  <p>You can refer to a step in a replacement algorithm before it occurs in text, like step <emu-xref href="#step-example" id="_ref_0"><a href="#step-example">2.a.i.2</a></emu-xref>.</p>
+
+  <p>You can similarly refer to a step in a replacement algorithm which itself which replaces a step in a replacement algorithm, like step <emu-xref href="#step-nested-example" id="_ref_1"><a href="#step-nested-example">2.a.i.2.c</a></emu-xref>.</p>
+
+  <p>An algorithm can come before the step it replaces.</p>
+
+  <emu-alg replaces-step="to-be-replaced"><ol start="1" class="nested-once"><li>Two a:<ol><li>Two a i:<ol><li>Two a i one.</li><li id="step-example">Two a i two.</li></ol></li></ol></li></ol></emu-alg>
+
+  <p>This is our sample algorithm.</p>
+  <emu-alg><ol><li>One.</li><li>Two:<ol><li id="step-to-be-replaced">Two a.</li></ol></li></ol></emu-alg>
+
+  <p>An algorithm can also come after the step it replaces.</p>
+
+  <emu-alg replaces-step="to-be-replaced"><ol start="1" class="nested-once"><li>Two a:<ol><li>Two a i:<ol><li>Two a i one.</li><li id="step-example">Two a i two.</li></ol></li></ol></li></ol></emu-alg>
+
+  <p>You can even replace steps in replacement algorithms.</p>
+
+  <emu-alg replaces-step="example"><ol start="2" class="nested-thrice"><li>Two a i two:<ol><li>Two a i two a.</li><li>Two a i two b.</li><li id="step-nested-example">Two a i two c:<ol><li>Two a i two c i:<ol><li>Two a i two c i i:<ol><li>Two a i two c i i i.</li><li>Two a i two c i i ii.</li></ol></li></ol></li></ol></li></ol></li></ol></emu-alg>
+</emu-clause>
+</div></body>

--- a/test/baselines/reference/step-xrefs.html
+++ b/test/baselines/reference/step-xrefs.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<head><meta charset="utf-8"></head><body><div id="spec-container">
+
+<emu-clause id="test">
+  <h1 class="first"><span class="secnum">1</span> Title</h1>
+
+  <p>You can refer to a step before it occurs in text, like step <emu-xref href="#step-example" id="_ref_0"><a href="#step-example">2.a.ii</a></emu-xref>.</p>
+
+  <emu-alg><ol><li>Step.</li><li><emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>:<ol><li><emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>:<ol><li>Step.</li><li id="step-example">Step.</li></ol></li></ol></li></ol></emu-alg>
+
+  <p>You can refer to it after as well, like step <emu-xref href="#step-example" id="_ref_1"><a href="#step-example">2.a.ii</a></emu-xref>.</p>
+</emu-clause>
+</div></body>

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -123,6 +123,17 @@ describe('linting algorithms', function () {
     it('simple', async function () {
       await assertLint(
         positioned`<emu-alg>
+          ${M}2. Step.
+          1. Step.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected step number to be "1." (found "2.")',
+        }
+      );
+      await assertLint(
+        positioned`<emu-alg>
           1. Step.
           ${M}2. Step.
         </emu-alg>`,
@@ -161,7 +172,7 @@ describe('linting algorithms', function () {
 
       await assertLint(
         positioned`<emu-alg>
-          2. Step:
+          1. Step:
             ${M}2. Substep.
         </emu-alg>`,
         {
@@ -202,9 +213,9 @@ describe('linting algorithms', function () {
     it('negative', async function () {
       await assertLintFree(`
         <emu-alg>
-          2. Step.
-          3. Step.
-          40. Step.
+          1. Step.
+          1. Step.
+          1. Step.
         </emu-alg>
       `);
     });

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -171,6 +171,19 @@ windows:${M}\r
     );
   });
 
+  it('step numbers', async function () {
+    await assertLint(
+      positioned`
+        Something about step ${M}1.
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'text',
+        message: 'Prefer using labeled steps and <emu-xref> tags over hardcoding step numbers',
+      }
+    );
+  });
+
   it('negative', async function () {
     await assertLintFree(`
       <p>
@@ -188,6 +201,11 @@ windows:${M}\r
       <emu-clause id="example">
         <h1>Example</h1>
       </emu-clause>
+
+      <emu-alg>
+        1. [label="example-label"] Foo.
+      </emu-alg>
+      Something about step <emu-xref href="#step-example-label"></emu-xref>.
     `);
   });
 });

--- a/test/step-xrefs.html
+++ b/test/step-xrefs.html
@@ -1,0 +1,21 @@
+<pre class=metadata>
+toc: false
+copyright: false
+assets: none
+</pre>
+
+<emu-clause id=test>
+  <h1>Title</h1>
+
+  <p>You can refer to a step before it occurs in text, like step <emu-xref href="#step-example"></emu-xref>.</p>
+
+  <emu-alg>
+    1. Step.
+    1. List:
+      1. List:
+        1. Step.
+        1. [label="example"] Step.
+  </emu-alg>
+
+  <p>You can refer to it after as well, like step <emu-xref href="#step-example"></emu-xref>.</p>
+</emu-clause>


### PR DESCRIPTION
This adds the ability to reference steps, both with `emu-xref`s and by marking algorithms as replacing steps (the latter so that they can have the appropriate numbering).

You can label steps using the `1. [label="foo"] Step.` syntax introduced in https://github.com/tc39/ecmarkdown/pull/74, and you can refer to them with `<emu-xref href="#step-foo"></emu-xref>` or `<emu-alg replaces-step="foo">`. The xref will automatically be populated with the appropriate step number (just the number itself, so you still need to write out "step", and possibly the name of the algorithm if it isn't clear). The labeled algorithm will automatically adopt the numbering of the labeled step, including for nested steps.

Now that we have support for replacement algorithms there is no longer a need to manually override the starting number for a list. I enforce that you do not, and that you do not write "step 1" or whatever, with the linter.

Fixes https://github.com/tc39/ecmarkup/issues/192.

Marked as draft until a version of ecmarkdown with support for the `[label=""]` syntax is published.

Corresponding ecmarkdown PR at https://github.com/tc39/ecmarkdown/pull/74. Corresponding ecma262 PR at https://github.com/tc39/ecma262/pull/2052.

Since it's hard to review the CSS in the PR, here's a screenshot of the new `algorithm-replacements` baseline:

![Screen Shot 2020-06-15 at 9 34 16 PM](https://user-images.githubusercontent.com/1653598/84737507-ea3deb80-af5c-11ea-8a43-c1b660c46b12.png)
