### PR TITLE
Linting: misc improvements

### DIFF
--- a/src/lint/collect-header-diagnostics.ts
+++ b/src/lint/collect-header-diagnostics.ts
@@ -46,7 +46,8 @@ export function collectHeaderDiagnostics(
       // Object.fromEntries
       // ForIn/OfHeadEvaluation
       // Array.prototype [ @@iterator ]
-      /^[A-Za-z][A-Za-z0-9/]*(\.[A-Za-z][A-Za-z0-9/]*)*( \[ @@[a-z][a-zA-Z]+ \])?\s*$/,
+      // Object.prototype.__defineGetter__
+      /^[A-Za-z][A-Za-z0-9/]*(\.[A-Za-z][A-Za-z0-9]*)*(\.__[a-z][A-Za-z0-9]*__| \[ @@[a-z][a-zA-Z]+ \])?\s*$/,
 
       // %ForInIteratorPrototype%.next
       // %TypedArray%.prototype [ @@iterator ]

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -65,6 +65,14 @@ let matchers = [
     pattern: /(?<=\S)  +(?! |<\/(td|th|dd|dt)>)/gu,
     message: 'multiple consecutive spaces are not allowed',
   },
+  {
+    pattern: /(?<=<[a-z]+( [a-z]+(="[^"\n]+")?)*>)(?<!(td|th|dd|dt)>) /gu,
+    message: 'tags should not contain leading whitespace',
+  },
+  {
+    pattern: /(?<=[^ \n]) +<\/(?!td|th|dd|dt)/gu,
+    message: 'tags should not contain trailing whitespace',
+  },
 ];
 
 export function collectSpellingDiagnostics(

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -56,6 +56,11 @@ let matchers = [
     pattern: /(?<=\b[Ss]teps? )\d/gu,
     message: 'prefer using labeled steps and <emu-xref> tags over hardcoding step numbers',
   },
+  {
+    pattern: /(?<=\b[Cc]lauses? )\d/gu,
+    message:
+      'clauses should be referenced using <emu-xref> tags rather than hardcoding clause numbers',
+  },
 ];
 
 export function collectSpellingDiagnostics(

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -61,6 +61,10 @@ let matchers = [
     message:
       'clauses should be referenced using <emu-xref> tags rather than hardcoding clause numbers',
   },
+  {
+    pattern: /(?<=\S)  +(?! |<\/(td|th|dd|dt)>)/gu,
+    message: 'multiple consecutive spaces are not allowed',
+  },
 ];
 
 export function collectSpellingDiagnostics(

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -9,19 +9,19 @@ let ruleId = 'spelling';
 let matchers = [
   {
     pattern: /\*this\* object/giu,
-    message: 'Prefer "*this* value"',
+    message: 'prefer "*this* value"',
   },
   {
     pattern: /1's complement/giu,
-    message: 'Prefer "one\'s complement"',
+    message: 'prefer "one\'s complement"',
   },
   {
     pattern: /2's complement/giu,
-    message: 'Prefer "two\'s complement"',
+    message: 'prefer "two\'s complement"',
   },
   {
     pattern: /\*0\*(?!<sub>ℤ<\/sub>)/gu,
-    message: 'The Number value 0 should be written "*+0*", to unambiguously exclude "*-0*"',
+    message: 'the Number value 0 should be written "*+0*", to unambiguously exclude "*-0*"',
   },
   {
     pattern: /behavior/giu,
@@ -29,32 +29,32 @@ let matchers = [
   },
   {
     pattern: /[Tt]he empty string/gu,
-    message: 'Prefer "the empty String"',
+    message: 'prefer "the empty String"',
   },
   {
     pattern: /[ \t]+\n/gu,
-    message: 'Trailing spaces are not allowed',
+    message: 'trailing spaces are not allowed',
   },
   {
     pattern: /(?<=(^|[^\n])\n\n)\n+/gu,
-    message: 'No more than one blank line is allowed',
+    message: 'no more than one blank line is allowed',
   },
   {
     pattern: /(?<=<emu-clause.*>\n)\n\s*<h1>/giu,
-    message: "There should not be a blank line between a clause's opening tag and its header",
+    message: "there should not be a blank line between a clause's opening tag and its header",
   },
   {
     pattern: /(?<=(^|[^\n])\n)\n+[ \t]*<\/emu-clause>/giu,
     message:
-      'There should not be a blank line between the last line of a clause and its closing tag',
+      'there should not be a blank line between the last line of a clause and its closing tag',
   },
   {
     pattern: /\r/gu,
-    message: 'Only Unix-style (LF) linebreaks are allowed',
+    message: 'only Unix-style (LF) linebreaks are allowed',
   },
   {
     pattern: /(?<=\b[Ss]teps? )\d/gu,
-    message: 'Prefer using labeled steps and <emu-xref> tags over hardcoding step numbers',
+    message: 'prefer using labeled steps and <emu-xref> tags over hardcoding step numbers',
   },
 ];
 

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -84,7 +84,7 @@ describe('spelling', function () {
   it('trailing whitespace', async function () {
     await assertLint(
       positioned`
-        <p>something</p>${M}  
+        <p>something</p>${M} 
       `,
       {
         ruleId: 'spelling',
@@ -198,6 +198,19 @@ windows:${M}\r
     );
   });
 
+  it('multiple internal spaces', async function () {
+    await assertLint(
+      positioned`
+        I am writing on a typewriter.${M}  In the 21st century, for some reason.
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'multiple consecutive spaces are not allowed',
+      }
+    );
+  });
+
   it('negative', async function () {
     await assertLintFree(`
       <p>
@@ -222,6 +235,11 @@ windows:${M}\r
       </emu-alg>
       <p>Something about step <emu-xref href="#step-label"></emu-xref>.</p>
       <p>See clause <emu-xref href="#example"></emu-xref>.</p>
+
+      <table><tr><td>Spaces for aligning table cells are acceptable.</td>
+      <td> For example, it is nice for these to line up.            </td>
+      <td> Also to pad them a bit, in some cases.                   </td>
+      </tr></table>
 
     `);
   });

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -11,7 +11,7 @@ describe('spelling', function () {
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'Prefer "*this* value"',
+        message: 'prefer "*this* value"',
       }
     );
   });
@@ -24,7 +24,7 @@ describe('spelling', function () {
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'Prefer "one\'s complement"',
+        message: 'prefer "one\'s complement"',
       }
     );
   });
@@ -37,7 +37,7 @@ describe('spelling', function () {
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'Prefer "two\'s complement"',
+        message: 'prefer "two\'s complement"',
       }
     );
   });
@@ -50,7 +50,7 @@ describe('spelling', function () {
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'The Number value 0 should be written "*+0*", to unambiguously exclude "*-0*"',
+        message: 'the Number value 0 should be written "*+0*", to unambiguously exclude "*-0*"',
       }
     );
   });
@@ -76,7 +76,7 @@ describe('spelling', function () {
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'Prefer "the empty String"',
+        message: 'prefer "the empty String"',
       }
     );
   });
@@ -89,7 +89,7 @@ describe('spelling', function () {
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'Trailing spaces are not allowed',
+        message: 'trailing spaces are not allowed',
       }
     );
   });
@@ -105,7 +105,7 @@ ${M}
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'No more than one blank line is allowed',
+        message: 'no more than one blank line is allowed',
       }
     );
 
@@ -120,7 +120,7 @@ ${M}
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'No more than one blank line is allowed',
+        message: 'no more than one blank line is allowed',
       }
     );
   });
@@ -136,7 +136,7 @@ ${M}
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: "There should not be a blank line between a clause's opening tag and its header",
+        message: "there should not be a blank line between a clause's opening tag and its header",
       }
     );
   });
@@ -153,7 +153,7 @@ ${M}
         ruleId: 'spelling',
         nodeType: 'html',
         message:
-          'There should not be a blank line between the last line of a clause and its closing tag',
+          'there should not be a blank line between the last line of a clause and its closing tag',
       }
     );
   });
@@ -166,7 +166,7 @@ windows:${M}\r
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'Only Unix-style (LF) linebreaks are allowed',
+        message: 'only Unix-style (LF) linebreaks are allowed',
       }
     );
   });
@@ -179,7 +179,7 @@ windows:${M}\r
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'Prefer using labeled steps and <emu-xref> tags over hardcoding step numbers',
+        message: 'prefer using labeled steps and <emu-xref> tags over hardcoding step numbers',
       }
     );
   });

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -211,6 +211,32 @@ windows:${M}\r
     );
   });
 
+  it('leading whitespace within tags', async function () {
+    await assertLint(
+      positioned`
+        <p>${M} This is an example.</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'tags should not contain leading whitespace',
+      }
+    );
+  });
+
+  it('trailing whitespace within tags', async function () {
+    await assertLint(
+      positioned`
+        <p>This is an example:${M} </p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'tags should not contain trailing whitespace',
+      }
+    );
+  });
+
   it('negative', async function () {
     await assertLintFree(`
       <p>
@@ -241,6 +267,9 @@ windows:${M}\r
       <td> Also to pad them a bit, in some cases.                   </td>
       </tr></table>
 
+      <p>
+        Paragraphs with the open/close tags on their own line are OK.
+      </p>
     `);
   });
 });

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -184,6 +184,20 @@ windows:${M}\r
     );
   });
 
+  it('clause numbers', async function () {
+    await assertLint(
+      positioned`
+        See clause ${M}1.
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message:
+          'clauses should be referenced using <emu-xref> tags rather than hardcoding clause numbers',
+      }
+    );
+  });
+
   it('negative', async function () {
     await assertLintFree(`
       <p>
@@ -206,7 +220,9 @@ windows:${M}\r
       <emu-alg>
         1. [id="step-label"] Foo.
       </emu-alg>
-      Something about step <emu-xref href="#step-label"></emu-xref>.
+      <p>Something about step <emu-xref href="#step-label"></emu-xref>.</p>
+      <p>See clause <emu-xref href="#example"></emu-xref>.</p>
+
     `);
   });
 });

--- a/test/lint.js
+++ b/test/lint.js
@@ -58,7 +58,7 @@ describe('linting whole program', function () {
     it('error in inline grammar', async function () {
       await assertLint(
         positioned`
-          <emu-grammar type="definition"> Statement[${M}a]: \`;\` </emu-grammar>
+          <emu-grammar type="definition">Statement[${M}a]: \`;\`</emu-grammar>
         `,
         {
           ruleId: 'grammarkdown:2008',
@@ -91,7 +91,7 @@ describe('linting whole program', function () {
     it('error in inline grammar', async function () {
       await assertLint(
         positioned`
-          <emu-grammar> ${M}Statement: EmptyStatement </emu-grammar>
+          <emu-grammar>${M}Statement: EmptyStatement</emu-grammar>
           <emu-alg>
             1. Return Foo.
           </emu-alg>

--- a/test/lint.js
+++ b/test/lint.js
@@ -211,6 +211,9 @@ describe('linting whole program', function () {
           <emu-clause id="i8">
             <h1>ForIn/OfHeadEvaluation ( )</h1>
           </emu-clause>
+          <emu-clause id="i9">
+            <h1>Object.prototype.__defineGetter__ ( )</h1>
+          </emu-clause>
       `);
     });
 

--- a/test/lint.js
+++ b/test/lint.js
@@ -156,18 +156,6 @@ describe('linting whole program', function () {
           message: 'expected header to have a single space before the argument list',
         }
       );
-
-      await assertLint(
-        positioned`
-          <emu-clause id="foo">
-            <h1>Example ${M} ( )</h1>
-        `,
-        {
-          ruleId: 'header-format',
-          nodeType: 'h1',
-          message: 'expected header to have a single space before the argument list',
-        }
-      );
     });
 
     it('arg format', async function () {


### PR DESCRIPTION
Three new lint rules and a couple of tweaks to existing ones.

d746f13 pertains to https://github.com/tc39/ecma262/pull/2133. 814c4c9 pertains to https://github.com/tc39/ecma262/pull/2125.

It's probably easiest to review the commits individually, and I would rebase rather than squash this PR.