### PR TITLE
Add multipage support to the menu

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -307,7 +307,7 @@ Menu.prototype.revealInToc = function (path) {
   while (index < path.length) {
     var children = current.children;
     for (var i = 0; i < children.length; i++) {
-      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+      if (path[index].id === children[i].children[1].getAttribute('href').split('#')[1]) {
         children[i].classList.add('revealed');
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');


### PR DESCRIPTION
Multipage builds link to a page and a fragment, instead of just a fragment. This transparently continues to work on single page builds because `'#xyz'.split('#')` is `['', 'xyz']`. Without this change, the script goes into an infinite loop and causes the page to become unresponsive.