### PR TITLE
Wrap ecmarkdown parse failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -734,9 +734,9 @@
       }
     },
     "ecmarkdown": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-5.1.2.tgz",
-      "integrity": "sha512-3mV+/g9p5dw1BTlIRJk5jnQY59CHOsKyhy/RWfcYEB721vcm6A2J9F6YYCbcCG6ZQF+nEUCgszUzMVhcYeP1ig==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-6.0.0.tgz",
+      "integrity": "sha512-zy4Qd/1K7LxCkzarnyGdXrXYH2iUzIysQAs+JLu7PcR2OAFzH2D0dgpRYdGJzJ49oHmxxSjx9NnAgFJINwWLOA==",
       "requires": {
         "escape-html": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	"dependencies": {
 		"bluebird": "^3.7.2",
 		"chalk": "^1.1.3",
-		"ecmarkdown": "^5.1.2",
+		"ecmarkdown": "^6.0.0",
 		"eslint": "^6.8.0",
 		"grammarkdown": "^2.2.0",
 		"highlight.js": "^9.17.1",

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -37,7 +37,7 @@ export default class Algorithm extends Builder {
       }
     }
     if (emdTree == null) {
-      node.innerHTML = `#### ECMARKDOWN PARSE FAILED ###<pre>${innerHTML}</pre>`
+      node.innerHTML = `#### ECMARKDOWN PARSE FAILED ###<pre>${innerHTML}</pre>`;
       return;
     }
 

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -3,7 +3,7 @@ import type { Node as EcmarkdownNode, OrderedListItemNode } from 'ecmarkdown';
 import type { StepBiblioEntry } from './Biblio';
 
 import Builder from './Builder';
-import { warnEmdFailure } from './utils';
+import { warnEmdFailure, wrapEmdFailure } from './utils';
 import * as emd from 'ecmarkdown';
 
 function findLabeledSteps(root: EcmarkdownNode) {
@@ -37,7 +37,7 @@ export default class Algorithm extends Builder {
       }
     }
     if (emdTree == null) {
-      node.innerHTML = `#### ECMARKDOWN PARSE FAILED ###<pre>${innerHTML}</pre>`;
+      node.innerHTML = wrapEmdFailure(innerHTML);
       return;
     }
 

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -29,7 +29,7 @@ export default class Algorithm extends Builder {
     const emdTree =
       'ecmarkdownTree' in node
         ? (node as any).ecmarkdownTree
-        : emd.parseAlgorithm(innerHTML, { trackPositions: true });
+        : emd.parseAlgorithm(innerHTML);
 
     const rawHtml = emd.emit(emdTree);
 
@@ -59,7 +59,7 @@ export default class Algorithm extends Builder {
             'labeling a step in a replacement algorithm which has multiple top-level steps is unsupported because the resulting step number would be ambiguous',
           node,
           nodeRelativeLine: step.location!.start.line,
-          nodeRelativeColumn: step.location!.start.column + 1 + offset, // + 1 because ecmarkdown has 0-based columns; todo remove
+          nodeRelativeColumn: step.location!.start.column + offset,
         });
       }
     }

--- a/src/Eqn.ts
+++ b/src/Eqn.ts
@@ -50,7 +50,7 @@ export default class Eqn extends Builder {
       contents = emd.fragment(node.innerHTML);
     } catch (e) {
       utils.warnEmdFailure(spec.warn, node, e);
-      node.innerHTML = `#### ECMARKDOWN PARSE FAILED ###<pre>${node.innerHTML}</pre>`;
+      node.innerHTML = utils.wrapEmdFailure(node.innerHTML);
       return;
     }
 

