### PR TITLE
Add --strict flag to turn warnings into errors

### DIFF
--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -1,7 +1,6 @@
 import type { Context } from './Context';
 import type { StepBiblioEntry } from './Biblio';
 
-import { logWarning } from './utils';
 import Builder from './Builder';
 import * as emd from 'ecmarkdown';
 
@@ -9,7 +8,7 @@ import * as emd from 'ecmarkdown';
 export default class Algorithm extends Builder {
   static enter(context: Context) {
     context.inAlg = true;
-    const { node } = context;
+    const { spec, node } = context;
 
     // prettier-ignore
     const rawHtml =
@@ -33,7 +32,7 @@ export default class Algorithm extends Builder {
 
     let labeledSteps = Array.from(node.querySelectorAll('li[id]'));
     if (replaces && labeledSteps.length > 0 && node.firstElementChild!.children.length > 1) {
-      logWarning(
+      spec.warn(
         'You should not label a step in a replacement algorithm which has multiple top-level steps because the resulting step number could be ambiguous.'
       );
     }

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,8 +1,6 @@
 import type Spec from './Spec';
 import type { Context } from './Context';
 
-import * as utils from './utils';
-
 const nodeIds = new Set<string>();
 
 // We use this instead of `typeof Builder` because using the class as the type also requires derived constructors to be subtypes of the base constructor, which is irritating.
@@ -26,16 +24,12 @@ export default class Builder {
 
     if (nodeId !== null) {
       if (nodeIds.has(nodeId)) {
-        this._log(`<${node.tagName.toLowerCase()}> has duplicate id: ${nodeId}`);
+        if (spec.opts.verbose) {
+          spec.warn(`<${node.tagName.toLowerCase()}> has duplicate id: ${nodeId}`);
+        }
       }
       nodeIds.add(nodeId);
     }
-  }
-
-  /*@internal*/
-  _log(str: string) {
-    if (!this.spec.opts.verbose) return;
-    utils.logWarning(str);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,8 +1,6 @@
 import type Spec from './Spec';
 import type { Context } from './Context';
 
-const nodeIds = new Set<string>();
-
 // We use this instead of `typeof Builder` because using the class as the type also requires derived constructors to be subtypes of the base constructor, which is irritating.
 /*@internal*/
 export interface BuilderInterface {
@@ -23,12 +21,10 @@ export default class Builder {
     let nodeId = node.getAttribute('id')!;
 
     if (nodeId !== null) {
-      if (nodeIds.has(nodeId)) {
-        if (spec.opts.verbose) {
-          spec.warn(`<${node.tagName.toLowerCase()}> has duplicate id: ${nodeId}`);
-        }
+      if (spec.nodeIds.has(nodeId)) {
+        spec.warn(`<${node.tagName.toLowerCase()}> has duplicate id: ${nodeId}`);
       }
-      nodeIds.add(nodeId);
+      spec.nodeIds.add(nodeId);
     }
   }
 

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -4,7 +4,6 @@ import type Spec from './Spec';
 import type { ClauseBiblioEntry } from './Biblio';
 import type { Context } from './Context';
 
-import { logWarning } from './utils';
 import Builder from './Builder';
 
 /*@internal*/
@@ -108,7 +107,7 @@ export default class Clause extends Builder {
 
   static enter({ spec, node, clauseStack, clauseNumberer }: Context) {
     if (!node.id) {
-      logWarning("Clause doesn't have an id: " + node.outerHTML.slice(0, 100));
+      spec.warn("Clause doesn't have an id: " + node.outerHTML.slice(0, 100));
     }
 
     let nextNumber = '';

--- a/src/Note.ts
+++ b/src/Note.ts
@@ -68,7 +68,7 @@ export default class Note extends Builder {
     } else if (this.type === 'editor') {
       label = "Editor's Note";
     } else {
-      this.spec._log(`Unknown note type ${this.type}. Skipping.`);
+      this.spec.warn(`Unknown note type ${this.type}. Skipping.`);
     }
 
     if (number !== undefined) {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -91,6 +91,7 @@ export default class Spec {
   doc: Document;
   imports: Import[];
   node: HTMLElement;
+  nodeIds: Set<string>;
   subclauses: Clause[];
   replacementAlgorithmToContainedLabeledStepEntries: Map<Element, StepBiblioEntry[]>; // map from re to its labeled nodes
   labeledStepsToBeRectified: Set<string>;
@@ -126,6 +127,7 @@ export default class Spec {
     this.subclauses = [];
     this.imports = [];
     this.node = this.doc.body;
+    this.nodeIds = new Set();
     this.replacementAlgorithmToContainedLabeledStepEntries = new Map();
     this.labeledStepsToBeRectified = new Set();
     this.replacementAlgorithms = [];

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -228,12 +228,21 @@ export default class Spec {
     const document = this.doc;
 
     if (this.opts.reportLintErrors) {
+      let { reportLintErrors } = this.opts;
       this._log('Linting...');
       const source = this.sourceText;
       if (source === undefined) {
         throw new Error('Cannot lint when source text is not available');
       }
-      lint(this.opts.reportLintErrors, source, this.dom, document);
+      lint(
+        (...args) => {
+          this.warned = true;
+          reportLintErrors(...args);
+        },
+        source,
+        this.dom,
+        document
+      );
     }
 
     const walker = document.createTreeWalker(document.body, 1 | 4 /* elements and text nodes */);

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -133,8 +133,8 @@ export default class Spec {
     this.labeledStepsToBeRectified = new Set();
     this.replacementAlgorithms = [];
     this.cancellationToken = token;
-    this.log = opts.log ?? (str => {});
-    this.warn = opts.warn ?? (str => {});
+    this.log = opts.log ?? (() => {});
+    this.warn = opts.warn ?? (() => {});
     this._figureCounts = {
       table: 0,
       figure: 0,

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -97,7 +97,8 @@ export default class Spec {
   labeledStepsToBeRectified: Set<string>;
   replacementAlgorithms: { element: Element; target: string }[];
   cancellationToken: CancellationToken;
-  warned: boolean;
+  log: (msg: string) => void;
+  warn: (msg: string) => void;
 
   _figureCounts: { [type: string]: number };
   _xrefs: Xref[];
@@ -132,7 +133,8 @@ export default class Spec {
     this.labeledStepsToBeRectified = new Set();
     this.replacementAlgorithms = [];
     this.cancellationToken = token;
-    this.warned = false;
+    this.log = opts.log ?? (str => {});
+    this.warn = opts.warn ?? (str => {});
     this._figureCounts = {
       table: 0,
       figure: 0,
@@ -200,19 +202,19 @@ export default class Spec {
     7. Add CSS & JS dependencies.
     */
 
-    this._log('Loading biblios...');
+    this.log('Loading biblios...');
     if (this.opts.ecma262Biblio) {
       await this.loadECMA262Biblio();
     }
     await this.loadBiblios();
 
-    this._log('Loading imports...');
+    this.log('Loading imports...');
     await this.loadImports();
 
-    this._log('Building boilerplate...');
+    this.log('Building boilerplate...');
     this.buildBoilerplate();
 
-    this._log('Walking document, building various elements...');
+    this.log('Walking document, building various elements...');
     const context: Context = {
       spec: this,
       node: this.doc.body,
@@ -231,20 +233,12 @@ export default class Spec {
 
     if (this.opts.reportLintErrors) {
       let { reportLintErrors } = this.opts;
-      this._log('Linting...');
+      this.log('Linting...');
       const source = this.sourceText;
       if (source === undefined) {
         throw new Error('Cannot lint when source text is not available');
       }
-      lint(
-        (...args) => {
-          this.warned = true;
-          reportLintErrors(...args);
-        },
-        source,
-        this.dom,
-        document
-      );
+      lint(reportLintErrors, source, this.dom, document);
     }
 
     const walker = document.createTreeWalker(document.body, 1 | 4 /* elements and text nodes */);
@@ -255,13 +249,13 @@ export default class Spec {
 
     this.autolink();
 
-    this._log('Linking xrefs...');
+    this.log('Linking xrefs...');
     this._xrefs.forEach(xref => xref.build());
-    this._log('Linking non-terminal references...');
+    this.log('Linking non-terminal references...');
     this._ntRefs.forEach(nt => nt.build());
-    this._log('Linking production references...');
+    this.log('Linking production references...');
     this._prodRefs.forEach(prod => prod.build());
-    this._log('Building reference graph...');
+    this.log('Building reference graph...');
     this.buildReferenceGraph();
 
     this.highlightCode();
@@ -270,7 +264,7 @@ export default class Spec {
     this.buildSpecWrapper();
 
     if (this.opts.toc) {
-      this._log('Building table of contents...');
+      this.log('Building table of contents...');
 
       let toc: Toc | Menu;
       if (this.opts.oldToc) {
@@ -284,7 +278,7 @@ export default class Spec {
 
     await this.buildAssets();
 
-    this._log('Done.');
+    this.log('Done.');
     return this;
   }
 
@@ -330,12 +324,12 @@ export default class Spec {
     const cssContents = await utils.readFile(path.join(__dirname, '../css/elements.css'));
 
     if (this.opts.jsOut) {
-      this._log(`Writing js file to ${this.opts.jsOut}...`);
+      this.log(`Writing js file to ${this.opts.jsOut}...`);
       await utils.writeFile(this.opts.jsOut, jsContents);
     }
 
     if (this.opts.cssOut) {
-      this._log(`Writing css file to ${this.opts.cssOut}...`);
+      this.log(`Writing css file to ${this.opts.cssOut}...`);
       await utils.writeFile(this.opts.cssOut, cssContents);
     }
 
@@ -358,7 +352,7 @@ export default class Spec {
         const script = scripts[i];
         const src = script.getAttribute('src');
         if (src && path.normalize(path.join(outDir, src)) === path.normalize(this.opts.jsOut)) {
-          this._log(`Found existing js link to ${src}, skipping inlining...`);
+          this.log(`Found existing js link to ${src}, skipping inlining...`);
           skipJs = true;
         }
       }
@@ -370,21 +364,21 @@ export default class Spec {
         const link = links[i];
         const href = link.getAttribute('href');
         if (href && path.normalize(path.join(outDir, href)) === path.normalize(this.opts.cssOut)) {
-          this._log(`Found existing css link to ${href}, skipping inlining...`);
+          this.log(`Found existing css link to ${href}, skipping inlining...`);
           skipCss = true;
         }
       }
     }
 
     if (!skipJs) {
-      this._log('Inlining JavaScript assets...');
+      this.log('Inlining JavaScript assets...');
       const script = this.doc.createElement('script');
       script.textContent = jsContents;
       this.doc.head.appendChild(script);
     }
 
     if (!skipCss) {
-      this._log('Inlining CSS assets...');
+      this.log('Inlining CSS assets...');
       const style = this.doc.createElement('style');
       style.textContent = cssContents;
       this.doc.head.appendChild(style);
@@ -461,7 +455,7 @@ export default class Spec {
   }
 
   private highlightCode() {
-    this._log('Highlighting syntax...');
+    this.log('Highlighting syntax...');
     const codes = this.doc.querySelectorAll('pre code');
     for (let i = 0; i < codes.length; i++) {
       const classAttr = codes[i].getAttribute('class');
@@ -648,7 +642,7 @@ export default class Spec {
   }
 
   private setReplacementAlgorithmOffsets() {
-    this._log('Finding offsets for replacement algorithm steps...');
+    this.log('Finding offsets for replacement algorithm steps...');
     let pending: Map<string, Element[]> = new Map();
 
     let setReplacementAlgorithmStart = (element: Element, stepNumbers: number[]) => {
@@ -712,7 +706,7 @@ export default class Spec {
   }
 
   public autolink() {
-    this._log('Autolinking terms and abstract ops...');
+    this.log('Autolinking terms and abstract ops...');
     let namespaces = Object.keys(this._textNodes);
     for (let i = 0; i < namespaces.length; i++) {
       let namespace = namespaces[i];
@@ -735,17 +729,6 @@ export default class Spec {
     }
 
     current.setAttribute('charset', 'utf-8');
-  }
-
-  /*@internal*/
-  _log(str: string) {
-    if (!this.opts.verbose) return;
-    utils.logVerbose(str);
-  }
-
-  public warn(str: string) {
-    this.warned = true;
-    utils.logWarning(str);
   }
 
   private _updateBySelector(selector: string, contents: string) {

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -4,7 +4,6 @@ import type * as Biblio from './Biblio';
 import type Clause from './Clause';
 
 import Builder from './Builder';
-import * as utils from './utils';
 
 /*@internal*/
 export default class Xref extends Builder {
@@ -46,13 +45,12 @@ export default class Xref extends Builder {
     }
 
     if (href && aoid) {
-      utils.logWarning("xref can't have both href and aoid.");
+      spec.warn("xref can't have both href and aoid.");
       return;
     }
 
     if (!href && !aoid) {
-      utils.logWarning('xref has no href or aoid.');
-      console.log(node.outerHTML);
+      spec.warn('xref has no href or aoid.');
       return;
     }
 
@@ -69,7 +67,7 @@ export default class Xref extends Builder {
 
     if (href) {
       if (href[0] !== '#') {
-        utils.logWarning(
+        spec.warn(
           'xref to anything other than a fragment id is not supported (is ' +
             href +
             '). Try href="#sec-id" instead.'
@@ -81,7 +79,7 @@ export default class Xref extends Builder {
 
       this.entry = spec.biblio.byId(id);
       if (!this.entry) {
-        utils.logWarning("can't find clause, production, note or example with id " + href);
+        spec.warn("can't find clause, production, note or example with id " + href);
         return;
       }
 
@@ -108,10 +106,10 @@ export default class Xref extends Builder {
           buildTermLink(node, this.entry);
           break;
         case 'step':
-          buildStepLink(node, this.entry);
+          buildStepLink(spec, node, this.entry);
           break;
         default:
-          utils.logWarning(
+          spec.warn(
             `found unknown biblio entry ${this.entry.type} (this is a bug, please file it with ecmarkup)`
           );
       }
@@ -123,7 +121,7 @@ export default class Xref extends Builder {
         return;
       }
 
-      utils.logWarning("can't find abstract op with aoid " + aoid + ' in namespace ' + namespace);
+      spec.warn("can't find abstract op with aoid " + aoid + ' in namespace ' + namespace);
     }
   }
 }
@@ -176,7 +174,7 @@ function buildFigureLink(
       // first need to find the associated clause
       const clauseEntry = spec.biblio.byId(entry.clauseId);
       if (clauseEntry.type !== 'clause') {
-        utils.logWarning('could not find parent clause for ' + type + ' id ' + entry.id);
+        spec.warn('could not find parent clause for ' + type + ' id ' + entry.id);
         return;
       }
 
@@ -211,15 +209,15 @@ let alphaBullet = Array.from({ length: 26 }).map((a, i) =>
 let romanBullet = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x', 'xi', 'xii', 'xiii', 'xiv', 'xv', 'xvi', 'xvii', 'xviii', 'xix', 'xx', 'xxi', 'xxii', 'xxiii', 'xxiv', 'xxv'];
 let bullets = [decimalBullet, alphaBullet, romanBullet, decimalBullet, alphaBullet, romanBullet];
 
-function buildStepLink(xref: Element, entry: Biblio.StepBiblioEntry) {
+function buildStepLink(spec: Spec, xref: Element, entry: Biblio.StepBiblioEntry) {
   if (xref.innerHTML !== '') {
-    utils.logWarning('the contents of emu-xrefs to steps are ignored');
+    spec.warn('the contents of emu-xrefs to steps are ignored');
   }
 
   let stepBullets = entry.stepNumbers.map((s, i) => {
     let applicable = bullets[Math.min(i, 5)];
     if (s > applicable.length) {
-      utils.logWarning(
+      spec.warn(
         `ecmarkup does not know how to deal with step numbers as high as ${s}; if you need this, open an issue on ecmarkup`
       );
       return '?';

--- a/src/args.ts
+++ b/src/args.ts
@@ -32,6 +32,11 @@ export const argParser = nomnom
       help:
         'The linting output formatter. Either the name of a built-in eslint formatter or the package name of an installed eslint compatible formatter.',
     },
+    strict: {
+      flag: true,
+      default: false,
+      help: 'Exit with an error if there are warnings. Cannot be used with --watch.',
+    },
     verbose: { flag: true, default: false, help: 'Display document build progress' },
     version: {
       abbr: 'v',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,8 +19,8 @@ if (args.js) {
   args.jsOut = args.js;
 }
 
-if (args.lintSpec && args.watch) {
-  console.error('Cannot use --lint-spec with --watch');
+if (args.strict && args.watch) {
+  console.error('Cannot use --strict with --watch');
   process.exit(1);
 }
 
@@ -55,7 +55,6 @@ const build = debounce(async function build() {
         ];
 
         console.error(formatter(results));
-        process.exit(1);
       };
     }
     const spec = await ecmarkup.build(args.infile, utils.readFile, opts);
@@ -78,6 +77,13 @@ const build = debounce(async function build() {
     }
 
     await Promise.all(pending);
+
+    if (args.strict && spec.warned) {
+      if (args.verbose) {
+        utils.logVerbose('Exiting with an error due to warnings');
+      }
+      process.exit(1);
+    }
 
     if (args.watch) {
       const toWatch = new Set<string>(spec.imports.map(i => i.importLocation).concat(args.infile));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,10 +52,9 @@ const build = debounce(async function build() {
         let results = [
           {
             filePath: args.infile,
-            // for now, everything is an error (2 in eslint terms)
-            messages: errors.map(e => ({ severity: 2, ...e })),
-            errorCount: errors.length,
-            warningCount: 0,
+            messages: errors.map(e => ({ severity: args.strict ? 2 : 1, ...e })),
+            errorCount: args.strict ? errors.length : 0,
+            warningCount: args.strict ? 0 : errors.length,
             // for now, nothing is fixable
             fixableErrorCount: 0,
             fixableWarningCount: 0,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,15 @@ const watching = new Map<string, fs.FSWatcher>();
 const build = debounce(async function build() {
   try {
     const opts: Options = { ...args };
+    if (args.verbose) {
+      opts.log = utils.logVerbose;
+    }
+    let warned = false;
+    opts.warn = str => {
+      warned = true;
+      utils.logWarning(str);
+    };
+
     if (args.lintSpec) {
       let descriptor = `eslint/lib/cli-engine/formatters/${args.lintFormatter}.js`;
       try {
@@ -54,6 +63,7 @@ const build = debounce(async function build() {
           },
         ];
 
+        warned = true;
         console.error(formatter(results));
       };
     }
@@ -78,7 +88,7 @@ const build = debounce(async function build() {
 
     await Promise.all(pending);
 
-    if (args.strict && spec.warned) {
+    if (args.strict && warned) {
       if (args.verbose) {
         utils.logVerbose('Exiting with an error due to warnings');
       }

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -26,7 +26,6 @@ export interface Options {
   toc?: boolean;
   oldToc?: boolean;
   lintSpec?: boolean;
-  verbose?: boolean;
   cssOut?: string;
   jsOut?: string;
   assets?: 'none' | 'inline' | 'external';
@@ -34,6 +33,8 @@ export interface Options {
   boilerplate?: Boilerplate;
   ecma262Biblio?: boolean;
   reportLintErrors?: Reporter;
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
 }
 
 export async function build(

--- a/test/cli.js
+++ b/test/cli.js
@@ -8,9 +8,19 @@ describe('ecmarkup#cli', () => {
     execSync('./bin/ecmarkup.js test/example.html', { encoding: 'utf8' });
   });
 
+  it('exits cleanly on warning', () => {
+    execSync('./bin/ecmarkup.js test/duplicate-ids.html', { encoding: 'utf8', stdio: 'ignore' });
+  });
+
   it('exits with an error on error', () => {
     assert.throws(() => {
       execSync('./bin/ecmarkup.js test/malformed.bad.html', { encoding: 'utf8', stdio: 'ignore' });
+    });
+  });
+
+  it('exits with an error on warning when using --strict', () => {
+    assert.throws(() => {
+      execSync('./bin/ecmarkup.js --strict test/duplicate-ids.html', { encoding: 'utf8', stdio: 'ignore' });
     });
   });
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -20,7 +20,10 @@ describe('ecmarkup#cli', () => {
 
   it('exits with an error on warning when using --strict', () => {
     assert.throws(() => {
-      execSync('./bin/ecmarkup.js --strict test/duplicate-ids.html', { encoding: 'utf8', stdio: 'ignore' });
+      execSync('./bin/ecmarkup.js --strict test/duplicate-ids.html', {
+        encoding: 'utf8',
+        stdio: 'ignore',
+      });
     });
   });
 });

--- a/test/duplicate-ids.js
+++ b/test/duplicate-ids.js
@@ -9,10 +9,10 @@ const execPath =
     : process.execPath;
 
 describe('detecting duplicate ids', () => {
-  it('reports when --verbose flag is present', done => {
+  it('reports', done => {
     cp.execFile(
       execPath,
-      ['./bin/ecmarkup.js', '--verbose', 'test/duplicate-ids.html'],
+      ['./bin/ecmarkup.js', 'test/duplicate-ids.html'],
       { encoding: 'utf8', shell: true, windowsVerbatimArguments: true },
       (error, result) => {
         if (error) {
@@ -24,24 +24,6 @@ describe('detecting duplicate ids', () => {
         assert.equal(result.match(/<emu-clause> has duplicate id: sec-a/g).length, 3);
         assert.equal(result.includes('<emu-table> has duplicate id: table-of-stuff'), true);
         assert.equal(result.includes('<emu-example> has duplicate id: an-example'), true);
-        done();
-      }
-    );
-  }).timeout(3000);
-  it('does not report when --verbose flag is not present', done => {
-    cp.execFile(
-      execPath,
-      ['./bin/ecmarkup.js', 'test/duplicate-ids.html'],
-      { encoding: 'utf8', shell: true, windowsVerbatimArguments: true },
-      (error, result) => {
-        if (error) {
-          assert.fail(error);
-          done();
-          return;
-        }
-        assert.equal(result.includes('<emu-clause> has duplicate id: sec-a'), false);
-        assert.equal(result.includes('<emu-table> has duplicate id: table-of-stuff'), false);
-        assert.equal(result.includes('<emu-example> has duplicate id: an-example'), false);
         done();
       }
     );

--- a/test/duplicate-ids.js
+++ b/test/duplicate-ids.js
@@ -19,7 +19,7 @@ describe('detecting duplicate ids', () => {
       '<emu-clause> has duplicate id: sec-a',
       '<emu-clause> has duplicate id: sec-a',
       '<emu-table> has duplicate id: table-of-stuff',
-      '<emu-example> has duplicate id: an-example'
+      '<emu-example> has duplicate id: an-example',
     ]);
   });
 });

--- a/test/duplicate-ids.js
+++ b/test/duplicate-ids.js
@@ -1,31 +1,25 @@
-/// <reference types="mocha" />
 'use strict';
-const cp = require('child_process');
 const assert = require('assert');
-
-const execPath =
-  /^win/.test(process.platform) && /\s/.test(process.execPath)
-    ? '"' + process.execPath + '"'
-    : process.execPath;
+const fs = require('fs');
+const emu = require('../lib/ecmarkup');
 
 describe('detecting duplicate ids', () => {
-  it('reports', done => {
-    cp.execFile(
-      execPath,
-      ['./bin/ecmarkup.js', 'test/duplicate-ids.html'],
-      { encoding: 'utf8', shell: true, windowsVerbatimArguments: true },
-      (error, result) => {
-        if (error) {
-          assert.fail(error);
-          done();
-          return;
-        }
-        // "sec-a" appears 4 times in the fixture, so there should be 3 warnings.
-        assert.equal(result.match(/<emu-clause> has duplicate id: sec-a/g).length, 3);
-        assert.equal(result.includes('<emu-table> has duplicate id: table-of-stuff'), true);
-        assert.equal(result.includes('<emu-example> has duplicate id: an-example'), true);
-        done();
-      }
-    );
-  }).timeout(3000);
+  it('warns for duplicate ids', async () => {
+    let input = fs.readFileSync('test/duplicate-ids.html', 'utf8');
+
+    let warnings = [];
+    await emu.build('duplicate-ids.emu', async () => input, {
+      ecma262Biblio: false,
+      copyright: false,
+      warn: str => warnings.push(str),
+    });
+
+    assert.deepStrictEqual(warnings, [
+      '<emu-clause> has duplicate id: sec-a',
+      '<emu-clause> has duplicate id: sec-a',
+      '<emu-clause> has duplicate id: sec-a',
+      '<emu-table> has duplicate id: table-of-stuff',
+      '<emu-example> has duplicate id: an-example'
+    ]);
+  });
 });

--- a/test/lint.js
+++ b/test/lint.js
@@ -170,25 +170,25 @@ describe('linting whole program', function () {
 
     it('legal names', async function () {
       await assertLintFree(`
-          <emu-clause id="foo">
+          <emu-clause id="i1">
             <h1>Example ( )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i2">
             <h1>Runtime Semantics: Example ( )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i3">
             <h1>The * Operator ( \`*\` )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i4">
             <h1>Number::example ( )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i5">
             <h1>[[Example]] ( )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i6">
             <h1>_Example_ ( )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i7">
             <h1>%Foo%.bar [ @@iterator ] ( )</h1>
           </emu-clause>
       `);
@@ -196,25 +196,25 @@ describe('linting whole program', function () {
 
     it('legal argument lists', async function () {
       await assertLintFree(`
-          <emu-clause id="foo">
+          <emu-clause id="i1">
             <h1>Example ( )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i2">
             <h1>Example ( _foo_ )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i3">
             <h1>Example ( [ _foo_ ] )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i4">
             <h1>Date ( _year_, _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i5">
             <h1>Object ( . . . )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i6">
             <h1>String.raw ( _template_, ..._substitutions_ )</h1>
           </emu-clause>
-          <emu-clause id="foo">
+          <emu-clause id="i7">
             <h1>Function ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
           </emu-clause>
       `);


### PR DESCRIPTION
This also makes `--lint-spec` not fail the build when there are linting errors; you have to additionally pass `--strict` to make that happen.

The idea is that you can omit `--strict` if you just want a render you can look at (e.g. in the ecma262 deploy preview), but we will include `--strict` in the ecma262 build job.