### PR TITLE
[meta] add "engines"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A web component-based source format for ECMAScript and related specifications. S
 
 ### Installing & Using
 
-Requires Node.js 4.0 or above.
+Requires node 8 or above.
 
 ```
 npm install ecmarkup

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
 		"singleQuote": true,
 		"arrowParens": "avoid",
 		"printWidth": 100
+	},
+	"engines": {
+		"node": ">= 12 || ^11.10.1 || ^10.13 || ^8.10"
 	}
 }


### PR DESCRIPTION
Ran `npx ls-engines` to calculate the ranges.

Closes #112.

(since "engines" is purely advisory, this is semver-neutral; for yarn users, however, it will fail the install on node versions where it was already broken)