### PR TITLE
Version 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkup",
-  "version": "3.25.3",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "3.25.3",
+	"version": "4.0.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",


### PR DESCRIPTION
Marked as major because https://github.com/tc39/ecmarkup/pull/228 changed the semantics of `--lint-spec`, but if someone wants to argue for minor I'm fine with that too.