--- a/src/Eqn.ts
+++ b/src/Eqn.ts
@@ -45,7 +45,14 @@ export default class Eqn extends Builder {
     // TODO: this value is unused, but apparently it has side effects. Removing this line removes emu-xrefs
     new Eqn(spec, node, id);
 
-    let contents = emd.fragment(node.innerHTML);
+    let contents;
+    try {
+      contents = emd.fragment(node.innerHTML);
+    } catch (e) {
+      utils.warnEmdFailure(spec.warn, node, e);
+      node.innerHTML = `#### ECMARKDOWN PARSE FAILED ###<pre>${node.innerHTML}</pre>`;
+      return;
+    }
 
     if (utils.shouldInline(node)) {
       const classString = node.getAttribute('class');

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -86,7 +86,7 @@ export type Warning =
     }
   | {
       type: 'node';
-      node: Element;
+      node: Text | Element;
       ruleId: string;
       message: string;
     }
@@ -99,7 +99,7 @@ export type Warning =
     }
   | {
       type: 'contents';
-      node: Element;
+      node: Text | Element;
       ruleId: string;
       message: string;
       nodeRelativeLine: number;
@@ -116,46 +116,79 @@ export type Warning =
 function wrapWarn(source: string, dom: any, warn: (err: EcmarkupError) => void) {
   return (e: Warning) => {
     let { message, ruleId } = e;
-    let line: number | undefined, column: number | undefined;
+    let line: number | undefined;
+    let column: number | undefined;
+    let nodeType: string;
     if (e.type === 'global') {
       line = undefined;
       column = undefined;
+      nodeType = 'html';
     } else if (e.type === 'raw') {
       ({ line, column } = e);
+      nodeType = 'html';
     } else {
-      let nodeLoc = utils.getLocation(dom, e.node);
       if (e.type === 'node') {
-        ({ line, col: column } = nodeLoc.startTag);
+        if (e.node.nodeType === 3) {
+          let loc = dom.nodeLocation(e.node);
+          if (loc == null) {
+            throw new Error(
+              'Could not find location for text node. This is a bug in ecmarkdown; please report it.'
+            );
+          }
+          ({ line, col: column } = loc);
+          nodeType = 'text';
+        } else {
+          let nodeLoc = utils.getLocation(dom, e.node as Element);
+          ({ line, col: column } = nodeLoc.startTag);
+          nodeType = (e.node as Element).tagName.toLowerCase();
+        }
       } else if (e.type === 'attr') {
+        let nodeLoc = utils.getLocation(dom, e.node);
         ({ line, column } = utils.attrValueLocation(source, nodeLoc, e.attr));
+        nodeType = e.node.tagName.toLowerCase();
       } else if (e.type === 'contents') {
         let { nodeRelativeLine, nodeRelativeColumn } = e;
 
-        // We have to adjust both for start of tag -> end of tag and end of tag -> passed position
-        // TODO switch to using nodeLoc.startTag.end{Line,Col} once parse5 can be upgraded
-        let tagSrc = source.slice(nodeLoc.startTag.startOffset, nodeLoc.startTag.endOffset);
-        let tagEnd = utils.offsetToLineAndColumn(
-          tagSrc,
-          nodeLoc.startTag.endOffset - nodeLoc.startOffset
-        );
-        line = nodeLoc.startTag.line + tagEnd.line + nodeRelativeLine - 2;
-        if (nodeRelativeLine === 1) {
-          if (tagEnd.line === 1) {
-            column = nodeLoc.startTag.col + tagEnd.column + nodeRelativeColumn - 2;
-          } else {
-            column = tagEnd.column + nodeRelativeColumn - 1;
+        if (e.node.nodeType === 3) {
+          // i.e. a text node, which does not have a tag
+          let loc = dom.nodeLocation(e.node);
+          if (loc == null) {
+            throw new Error(
+              'Could not find location for text node. This is a bug in ecmarkdown; please report it.'
+            );
           }
+          line = loc.line + nodeRelativeLine - 1;
+          column = nodeRelativeLine === 1 ? loc.col + nodeRelativeColumn - 1 : nodeRelativeColumn;
+          nodeType = 'text';
         } else {
-          column = nodeRelativeColumn;
+          let nodeLoc = utils.getLocation(dom, e.node as Element);
+          // We have to adjust both for start of tag -> end of tag and end of tag -> passed position
+          // TODO switch to using nodeLoc.startTag.end{Line,Col} once parse5 can be upgraded
+          let tagSrc = source.slice(nodeLoc.startTag.startOffset, nodeLoc.startTag.endOffset);
+          let tagEnd = utils.offsetToLineAndColumn(
+            tagSrc,
+            nodeLoc.startTag.endOffset - nodeLoc.startOffset
+          );
+          line = nodeLoc.startTag.line + tagEnd.line + nodeRelativeLine - 2;
+          if (nodeRelativeLine === 1) {
+            if (tagEnd.line === 1) {
+              column = nodeLoc.startTag.col + tagEnd.column + nodeRelativeColumn - 2;
+            } else {
+              column = tagEnd.column + nodeRelativeColumn - 1;
+            }
+          } else {
+            column = nodeRelativeColumn;
+          }
+          nodeType = (e.node as Element).tagName.toLowerCase();
         }
       }
     }
 
-    let nodeType = e.type === 'global' || e.type === 'raw' ? 'html' : e.node.tagName.toLowerCase();
     warn({
       message,
       ruleId,
       source: e.type === 'global' ? undefined : source,
+      // @ts-ignore TS can't prove this is initialized, for some reason
       nodeType,
       // @ts-ignore TS can't prove this is initialized, for some reason
       line,
@@ -924,7 +957,7 @@ function walk(walker: TreeWalker, context: Context) {
       }
       // else, inNoEmd will just continue to the end of the file
 
-      utils.emdTextNode(context.spec, context.node);
+      utils.emdTextNode(context.spec, (context.node as unknown) as Text);
     }
 
     if (!context.inNoAutolink) {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -128,7 +128,7 @@ function wrapWarn(source: string, dom: any, warn: (err: EcmarkupError) => void) 
       nodeType = 'html';
     } else {
       if (e.type === 'node') {
-        if (e.node.nodeType === 3) {
+        if (e.node.nodeType === 3 /* Node.TEXT_NODE */) {
           let loc = dom.nodeLocation(e.node);
           if (loc == null) {
             throw new Error(
@@ -149,7 +149,7 @@ function wrapWarn(source: string, dom: any, warn: (err: EcmarkupError) => void) 
       } else if (e.type === 'contents') {
         let { nodeRelativeLine, nodeRelativeColumn } = e;
 
-        if (e.node.nodeType === 3) {
+        if (e.node.nodeType === 3 /* Node.TEXT_NODE */) {
           // i.e. a text node, which does not have a tag
           let loc = dom.nodeLocation(e.node);
           if (loc == null) {

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -59,7 +59,7 @@ export function collectAlgorithmDiagnostics(
         message,
         node: element,
         nodeRelativeLine: line,
-        nodeRelativeColumn: column + 1, // since EMD columns are 1-based
+        nodeRelativeColumn: column,
       });
     };
 
@@ -70,7 +70,7 @@ export function collectAlgorithmDiagnostics(
     let observer = composeObservers(
       ...algorithmRules.map(f => f(reporter, element, algorithmSource))
     );
-    let tree = parseAlgorithm(algorithmSource, { trackPositions: true });
+    let tree = parseAlgorithm(algorithmSource);
     visit(tree, observer);
     algorithm.tree = tree;
   }

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -5,7 +5,7 @@ import type { Warning } from '../Spec';
 
 import { parseAlgorithm, visit } from 'ecmarkdown';
 
-import { getLocation } from '../utils';
+import { getLocation, warnEmdFailure } from '../utils';
 import lintAlgorithmLineEndings from './rules/algorithm-line-endings';
 import lintAlgorithmStepNumbering from './rules/algorithm-step-numbering';
 import lintAlgorithmStepLabels from './rules/algorithm-step-labels';
@@ -70,8 +70,16 @@ export function collectAlgorithmDiagnostics(
     let observer = composeObservers(
       ...algorithmRules.map(f => f(reporter, element, algorithmSource))
     );
-    let tree = parseAlgorithm(algorithmSource);
-    visit(tree, observer);
+    let tree;
+    try {
+      let tree = parseAlgorithm(algorithmSource);
+    } catch (e) {
+      warnEmdFailure(report, element, e);
+    }
+    if (tree != null) {
+      visit(tree, observer);
+    }
+
     algorithm.tree = tree;
   }
 }

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -72,7 +72,7 @@ export function collectAlgorithmDiagnostics(
     );
     let tree;
     try {
-      let tree = parseAlgorithm(algorithmSource);
+      tree = parseAlgorithm(algorithmSource);
     } catch (e) {
       warnEmdFailure(report, element, e);
     }

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -66,10 +66,10 @@ export function lint(
   //     grammarEle.grammarkdownOut = source;
   //   });
   // }
-  for (let { element, tree } of algorithms) {
-    if (tree != null) {
+  for (let pair of algorithms) {
+    if ('tree' in pair) {
       // @ts-ignore we are intentionally adding a property here
-      element.ecmarkdownTree = tree;
+      pair.element.ecmarkdownTree = pair.tree;
     }
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,11 @@ import * as chalk from 'chalk';
 import * as emd from 'ecmarkdown';
 import * as fs from 'fs';
 
-
-export function warnEmdFailure(report: Spec['warn'], node: Element | Text, e: SyntaxError & { line?: number, column?: number }) {
+export function warnEmdFailure(
+  report: Spec['warn'],
+  node: Element | Text,
+  e: SyntaxError & { line?: number; column?: number }
+) {
   if (typeof e.line === 'number' && typeof e.column === 'number') {
     report({
       type: 'contents',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,10 @@ export function warnEmdFailure(
   }
 }
 
+export function wrapEmdFailure(src: string) {
+  return `#### ECMARKDOWN PARSE FAILED ####<pre>${src}</pre>`;
+}
+
 /*@internal*/
 export function emdTextNode(spec: Spec, node: Text) {
   let c = node.textContent!.replace(/</g, '&lt;');
@@ -40,7 +44,7 @@ export function emdTextNode(spec: Spec, node: Text) {
     processed = emd.fragment(c);
   } catch (e) {
     warnEmdFailure(spec.warn, node, e);
-    processed = `#### ECMARKDOWN PARSE FAILED ###<pre>${c}</pre>`;
+    processed = wrapEmdFailure(c);
   }
 
   const template = spec.doc.createElement('template');

--- a/test/errors.js
+++ b/test/errors.js
@@ -326,4 +326,22 @@ ${M}      </pre>
       }
     );
   });
+
+  it('ecmarkdown failed', async () => {
+    await assertError(
+      positioned`
+      <p>
+      text:${M}
+
+
+      more text.
+      </p>
+      `,
+      {
+        ruleId: 'invalid-emd',
+        nodeType: 'text',
+        message: 'ecmarkdown failed to parse: Unexpected token parabreak; expected EOF',
+      }
+    );
+  });
 });

--- a/test/errors.js
+++ b/test/errors.js
@@ -327,7 +327,7 @@ ${M}      </pre>
     );
   });
 
-  it('ecmarkdown failed', async () => {
+  it('ecmarkdown failed: fragment', async () => {
     await assertError(
       positioned`
       <p>
@@ -344,4 +344,32 @@ ${M}      </pre>
       }
     );
   });
+
+  it('ecmarkdown failed: algorithm', async () => {
+    await assertError(
+      positioned`
+      <emu-alg>${M}This is not an algrithm</emu-alg>
+      `,
+      {
+        ruleId: 'invalid-emd',
+        nodeType: 'emu-alg',
+        message: 'ecmarkdown failed to parse: Unexpected token text; expected ol',
+      }
+    );
+  });
+
+  it('ecmarkdown failed: algorithm with linting enabled', async () => {
+    await assertError(
+      positioned`
+      <emu-alg>${M}This is not an algrithm</emu-alg>
+      `,
+      {
+        ruleId: 'invalid-emd',
+        nodeType: 'emu-alg',
+        message: 'ecmarkdown failed to parse: Unexpected token text; expected ol',
+      },
+      { lintSpec: true }
+    );
+  });
+
 });

--- a/test/errors.js
+++ b/test/errors.js
@@ -333,13 +333,27 @@ ${M}      </pre>
       <p>
       text:${M}
 
-
       more text.
       </p>
       `,
       {
         ruleId: 'invalid-emd',
         nodeType: 'text',
+        message: 'ecmarkdown failed to parse: Unexpected token parabreak; expected EOF',
+      }
+    );
+  });
+
+  it('ecmarkdown failed: equation', async () => {
+    await assertError(
+      positioned`
+      <emu-eqn>text:${M}
+
+      more text.</emu-eqn>
+      `,
+      {
+        ruleId: 'invalid-emd',
+        nodeType: 'emu-eqn',
         message: 'ecmarkdown failed to parse: Unexpected token parabreak; expected EOF',
       }
     );

--- a/test/errors.js
+++ b/test/errors.js
@@ -385,5 +385,4 @@ ${M}      </pre>
       { lintSpec: true }
     );
   });
-
 });


### PR DESCRIPTION
This wraps ecmarkdown parse failures with the same error-reporting mechanism used elsewhere (see https://github.com/tc39/ecmarkup/pull/229).

Previously when a node failed to parse with Ecmarkdown, Ecmarkup threw an exception. Now it emits a warning, and puts the raw source for that node (wrapped in `#### ECMARKDOWN PARSE FAILED ###<pre>` ) in the output.

This means that a.) you get useful location information (including a little snippet of context if you pass `--verbose`) instead of just being told something somewhere broke and b.) you still get a build artifact you can review (except for the broken part), unless you pass `--strict`.

Fixes https://github.com/tc39/ecmarkup/issues/226.