### PR TITLE
use id rather than label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -734,9 +734,9 @@
       }
     },
     "ecmarkdown": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.1.0.tgz",
-      "integrity": "sha512-v0CrpKQLmHdlwyljGQt+MkqI9YM1kcE3RUxrQKF7bagbfBt40Soyruo51J14QMh9ohnWj781Kz7jdP9mbgYoyg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.1.2.tgz",
+      "integrity": "sha512-3mV+/g9p5dw1BTlIRJk5jnQY59CHOsKyhy/RWfcYEB721vcm6A2J9F6YYCbcCG6ZQF+nEUCgszUzMVhcYeP1ig==",
       "requires": {
         "escape-html": "^1.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkup",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "3.25.0",
+	"version": "3.25.1",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	"dependencies": {
 		"bluebird": "^3.7.2",
 		"chalk": "^1.1.3",
-		"ecmarkdown": "^5.1.0",
+		"ecmarkdown": "^5.1.2",
 		"eslint": "^6.8.0",
 		"grammarkdown": "^2.2.0",
 		"highlight.js": "^9.17.1",

--- a/spec/index.html
+++ b/spec/index.html
@@ -207,10 +207,10 @@ toc: false
     &lt;emu-alg>
       1. Step.
       1. Step 2.
-        1. [label="replace-me"] Replaced.
+        1. [id="replace-me"] Replaced.
           1. Substep.
     &lt;/emu-alg>
-    &lt;p>The following is an alernative definition of step &lt;emu-xref href="#step-replace-me">&lt;/emu-xref>.&lt;/p>
+    &lt;p>The following is an alernative definition of step &lt;emu-xref href="#replace-me">&lt;/emu-xref>.&lt;/p>
     &lt;emu-alg replaces-step="replace-me">
       1. Replacement.
         1. Substep.
@@ -220,10 +220,10 @@ toc: false
   <emu-alg>
     1. Step.
     1. Step 2.
-      1. [label="replace-me"] Replaced.
+      1. [id="replace-me"] Replaced.
         1. Substep.
   </emu-alg>
-  <p>The following is an alernative definition of step <emu-xref href="#step-replace-me"></emu-xref>.</p>
+  <p>The following is an alernative definition of step <emu-xref href="#replace-me"></emu-xref>.</p>
   <emu-alg replaces-step="replace-me">
     1. Replacement.
       1. Substep.
@@ -269,8 +269,8 @@ toc: false
     &lt;p>See &lt;emu-xref href="#emu-note" title>&lt;/emu-xref> for information on the emu-note element.&lt;/p>
     &lt;p>The &lt;emu-xref href="#emu-biblio">biblio element&lt;/emu-xref> supports xref to external specs.&lt;/p>
     &lt;p>&lt;emu-xref aoid="Get">&lt;/emu-xref> is an abstract operation from ES6&lt;/p>
-    &lt;p>&lt;emu-alg>1. [label="example-step-label"] Example labeled step.&lt;/emu-alg>&lt;/p>
-    &lt;p>You can reference step &lt;emu-xref href="#step-example-step-label">&lt;/emu-xref> like this&lt;/p>
+    &lt;p>&lt;emu-alg>1. [id="example-step-label"] Example labeled step.&lt;/emu-alg>&lt;/p>
+    &lt;p>You can reference step &lt;emu-xref href="#example-step-label">&lt;/emu-xref> like this&lt;/p>
   </code></pre>
 
   <b>Result</b>
@@ -278,8 +278,8 @@ toc: false
   <p>See <emu-xref href="#emu-note" title></emu-xref> for information on the emu-note element.</p>
   <p>The <emu-xref href="#emu-biblio">biblio element</emu-xref> will eventually support xref to external specs.</p>
   <p><emu-xref aoid="Get"></emu-xref> is an abstract operation from ES6</p>
-  <p><emu-alg>1. [label="example-step-label"] Example labeled step.</emu-alg></p>
-  <p>You can reference step <emu-xref href="#step-example-step-label"></emu-xref> like this</p>
+  <p><emu-alg>1. [id="example-step-label"] Example labeled step.</emu-alg></p>
+  <p>You can reference step <emu-xref href="#example-step-label"></emu-xref> like this</p>
 </emu-clause>
 
 <emu-clause id="emu-not-ref" namespace="emu-not-ref">

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -24,7 +24,6 @@ export default class Algorithm extends Builder {
     let labeledStepEntries: StepBiblioEntry[] = [];
     let replaces = node.getAttribute('replaces-step');
     if (replaces) {
-      replaces = 'step-' + replaces;
       context.spec.replacementAlgorithms.push({
         element: node,
         target: replaces,

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -7,8 +7,13 @@ import { parseAlgorithm, visit } from 'ecmarkdown';
 import { getLocation } from './utils';
 import lintAlgorithmLineEndings from './rules/algorithm-line-endings';
 import lintAlgorithmStepNumbering from './rules/algorithm-step-numbering';
+import lintAlgorithmStepLabels from './rules/algorithm-step-labels';
 
-let algorithmRules = [lintAlgorithmLineEndings, lintAlgorithmStepNumbering];
+let algorithmRules = [
+  lintAlgorithmLineEndings,
+  lintAlgorithmStepNumbering,
+  lintAlgorithmStepLabels,
+];
 
 function composeObservers(...observers: Observer[]): Observer {
   return {

--- a/src/lint/rules/algorithm-step-labels.ts
+++ b/src/lint/rules/algorithm-step-labels.ts
@@ -1,0 +1,34 @@
+import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { LintingError } from '../algorithm-error-reporter-type';
+
+const ruleId = 'algorithm-step-labels';
+
+/*
+Checks that step labels all start with `step-`.
+*/
+export default function (
+  report: (e: LintingError) => void,
+  node: Element,
+  algorithmSource: string
+): Observer {
+  const nodeType = node.tagName;
+  return {
+    enter(node: EcmarkdownNode) {
+      // console.log(node)
+      if (node.name === 'ordered-list-item' && node.id != null && !/^step-/.test(node.id)) {
+        let itemSource = algorithmSource.slice(
+          node.location!.start.offset,
+          node.location!.end.offset
+        );
+        let offset = itemSource.match(/^\s*\d+\. \[id="/)![0].length;
+        report({
+          ruleId,
+          nodeType,
+          line: node.location!.start.line,
+          column: node.location!.start.column + offset,
+          message: `step labels should start with "step-"`,
+        });
+      }
+    },
+  };
+}

--- a/test/algorithm-replacements.html
+++ b/test/algorithm-replacements.html
@@ -7,9 +7,9 @@ assets: none
 <emu-clause id=test>
   <h1>Title</h1>
 
-  <p>You can refer to a step in a replacement algorithm before it occurs in text, like step <emu-xref href="#step-example"></emu-xref>.</p>
+  <p>You can refer to a step in a replacement algorithm before it occurs in text, like step <emu-xref href="#example"></emu-xref>.</p>
 
-  <p>You can similarly refer to a step in a replacement algorithm which itself which replaces a step in a replacement algorithm, like step <emu-xref href="#step-nested-example"></emu-xref>.</p>
+  <p>You can similarly refer to a step in a replacement algorithm which itself which replaces a step in a replacement algorithm, like step <emu-xref href="#nested-example"></emu-xref>.</p>
 
   <p>An algorithm can come before the step it replaces.</p>
 
@@ -17,14 +17,14 @@ assets: none
     1. Two a:
       1. Two a i:
         1. Two a i one.
-        1. [label="example"] Two a i two.
+        1. [id="example"] Two a i two.
   </emu-alg>
 
   <p>This is our sample algorithm.</p>
   <emu-alg>
     1. One.
     1. Two:
-      1. [label="to-be-replaced"] Two a.
+      1. [id="to-be-replaced"] Two a.
   </emu-alg>
 
   <p>An algorithm can also come after the step it replaces.</p>
@@ -33,7 +33,7 @@ assets: none
     1. Two a:
       1. Two a i:
         1. Two a i one.
-        1. [label="example"] Two a i two.
+        1. [id="example"] Two a i two.
   </emu-alg>
 
   <p>You can even replace steps in replacement algorithms.</p>
@@ -42,7 +42,7 @@ assets: none
     1. Two a i two:
       1. Two a i two a.
       1. Two a i two b.
-      1. [label="nested-example"] Two a i two c:
+      1. [id="nested-example"] Two a i two c:
         1. Two a i two c i:
           1. Two a i two c i i:
             1. Two a i two c i i i.

--- a/test/baselines/reference/algorithm-replacements.html
+++ b/test/baselines/reference/algorithm-replacements.html
@@ -4,23 +4,23 @@
 <emu-clause id="test">
   <h1 class="first"><span class="secnum">1</span> Title</h1>
 
-  <p>You can refer to a step in a replacement algorithm before it occurs in text, like step <emu-xref href="#step-example" id="_ref_0"><a href="#step-example">2.a.i.2</a></emu-xref>.</p>
+  <p>You can refer to a step in a replacement algorithm before it occurs in text, like step <emu-xref href="#example" id="_ref_0"><a href="#example">2.a.i.2</a></emu-xref>.</p>
 
-  <p>You can similarly refer to a step in a replacement algorithm which itself which replaces a step in a replacement algorithm, like step <emu-xref href="#step-nested-example" id="_ref_1"><a href="#step-nested-example">2.a.i.2.c</a></emu-xref>.</p>
+  <p>You can similarly refer to a step in a replacement algorithm which itself which replaces a step in a replacement algorithm, like step <emu-xref href="#nested-example" id="_ref_1"><a href="#nested-example">2.a.i.2.c</a></emu-xref>.</p>
 
   <p>An algorithm can come before the step it replaces.</p>
 
-  <emu-alg replaces-step="to-be-replaced"><ol start="1" class="nested-once"><li>Two a:<ol><li>Two a i:<ol><li>Two a i one.</li><li id="step-example">Two a i two.</li></ol></li></ol></li></ol></emu-alg>
+  <emu-alg replaces-step="to-be-replaced"><ol start="1" class="nested-once"><li>Two a:<ol><li>Two a i:<ol><li>Two a i one.</li><li id="example">Two a i two.</li></ol></li></ol></li></ol></emu-alg>
 
   <p>This is our sample algorithm.</p>
-  <emu-alg><ol><li>One.</li><li>Two:<ol><li id="step-to-be-replaced">Two a.</li></ol></li></ol></emu-alg>
+  <emu-alg><ol><li>One.</li><li>Two:<ol><li id="to-be-replaced">Two a.</li></ol></li></ol></emu-alg>
 
   <p>An algorithm can also come after the step it replaces.</p>
 
-  <emu-alg replaces-step="to-be-replaced"><ol start="1" class="nested-once"><li>Two a:<ol><li>Two a i:<ol><li>Two a i one.</li><li id="step-example">Two a i two.</li></ol></li></ol></li></ol></emu-alg>
+  <emu-alg replaces-step="to-be-replaced"><ol start="1" class="nested-once"><li>Two a:<ol><li>Two a i:<ol><li>Two a i one.</li><li id="example">Two a i two.</li></ol></li></ol></li></ol></emu-alg>
 
   <p>You can even replace steps in replacement algorithms.</p>
 
-  <emu-alg replaces-step="example"><ol start="2" class="nested-thrice"><li>Two a i two:<ol><li>Two a i two a.</li><li>Two a i two b.</li><li id="step-nested-example">Two a i two c:<ol><li>Two a i two c i:<ol><li>Two a i two c i i:<ol><li>Two a i two c i i i.</li><li>Two a i two c i i ii.</li></ol></li></ol></li></ol></li></ol></li></ol></emu-alg>
+  <emu-alg replaces-step="example"><ol start="2" class="nested-thrice"><li>Two a i two:<ol><li>Two a i two a.</li><li>Two a i two b.</li><li id="nested-example">Two a i two c:<ol><li>Two a i two c i:<ol><li>Two a i two c i i:<ol><li>Two a i two c i i i.</li><li>Two a i two c i i ii.</li></ol></li></ol></li></ol></li></ol></li></ol></emu-alg>
 </emu-clause>
 </div></body>

--- a/test/baselines/reference/step-xrefs.html
+++ b/test/baselines/reference/step-xrefs.html
@@ -4,10 +4,10 @@
 <emu-clause id="test">
   <h1 class="first"><span class="secnum">1</span> Title</h1>
 
-  <p>You can refer to a step before it occurs in text, like step <emu-xref href="#step-example" id="_ref_0"><a href="#step-example">2.a.ii</a></emu-xref>.</p>
+  <p>You can refer to a step before it occurs in text, like step <emu-xref href="#example" id="_ref_0"><a href="#example">2.a.ii</a></emu-xref>.</p>
 
-  <emu-alg><ol><li>Step.</li><li><emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>:<ol><li><emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>:<ol><li>Step.</li><li id="step-example">Step.</li></ol></li></ol></li></ol></emu-alg>
+  <emu-alg><ol><li>Step.</li><li><emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>:<ol><li><emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>:<ol><li>Step.</li><li id="example">Step.</li></ol></li></ol></li></ol></emu-alg>
 
-  <p>You can refer to it after as well, like step <emu-xref href="#step-example" id="_ref_1"><a href="#step-example">2.a.ii</a></emu-xref>.</p>
+  <p>You can refer to it after as well, like step <emu-xref href="#example" id="_ref_1"><a href="#example">2.a.ii</a></emu-xref>.</p>
 </emu-clause>
 </div></body>

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -21,6 +21,19 @@ describe('linting algorithms', function () {
       );
     });
 
+    it('labeled', async function () {
+      await assertLint(
+        positioned`<emu-alg>
+          1. [id="step-test"] testing${M}
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected freeform line to end with "." (found "testing")',
+        }
+      );
+    });
+
     it('inline', async function () {
       await assertLint(positioned`<emu-alg>1. testing${M}</emu-alg>`, {
         ruleId,
@@ -216,6 +229,32 @@ describe('linting algorithms', function () {
           1. Step.
           1. Step.
           1. Step.
+        </emu-alg>
+      `);
+    });
+  });
+
+  describe('step labels', function () {
+    const ruleId = 'algorithm-step-labels';
+    it('rejects unprefixed labels', async function () {
+      await assertLint(
+        positioned`<emu-alg>
+          1. [id="${M}example"] Step.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'step labels should start with "step-"',
+        }
+      );
+    });
+
+    it('negative', async function () {
+      await assertLintFree(`
+        <emu-alg>
+          1. Step.
+          1. [id="step-example"] Step.
+          1. This is <span id="example">valid</span>.
         </emu-alg>
       `);
     });

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -203,9 +203,9 @@ windows:${M}\r
       </emu-clause>
 
       <emu-alg>
-        1. [label="example-label"] Foo.
+        1. [id="step-label"] Foo.
       </emu-alg>
-      Something about step <emu-xref href="#step-example-label"></emu-xref>.
+      Something about step <emu-xref href="#step-label"></emu-xref>.
     `);
   });
 });

--- a/test/step-xrefs.html
+++ b/test/step-xrefs.html
@@ -7,15 +7,15 @@ assets: none
 <emu-clause id=test>
   <h1>Title</h1>
 
-  <p>You can refer to a step before it occurs in text, like step <emu-xref href="#step-example"></emu-xref>.</p>
+  <p>You can refer to a step before it occurs in text, like step <emu-xref href="#example"></emu-xref>.</p>
 
   <emu-alg>
     1. Step.
     1. List:
       1. List:
         1. Step.
-        1. [label="example"] Step.
+        1. [id="example"] Step.
   </emu-alg>
 
-  <p>You can refer to it after as well, like step <emu-xref href="#step-example"></emu-xref>.</p>
+  <p>You can refer to it after as well, like step <emu-xref href="#example"></emu-xref>.</p>
 </emu-clause>


### PR DESCRIPTION
Followup to https://github.com/tc39/ecmarkdown/pull/75.

Do we want to introduce an editorial convention that all step labels must be prefixed with `step-`, now that tooling doesn't do that for us? I can add a lint rule to enforce that, if so.

Contains version bump commit, so please **rebase**, not squash.