### PR TITLE
Fix <emu‑biblio> documentation

### DIFF
--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -1,8 +1,9 @@
 {
-  "https://tc39.github.io/ecma262/": [
+  "https://tc39.es/ecma262/": [
     {
       "type": "op",
-      "aoid": "ReturnIfAbrubt"
+      "id": "sec-returnifabrupt",
+      "aoid": "ReturnIfAbrupt"
     },
     {
       "type": "op",

--- a/spec/index.html
+++ b/spec/index.html
@@ -396,7 +396,13 @@ toc: false
   "https://tc39.github.io/ecma262/": [
     {
       "type": "op",
-      "aoid": "ReturnIfAbrubt"
+      "id": "sec-returnifabrupt",
+      "aoid": "ReturnIfAbrupt"
+    },
+    {
+      "type": "op",
+      "id": "sec-get-o-p",
+      "aoid": "Get"
     }
   ]
 }</code></pre>
@@ -404,7 +410,7 @@ toc: false
   <pre><code class="language-html">
 &lt;emu-biblio href="./biblio.json">&lt;/emu-biblio>
 &lt;emu-alg>
-1. let _res_ be some value.
+1. let _res_ be Get(_obj_, _key_).
 2. ReturnIfAbrupt(_res_)
 &lt;/emu-alg>
   </code></pre>


### PR DESCRIPTION
This also fixes the auto‑link for `Get` to point to <https://tc39.es/ecma262/#sec-get-o-p> instead of <https://tc39.github.io/ecma262/#sec-get-o-p>