### PR TITLE
Track location information for emu-import'd nodes

### DIFF
--- a/src/Import.ts
+++ b/src/Import.ts
@@ -8,11 +8,19 @@ import * as path from 'path';
 export default class Import extends Builder {
   public importLocation: string;
   public relativeRoot: string;
+  public source: string;
 
-  constructor(spec: Spec, node: HTMLElement, importLocation: string, relativeRoot: string) {
+  constructor(
+    spec: Spec,
+    node: HTMLElement,
+    importLocation: string,
+    relativeRoot: string,
+    source: string
+  ) {
     super(spec, node);
     this.importLocation = importLocation;
     this.relativeRoot = relativeRoot;
+    this.source = source;
   }
 
   static async build(spec: Spec, node: HTMLElement, root: string) {
@@ -20,18 +28,27 @@ export default class Import extends Builder {
     if (!href) throw new Error('Import missing href attribute.');
     const importPath = path.join(root, href);
     const relativeRoot = path.dirname(importPath);
-    const imp = new Import(spec, node, importPath, relativeRoot);
-    spec.imports.push(imp);
 
     const html = await spec.fetch(importPath);
-    const importDoc = await utils.htmlToDom(html).window.document;
+
+    const imp = new Import(spec, node, importPath, relativeRoot, html);
+    spec.imports.push(imp);
+
+    const importDom = utils.htmlToDom(html);
+    // @ts-ignore intentionally adding a property
+    node.dom = importDom;
+    // @ts-ignore intentionally adding a property
+    node.source = html;
+    // @ts-ignore intentionally adding a property
+    node.importPath = importPath;
+    const importDoc = importDom.window.document;
 
     const nodes = importDoc.body.childNodes;
     const frag = spec.doc.createDocumentFragment();
 
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
-      const importedNode = spec.doc.importNode(node, true);
+      const importedNode = spec.doc.adoptNode(node);
       frag.appendChild(importedNode);
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ const build = debounce(async function build() {
     let warnings: EcmarkupError[] = [];
     opts.warn = err => {
       warned = true;
-      let file = normalizePath(args.infile, err.file);
+      let file = normalizePath(err.file ?? args.infile);
       // prettier-ignore
       let message = `${args.strict ? 'Error' : 'Warning'}: ${file}:${err.line == null ? '' : `${err.line}:${err.column}:`} ${err.message}`;
       utils.logWarning(message);
@@ -66,8 +66,8 @@ const build = debounce(async function build() {
 
     if (args.verbose && warned) {
       warnings.sort((a, b) => {
-        let aPath = normalizePath(args.infile, a.file);
-        let bPath = normalizePath(args.infile, b.file);
+        let aPath = normalizePath(a.file ?? args.infile);
+        let bPath = normalizePath(a.file ?? args.infile);
         if (aPath !== bPath) {
           return aPath.localeCompare(bPath);
         }
@@ -92,7 +92,7 @@ const build = debounce(async function build() {
         return a.line - b.line;
       });
       let results = warnings.map(err => ({
-        filePath: normalizePath(args.infile, err.file),
+        filePath: normalizePath(err.file ?? args.infile),
         messages: [{ severity: args.strict ? 2 : 1, ...err }],
         errorCount: args.strict ? 1 : 0,
         warningCount: args.strict ? 0 : 1,
@@ -160,6 +160,6 @@ build().catch(e => {
   process.exit(1);
 });
 
-function normalizePath(root: string, relative: string | undefined) {
-  return path.relative(process.cwd(), relative ?? root);
+function normalizePath(absolute: string) {
+  return path.relative(process.cwd(), absolute);
 }

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -15,6 +15,7 @@ export class Boilerplate {
 export type EcmarkupError = {
   ruleId: string;
   message: string;
+  file?: string;
   source?: string;
   line?: number;
   column?: number;

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -34,12 +34,12 @@ function composeObservers(...observers: Observer[]): Observer {
 export function collectAlgorithmDiagnostics(
   report: (e: Warning) => void,
   spec: Spec,
-  sourceText: string,
+  mainSource: string,
   algorithms: { element: Element; tree?: EcmarkdownNode }[]
 ) {
   for (let algorithm of algorithms) {
     let element = algorithm.element;
-    let { source, ...location } = spec.locate(element);
+    let { source: importSource, ...location } = spec.locate(element);
 
     if (location.endTag == null) {
       report({
@@ -63,7 +63,7 @@ export function collectAlgorithmDiagnostics(
       });
     };
 
-    let algorithmSource = (source ?? sourceText).slice(
+    let algorithmSource = (importSource ?? mainSource).slice(
       location.startTag.endOffset,
       location.endTag.startOffset
     );

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -1,11 +1,11 @@
 import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
 
 import type { LintingError } from './algorithm-error-reporter-type';
-import type { Warning } from '../Spec';
+import type { default as Spec, Warning } from '../Spec';
 
 import { parseAlgorithm, visit } from 'ecmarkdown';
 
-import { getLocation, warnEmdFailure } from '../utils';
+import { warnEmdFailure } from '../utils';
 import lintAlgorithmLineEndings from './rules/algorithm-line-endings';
 import lintAlgorithmStepNumbering from './rules/algorithm-step-numbering';
 import lintAlgorithmStepLabels from './rules/algorithm-step-labels';
@@ -33,13 +33,13 @@ function composeObservers(...observers: Observer[]): Observer {
 
 export function collectAlgorithmDiagnostics(
   report: (e: Warning) => void,
-  dom: any,
+  spec: Spec,
   sourceText: string,
   algorithms: { element: Element; tree?: EcmarkdownNode }[]
 ) {
   for (let algorithm of algorithms) {
     let element = algorithm.element;
-    let location = getLocation(dom, element);
+    let { source, ...location } = spec.locate(element);
 
     if (location.endTag == null) {
       report({
@@ -63,7 +63,7 @@ export function collectAlgorithmDiagnostics(
       });
     };
 
-    let algorithmSource = sourceText.slice(
+    let algorithmSource = (source ?? sourceText).slice(
       location.startTag.endOffset,
       location.endTag.startOffset
     );

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -1,4 +1,4 @@
-import type { Warning } from '../Spec';
+import type { default as Spec, Warning } from '../Spec';
 
 import {
   Grammar as GrammarFile,
@@ -14,11 +14,10 @@ import {
 } from 'grammarkdown';
 
 import { getProductions, rhsMatches } from './utils';
-import { getLocation } from '../utils';
 
 export function collectGrammarDiagnostics(
   report: (e: Warning) => void,
-  dom: any,
+  spec: Spec,
   sourceText: string,
   mainGrammar: { element: Element; source: string }[],
   sdos: { grammar: Element; alg: Element }[],
@@ -101,7 +100,7 @@ export function collectGrammarDiagnostics(
     ...earlyErrors.map(e => ({ grammar: e.grammar, rules: e.lists, type: 'early error' })),
   ];
   for (let { grammar: grammarEle, rules: rulesEles, type } of grammarsAndRules) {
-    let grammarLoc = getLocation(dom, grammarEle);
+    let { source, ...grammarLoc } = spec.locate(grammarEle);
 
     if (grammarLoc.endTag == null) {
       report({
@@ -114,7 +113,7 @@ export function collectGrammarDiagnostics(
     }
 
     let grammarHost = SyncHost.forFile(
-      sourceText.slice(grammarLoc.startTag.endOffset, grammarLoc.endTag.startOffset)
+      (source ?? sourceText).slice(grammarLoc.startTag.endOffset, grammarLoc.endTag.startOffset)
     );
     let grammar = new GrammarFile([grammarHost.file], {}, grammarHost);
     grammar.parseSync();

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -18,7 +18,7 @@ import { getProductions, rhsMatches } from './utils';
 export function collectGrammarDiagnostics(
   report: (e: Warning) => void,
   spec: Spec,
-  sourceText: string,
+  mainSource: string,
   mainGrammar: { element: Element; source: string }[],
   sdos: { grammar: Element; alg: Element }[],
   earlyErrors: { grammar: Element; lists: HTMLUListElement[] }[]
@@ -100,7 +100,7 @@ export function collectGrammarDiagnostics(
     ...earlyErrors.map(e => ({ grammar: e.grammar, rules: e.lists, type: 'early error' })),
   ];
   for (let { grammar: grammarEle, rules: rulesEles, type } of grammarsAndRules) {
-    let { source, ...grammarLoc } = spec.locate(grammarEle);
+    let { source: importSource, ...grammarLoc } = spec.locate(grammarEle);
 
     if (grammarLoc.endTag == null) {
       report({
@@ -113,7 +113,7 @@ export function collectGrammarDiagnostics(
     }
 
     let grammarHost = SyncHost.forFile(
-      (source ?? sourceText).slice(grammarLoc.startTag.endOffset, grammarLoc.endTag.startOffset)
+      (importSource ?? mainSource).slice(grammarLoc.startTag.endOffset, grammarLoc.endTag.startOffset)
     );
     let grammar = new GrammarFile([grammarHost.file], {}, grammarHost);
     grammar.parseSync();

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -113,7 +113,10 @@ export function collectGrammarDiagnostics(
     }
 
     let grammarHost = SyncHost.forFile(
-      (importSource ?? mainSource).slice(grammarLoc.startTag.endOffset, grammarLoc.endTag.startOffset)
+      (importSource ?? mainSource).slice(
+        grammarLoc.startTag.endOffset,
+        grammarLoc.endTag.startOffset
+      )
     );
     let grammar = new GrammarFile([grammarHost.file], {}, grammarHost);
     grammar.parseSync();

--- a/src/lint/collect-header-diagnostics.ts
+++ b/src/lint/collect-header-diagnostics.ts
@@ -6,7 +6,6 @@ const ruleId = 'header-format';
 
 export function collectHeaderDiagnostics(
   report: (e: Warning) => void,
-  dom: any,
   headers: { element: Element; contents: string }[]
 ) {
   for (let { element, contents } of headers) {

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -1,8 +1,6 @@
-import type { Warning } from '../Spec';
+import type { default as Spec, Warning } from '../Spec';
 
 import type { Node as EcmarkdownNode } from 'ecmarkdown';
-
-import { getLocation } from '../utils';
 
 type CollectNodesReturnType =
   | {
@@ -20,7 +18,7 @@ type CollectNodesReturnType =
 export function collectNodes(
   report: (e: Warning) => void,
   sourceText: string,
-  dom: any,
+  spec: Spec,
   document: Document
 ): CollectNodesReturnType {
   let headers: { element: Element; contents: string }[] = [];
@@ -89,7 +87,7 @@ export function collectNodes(
       } else if (node.nodeName === 'EMU-GRAMMAR') {
         // Look for grammar definitions and SDOs
         if (node.getAttribute('type') === 'definition') {
-          let loc = getLocation(dom, node);
+          let { source, ...loc } = spec.locate(node);
           if (loc.endTag == null) {
             failed = true;
             report({
@@ -101,7 +99,7 @@ export function collectNodes(
           } else {
             let start = loc.startTag.endOffset;
             let end = loc.endTag.startOffset;
-            let realSource = sourceText.slice(start, end);
+            let realSource = (source ?? sourceText).slice(start, end);
             mainGrammar.push({ element: node as Element, source: realSource });
           }
         } else if (node.getAttribute('type') !== 'example') {

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -17,7 +17,7 @@ type CollectNodesReturnType =
 
 export function collectNodes(
   report: (e: Warning) => void,
-  sourceText: string,
+  mainSource: string,
   spec: Spec,
   document: Document
 ): CollectNodesReturnType {
@@ -87,7 +87,7 @@ export function collectNodes(
       } else if (node.nodeName === 'EMU-GRAMMAR') {
         // Look for grammar definitions and SDOs
         if (node.getAttribute('type') === 'definition') {
-          let { source, ...loc } = spec.locate(node);
+          let { source: importSource, ...loc } = spec.locate(node);
           if (loc.endTag == null) {
             failed = true;
             report({
@@ -99,7 +99,7 @@ export function collectNodes(
           } else {
             let start = loc.startTag.endOffset;
             let end = loc.endTag.startOffset;
-            let realSource = (source ?? sourceText).slice(start, end);
+            let realSource = (importSource ?? mainSource).slice(start, end);
             mainGrammar.push({ element: node as Element, source: realSource });
           }
         } else if (node.getAttribute('type') !== 'example') {

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -1,4 +1,5 @@
 import type { Warning } from '../Spec';
+import type { default as Import } from '../Import';
 
 import { offsetToLineAndColumn } from '../utils';
 
@@ -57,32 +58,43 @@ let matchers = [
   },
 ];
 
-export function collectSpellingDiagnostics(report: (e: Warning) => void, sourceText: string) {
+export function collectSpellingDiagnostics(
+  report: (e: Warning) => void,
+  sourceText: string,
+  imports: Import[]
+) {
   let composed = new RegExp(matchers.map(m => `(?:${m.pattern.source})`).join('|'), 'u');
 
-  // The usual case will be to have no errors, so we have a fast path for that case.
-  // We only fall back to slower individual tests if there is at least one error.
-  if (composed.test(sourceText)) {
-    let reported = false;
-    for (let { pattern, message } of matchers) {
-      let match = pattern.exec(sourceText);
-      while (match !== null) {
-        reported = true;
-        let { line, column } = offsetToLineAndColumn(sourceText, match.index);
-        report({
-          type: 'raw',
-          ruleId,
-          line,
-          column,
-          message,
-        });
-        match = pattern.exec(sourceText);
+  let toTest: { source: string; importLocation?: string }[] = [{ source: sourceText }].concat(
+    imports
+  );
+  for (let { source, importLocation } of toTest) {
+    // The usual case will be to have no errors, so we have a fast path for that case.
+    // We only fall back to slower individual tests if there is at least one error.
+    if (composed.test(source)) {
+      let reported = false;
+      for (let { pattern, message } of matchers) {
+        let match = pattern.exec(source);
+        while (match !== null) {
+          reported = true;
+          let { line, column } = offsetToLineAndColumn(source, match.index);
+          report({
+            type: 'raw',
+            ruleId,
+            line,
+            column,
+            message,
+            source,
+            file: importLocation,
+          });
+          match = pattern.exec(source);
+        }
       }
-    }
-    if (!reported) {
-      throw new Error(
-        'Ecmarkup has a bug: the spell checker reported an error, but could not find one. Please report this at https://github.com/tc39/ecmarkup/issues/new.'
-      );
+      if (!reported) {
+        throw new Error(
+          'Ecmarkup has a bug: the spell checker reported an error, but could not find one. Please report this at https://github.com/tc39/ecmarkup/issues/new.'
+        );
+      }
     }
   }
 }

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -60,12 +60,12 @@ let matchers = [
 
 export function collectSpellingDiagnostics(
   report: (e: Warning) => void,
-  sourceText: string,
+  mainSource: string,
   imports: Import[]
 ) {
   let composed = new RegExp(matchers.map(m => `(?:${m.pattern.source})`).join('|'), 'u');
 
-  let toTest: { source: string; importLocation?: string }[] = [{ source: sourceText }].concat(
+  let toTest: { source: string; importLocation?: string }[] = [{ source: mainSource }].concat(
     imports
   );
   for (let { source, importLocation } of toTest) {

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -1,4 +1,4 @@
-import type { Warning } from '../Spec';
+import type { default as Spec, Warning } from '../Spec';
 
 import { collectNodes } from './collect-nodes';
 import { collectGrammarDiagnostics } from './collect-grammar-diagnostics';
@@ -21,10 +21,10 @@ https://github.com/tc39/ecmarkup/issues/173
 export function lint(
   report: (err: Warning) => void,
   sourceText: string,
-  dom: any,
+  spec: Spec,
   document: Document
 ) {
-  let collection = collectNodes(report, sourceText, dom, document);
+  let collection = collectNodes(report, sourceText, spec, document);
   if (!collection.success) {
     return;
   }
@@ -32,18 +32,18 @@ export function lint(
 
   let { grammar } = collectGrammarDiagnostics(
     report,
-    dom,
+    spec,
     sourceText,
     mainGrammar,
     sdos,
     earlyErrors
   );
 
-  collectAlgorithmDiagnostics(report, dom, sourceText, algorithms);
+  collectAlgorithmDiagnostics(report, spec, sourceText, algorithms);
 
-  collectHeaderDiagnostics(report, dom, headers);
+  collectHeaderDiagnostics(report, headers);
 
-  collectSpellingDiagnostics(report, sourceText);
+  collectSpellingDiagnostics(report, sourceText, spec.imports);
 
   // Stash intermediate results for later use
   // This isn't actually necessary for linting, but we might as well avoid redoing work later when we can.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,6 +155,9 @@ export function offsetToLineAndColumn(string: string, offset: number) {
   let line = 0;
   let seen = 0;
   while (true) {
+    if (line >= lines.length) {
+      throw new Error(`offset ${offset} exceeded string ${JSON.stringify(string)}`);
+    }
     if (seen + lines[line].length >= offset) {
       break;
     }
@@ -163,14 +166,6 @@ export function offsetToLineAndColumn(string: string, offset: number) {
   }
   let column = offset - seen;
   return { line: line + 1, column: column + 1 };
-}
-
-export function getLocation(dom: any, node: Element): MarkupData.ElementLocation {
-  let loc = dom.nodeLocation(node);
-  if (!loc || !loc.startTag) {
-    throw new Error('could not find location: this is a bug in ecmarkdown; please report it');
-  }
-  return loc;
 }
 
 export function attrValueLocation(

--- a/test/baselines/reference/imports.html
+++ b/test/baselines/reference/imports.html
@@ -8,14 +8,11 @@
   <emu-import href="sub/import3.html"><emu-clause id="import3">
   <h1><span class="secnum">1.1</span> Import 3</h1>
   wtf??
-</emu-clause>
-</emu-import>
-</emu-clause>
-</emu-import>
+</emu-clause></emu-import>
+</emu-clause></emu-import>
 <emu-import href="imports/import2.html"><emu-clause id="import2">
   <h1><span class="secnum">2</span> Import 2</h1>
-</emu-clause>
-</emu-import>
+</emu-clause></emu-import>
 
 <emu-alg><ol><li>Ensure we can auto-link to imported aoids: <emu-xref aoid="Baz" id="_ref_0"><a href="#Baz">Baz</a></emu-xref>()</li></ol></emu-alg>
 </div></body>

--- a/test/baselines/reference/test.html
+++ b/test/baselines/reference/test.html
@@ -31,10 +31,8 @@
   <emu-import href="sub/import3.html"><emu-clause id="import3">
   <h1><span class="secnum">1.3.1</span> Import 3</h1>
   wtf??
-</emu-clause>
-</emu-import>
-</emu-clause>
-</emu-import>
+</emu-clause></emu-import>
+</emu-clause></emu-import>
 
   <emu-alg><ol><li>Call <emu-xref aoid="Foo" id="_ref_3"><a href="#Foo">Foo</a></emu-xref>(<var>a</var>).</li><li>Call <emu-xref aoid="Bar" id="_ref_4"><a href="#Bar">Bar</a></emu-xref>(<code>toString</code>).</li><li>Call <emu-xref aoid="Baz" id="_ref_5"><a href="#Baz">Baz</a></emu-xref>(<emu-val>true</emu-val>).<ol><li>Do something else.</li><li>And again.</li></ol></li></ol></emu-alg>
 


### PR DESCRIPTION
Fixes https://github.com/tc39/ecmarkup/issues/213.

`emu-import` works by parsing the referenced file and sticking its contents in the DOM. Errors in the resulting nodes need to be mapped back to the correct location in the imported file; they can't just be looked up in the origin jsdom object.

Rather than adding a bunch of new tests I just modified the existing test helper to also test the given error in an `emu-import`.

One oddity is that I modified `Import.ts` to insert nodes in the original DOM using `adoptNode` rather than `cloneNode` (so that identity is preserved for jsdom's location-querying method) and this change for some reason results in there not being a trailing linebreak before the closing `</emu-import>` when rendering the HTML. No idea what's up with that, but it shouldn't cause any issues. That's why the baselines changed.