### PR TITLE
meta: add a couple eslint rules for arrows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,6 +40,7 @@
   "rules": {
     "prettier/prettier": "error",
     "arrow-body-style": "error",
+    "prefer-arrow-callback": "error",
     "no-inner-declarations": "off",
     "consistent-return": "off",
     "no-floating-decimal": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
   ],
   "rules": {
     "prettier/prettier": "error",
+    "arrow-body-style": "error",
     "no-inner-declarations": "off",
     "consistent-return": "off",
     "no-floating-decimal": "error",

--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -283,15 +283,9 @@ export type BiblioEntry =
 
 function dumpEnv(env: EnvRec) {
   console.log('## ' + env._namespace);
-  console.log(
-    env
-      .map(function (entry) {
-        return JSON.stringify(entry);
-      })
-      .join(', ')
-  );
+  console.log(env.map(entry => JSON.stringify(entry)).join(', '));
 
-  env._children.forEach(function (child) {
+  env._children.forEach(child => {
     dumpEnv(child);
   });
 }

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -91,10 +91,8 @@ export function replacerForNamespace(namespace: string, biblio: Biblio): [RegExp
 
   const clauseReplacer = new RegExp(
     Object.keys(autolinkmap)
-      .sort(function (a, b) {
-        return b.length - a.length;
-      })
-      .map(function (k) {
+      .sort((a, b) => b.length - a.length)
+      .map(k => {
         const entry = autolinkmap[k];
         const key = regexpEscape(entry.key!);
 

--- a/test/biblio.js
+++ b/test/biblio.js
@@ -5,14 +5,14 @@ const BiblioModule = require('../lib/Biblio');
 const Biblio = BiblioModule.default;
 const location = 'https://tc39.github.io/ecma262/';
 
-describe('Biblio', function () {
+describe('Biblio', () => {
   let biblio;
 
-  beforeEach(function () {
+  beforeEach(() => {
     biblio = new Biblio(location);
   });
 
-  specify('is created with a root namespace named "global"', function () {
+  specify('is created with a root namespace named "global"', () => {
     const opEntry = {
       type: 'op',
       aoid: 'aoid',
@@ -23,7 +23,7 @@ describe('Biblio', function () {
     assert.equal(biblio.byAoid('aoid'), opEntry);
   });
 
-  specify("is created with a nested namespace for the doc's location", function () {
+  specify("is created with a nested namespace for the doc's location", () => {
     const opEntry = {
       type: 'op',
       aoid: 'aoid',
@@ -35,7 +35,7 @@ describe('Biblio', function () {
     assert.equal(biblio.byAoid('aoid', location), opEntry);
   });
 
-  specify('stringifies with only the local scope', function () {
+  specify('stringifies with only the local scope', () => {
     const opEntry1 = {
       type: 'op',
       aoid: 'aoid1',
@@ -57,8 +57,8 @@ describe('Biblio', function () {
     assert(str.indexOf('aoid2') === -1);
   });
 
-  describe('inScopeByType', function () {
-    specify('de-dupes by key', function () {
+  describe('inScopeByType', () => {
+    specify('de-dupes by key', () => {
       const opEntry1 = {
         type: 'op',
         aoid: 'aoid',

--- a/test/build.js
+++ b/test/build.js
@@ -7,6 +7,7 @@ const doc =
   '<!doctype html><pre class=metadata>toc: false\ncopyright: false\nassets: none</pre><emu-clause id=sec><h1>hi</h1></emu-clause>';
 const out =
   '<!doctype html>\n<head><meta charset="utf-8"></head><body><div id="spec-container"><emu-clause id="sec"><h1 class="first"><span class="secnum">1</span> hi</h1></emu-clause></div></body>';
+
 function fetch(file) {
   if (file.match(/\.json$/)) {
     return '{}';
@@ -16,13 +17,14 @@ function fetch(file) {
 }
 
 describe('ecmarkup#build', () => {
-  it('takes a fetch callback that returns a promise', () => {
-    return build('root.html', file => {
-      return new Promise(res => {
-        process.nextTick(() => res(fetch(file)));
-      });
-    }).then(spec => {
-      assert.equal(spec.toHTML(), out);
-    });
+  it('takes a fetch callback that returns a promise', async () => {
+    let spec = await build(
+      'root.html',
+      file =>
+        new Promise(res => {
+          process.nextTick(() => res(fetch(file)));
+        })
+    );
+    assert.equal(spec.toHTML(), out);
   });
 });

--- a/test/clauseIds.js
+++ b/test/clauseIds.js
@@ -3,14 +3,14 @@
 const assert = require('assert');
 const sectionNums = require('../lib/clauseNums').default;
 
-describe('clause id generation', function () {
+describe('clause id generation', () => {
   let iter;
 
-  beforeEach(function () {
+  beforeEach(() => {
     iter = sectionNums();
   });
 
-  specify('generating clause ids', function () {
+  specify('generating clause ids', () => {
     assert.strictEqual(iter.next(0).value, '1');
     assert.strictEqual(iter.next(1).value, '1.1');
     assert.strictEqual(iter.next(1).value, '1.2');
@@ -23,22 +23,22 @@ describe('clause id generation', function () {
     assert.strictEqual(iter.next(0, true).value, 'B');
   });
 
-  specify('error thrown for skipping clauses', function () {
-    assert.throws(function () {
+  specify('error thrown for skipping clauses', () => {
+    assert.throws(() => {
       iter.next(2);
     }, /Skipped clause/);
   });
 
-  specify('error thrown for non-annex following annex', function () {
-    assert.throws(function () {
+  specify('error thrown for non-annex following annex', () => {
+    assert.throws(() => {
       iter.next(0);
       iter.next(0, true);
       iter.next(0);
     }, /Clauses cannot follow annexes/);
   });
 
-  specify('error thrown for annex not starting at depth 0', function () {
-    assert.throws(function () {
+  specify('error thrown for annex not starting at depth 0', () => {
+    assert.throws(() => {
       iter.next(0);
       iter.next(1, true);
     }, /First annex must be at depth 0/);

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -4,11 +4,11 @@ let { assertLint, assertLintFree, lintLocationMarker: M, positioned } = require(
 
 const nodeType = 'emu-alg';
 
-describe('linting algorithms', function () {
-  describe('line endings', function () {
+describe('linting algorithms', () => {
+  describe('line endings', () => {
     const ruleId = 'algorithm-line-endings';
 
-    it('simple', async function () {
+    it('simple', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. testing${M}
@@ -21,7 +21,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('labeled', async function () {
+    it('labeled', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. [id="step-test"] testing${M}
@@ -34,7 +34,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('inline', async function () {
+    it('inline', async () => {
       await assertLint(positioned`<emu-alg>1. testing${M}</emu-alg>`, {
         ruleId,
         nodeType,
@@ -42,7 +42,7 @@ describe('linting algorithms', function () {
       });
     });
 
-    it('repeat', async function () {
+    it('repeat', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. Repeat, while _x_ < 10${M}
@@ -56,7 +56,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('inline if', async function () {
+    it('inline if', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. If _x_, then${M}
@@ -69,7 +69,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('multiline if', async function () {
+    it('multiline if', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. If _x_,${M}
@@ -83,7 +83,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('pre', async function () {
+    it('pre', async () => {
       await assertLint(
         positioned`<emu-alg>
             1. ${M}Let _constructorText_ be the source text
@@ -98,7 +98,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('negative', async function () {
+    it('negative', async () => {
       await assertLintFree(`
         <emu-alg>
           1. If foo, bar.
@@ -130,10 +130,10 @@ describe('linting algorithms', function () {
     });
   });
 
-  describe('step numbering', function () {
+  describe('step numbering', () => {
     const ruleId = 'algorithm-step-numbering';
 
-    it('simple', async function () {
+    it('simple', async () => {
       await assertLint(
         positioned`<emu-alg>
           ${M}2. Step.
@@ -170,7 +170,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('nested', async function () {
+    it('nested', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. Step:
@@ -209,7 +209,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('ten', async function () {
+    it('ten', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. Step.
@@ -223,7 +223,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('negative', async function () {
+    it('negative', async () => {
       await assertLintFree(`
         <emu-alg>
           1. Step.
@@ -234,9 +234,9 @@ describe('linting algorithms', function () {
     });
   });
 
-  describe('step labels', function () {
+  describe('step labels', () => {
     const ruleId = 'algorithm-step-labels';
-    it('rejects unprefixed labels', async function () {
+    it('rejects unprefixed labels', async () => {
       await assertLint(
         positioned`<emu-alg>
           1. [id="${M}example"] Step.
@@ -249,7 +249,7 @@ describe('linting algorithms', function () {
       );
     });
 
-    it('negative', async function () {
+    it('negative', async () => {
       await assertLintFree(`
         <emu-alg>
           1. Step.

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -2,8 +2,8 @@
 
 let { assertLint, assertLintFree, positioned, lintLocationMarker: M } = require('./utils.js');
 
-describe('spelling', function () {
-  it('*this* object', async function () {
+describe('spelling', () => {
+  it('*this* object', async () => {
     await assertLint(
       positioned`
         <p>If the ${M}*this* object ...</p>
@@ -16,7 +16,7 @@ describe('spelling', function () {
     );
   });
 
-  it("1's complement", async function () {
+  it("1's complement", async () => {
     await assertLint(
       positioned`
         <p>It returns the ${M}1's complement of _x_.</p>
@@ -29,7 +29,7 @@ describe('spelling', function () {
     );
   });
 
-  it("2's complement", async function () {
+  it("2's complement", async () => {
     await assertLint(
       positioned`
         <p>BigInts act as ${M}2's complement binary strings</p>
@@ -42,7 +42,7 @@ describe('spelling', function () {
     );
   });
 
-  it('*0*', async function () {
+  it('*0*', async () => {
     await assertLint(
       positioned`
         <emu-alg>1. If _x_ is ${M}*0*, then foo.</emu-alg>
@@ -55,7 +55,7 @@ describe('spelling', function () {
     );
   });
 
-  it('behavior', async function () {
+  it('behavior', async () => {
     await assertLint(
       positioned`
         <p>Most hosts will be able to simply define HostGetImportMetaProperties, and leave HostFinalizeImportMeta with its default ${M}behavior.</p>
@@ -68,7 +68,7 @@ describe('spelling', function () {
     );
   });
 
-  it('the empty string', async function () {
+  it('the empty string', async () => {
     await assertLint(
       positioned`
         <p>_searchValue_ is ${M}the empty string</p>
@@ -81,7 +81,7 @@ describe('spelling', function () {
     );
   });
 
-  it('trailing whitespace', async function () {
+  it('trailing whitespace', async () => {
     await assertLint(
       positioned`
         <p>something</p>${M} 
@@ -94,7 +94,7 @@ describe('spelling', function () {
     );
   });
 
-  it('two blank lines', async function () {
+  it('two blank lines', async () => {
     await assertLint(
       positioned`
 <p></p>
@@ -125,7 +125,7 @@ ${M}
     );
   });
 
-  it('header linebreak', async function () {
+  it('header linebreak', async () => {
     await assertLint(
       positioned`
 <emu-clause id="example">
@@ -141,7 +141,7 @@ ${M}
     );
   });
 
-  it('footer linebreak', async function () {
+  it('footer linebreak', async () => {
     await assertLint(
       positioned`
 <emu-clause id="example">
@@ -158,7 +158,7 @@ ${M}
     );
   });
 
-  it('CR', async function () {
+  it('CR', async () => {
     await assertLint(
       positioned`
 windows:${M}\r
@@ -171,7 +171,7 @@ windows:${M}\r
     );
   });
 
-  it('step numbers', async function () {
+  it('step numbers', async () => {
     await assertLint(
       positioned`
         Something about step ${M}1.
@@ -184,7 +184,7 @@ windows:${M}\r
     );
   });
 
-  it('clause numbers', async function () {
+  it('clause numbers', async () => {
     await assertLint(
       positioned`
         See clause ${M}1.
@@ -198,7 +198,7 @@ windows:${M}\r
     );
   });
 
-  it('multiple internal spaces', async function () {
+  it('multiple internal spaces', async () => {
     await assertLint(
       positioned`
         I am writing on a typewriter.${M}  In the 21st century, for some reason.
@@ -211,7 +211,7 @@ windows:${M}\r
     );
   });
 
-  it('leading whitespace within tags', async function () {
+  it('leading whitespace within tags', async () => {
     await assertLint(
       positioned`
         <p>${M} This is an example.</p>
@@ -224,7 +224,7 @@ windows:${M}\r
     );
   });
 
-  it('trailing whitespace within tags', async function () {
+  it('trailing whitespace within tags', async () => {
     await assertLint(
       positioned`
         <p>This is an example:${M} </p>
@@ -237,7 +237,7 @@ windows:${M}\r
     );
   });
 
-  it('negative', async function () {
+  it('negative', async () => {
     await assertLintFree(`
       <p>
         the *this* value

--- a/test/lint.js
+++ b/test/lint.js
@@ -2,9 +2,9 @@
 
 let { assertLint, assertLintFree, positioned, lintLocationMarker: M } = require('./utils.js');
 
-describe('linting whole program', function () {
-  describe('grammar validity', function () {
-    it('unused parameters', async function () {
+describe('linting whole program', () => {
+  describe('grammar validity', () => {
+    it('unused parameters', async () => {
       await assertLint(
         positioned`
           <emu-grammar type="definition">
@@ -19,7 +19,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('parameters used in SDO', async function () {
+    it('parameters used in SDO', async () => {
       await assertLintFree(`
         <emu-grammar type="definition">
           Statement[a]: \`;\`
@@ -36,7 +36,7 @@ describe('linting whole program', function () {
       `);
     });
 
-    it('missing parameters', async function () {
+    it('missing parameters', async () => {
       await assertLint(
         positioned`
           <emu-grammar type="definition">
@@ -55,7 +55,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('error in inline grammar', async function () {
+    it('error in inline grammar', async () => {
       await assertLint(
         positioned`
           <emu-grammar type="definition">Statement[${M}a]: \`;\`</emu-grammar>
@@ -69,8 +69,8 @@ describe('linting whole program', function () {
     });
   });
 
-  describe('grammar+SDO validity', function () {
-    it('undefined nonterminals in SDOs', async function () {
+  describe('grammar+SDO validity', () => {
+    it('undefined nonterminals in SDOs', async () => {
       await assertLint(
         positioned`
           <emu-grammar>
@@ -88,7 +88,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('error in inline grammar', async function () {
+    it('error in inline grammar', async () => {
       await assertLint(
         positioned`
           <emu-grammar>${M}Statement: EmptyStatement</emu-grammar>
@@ -104,7 +104,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('undefined productions in SDOs', async function () {
+    it('undefined productions in SDOs', async () => {
       await assertLint(
         positioned`
           <emu-grammar type="definition">
@@ -128,8 +128,8 @@ describe('linting whole program', function () {
     });
   });
 
-  describe('header format', function () {
-    it('name format', async function () {
+  describe('header format', () => {
+    it('name format', async () => {
       await assertLint(
         positioned`
           <emu-clause id="foo">
@@ -144,7 +144,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('spacing', async function () {
+    it('spacing', async () => {
       await assertLint(
         positioned`
           <emu-clause id="foo">
@@ -158,7 +158,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('arg format', async function () {
+    it('arg format', async () => {
       await assertLint(
         positioned`
           <emu-clause id="foo">
@@ -173,7 +173,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('legal names', async function () {
+    it('legal names', async () => {
       await assertLintFree(`
           <emu-clause id="i1">
             <h1>Example ( )</h1>
@@ -205,7 +205,7 @@ describe('linting whole program', function () {
       `);
     });
 
-    it('legal argument lists', async function () {
+    it('legal argument lists', async () => {
       await assertLintFree(`
           <emu-clause id="i1">
             <h1>Example ( )</h1>
@@ -232,8 +232,8 @@ describe('linting whole program', function () {
     });
   });
 
-  describe('closing tags', function () {
-    it('grammar', async function () {
+  describe('closing tags', () => {
+    it('grammar', async () => {
       await assertLint(
         positioned`
           ${M}<emu-grammar type="definition">
@@ -248,7 +248,7 @@ describe('linting whole program', function () {
       );
     });
 
-    it('algorithm', async function () {
+    it('algorithm', async () => {
       await assertLint(
         positioned`
           ${M}<emu-alg>

--- a/test/output.js
+++ b/test/output.js
@@ -20,28 +20,27 @@ describe('baselines', () => {
     const local = 'test/baselines/local/' + file;
     const reference = 'test/baselines/reference/' + file;
     file = 'test/' + file;
-    it(file, () =>
-      build(file).then(spec => {
-        const contents = spec.toHTML();
-        let str;
+    it(file, async () => {
+      let spec = await build(file);
+      const contents = spec.toHTML();
+      let str;
+      try {
+        str = fs.readFileSync(reference, 'utf8');
+      } catch (e) {
+        // ignored
+      }
+      if (contents !== str) {
         try {
-          str = fs.readFileSync(reference, 'utf8');
+          fs.mkdirSync('test/baselines/local');
         } catch (e) {
           // ignored
         }
-        if (contents !== str) {
-          try {
-            fs.mkdirSync('test/baselines/local');
-          } catch (e) {
-            // ignored
-          }
-          fs.writeFileSync(local, contents, 'utf8');
-          const error = new Error('Incorrect baseline');
-          error.expected = str || '';
-          error.actual = contents;
-          throw error;
-        }
-      })
-    );
+        fs.writeFileSync(local, contents, 'utf8');
+        const error = new Error('Incorrect baseline');
+        error.expected = str || '';
+        error.actual = contents;
+        throw error;
+      }
+    });
   });
 });

--- a/test/output.js
+++ b/test/output.js
@@ -3,25 +3,25 @@ const fs = require('fs');
 
 const emu = require('../lib/ecmarkup');
 
-const files = fs.readdirSync('test').filter(function (f) {
-  return f.endsWith('.html') && !f.endsWith('.bad.html');
-});
+const files = fs.readdirSync('test').filter(f => f.endsWith('.html') && !f.endsWith('.bad.html'));
 
 function build(file) {
-  return emu.build(file, function (file) {
-    return new Promise((resolve, reject) =>
-      fs.readFile(file, 'utf-8', (err, data) => (err ? reject(err) : resolve(data)))
-    );
-  });
+  return emu.build(
+    file,
+    file =>
+      new Promise((resolve, reject) =>
+        fs.readFile(file, 'utf-8', (err, data) => (err ? reject(err) : resolve(data)))
+      )
+  );
 }
 
-describe('baselines', function () {
-  files.forEach(function (file) {
+describe('baselines', () => {
+  files.forEach(file => {
     const local = 'test/baselines/local/' + file;
     const reference = 'test/baselines/reference/' + file;
     file = 'test/' + file;
-    it(file, function () {
-      return build(file).then(function (spec) {
+    it(file, () =>
+      build(file).then(spec => {
         const contents = spec.toHTML();
         let str;
         try {
@@ -41,7 +41,7 @@ describe('baselines', function () {
           error.actual = contents;
           throw error;
         }
-      });
-    });
+      })
+    );
   });
 });


### PR DESCRIPTION
I was going to also add a rule which said that `x = y` and `x++` can only be used in statement position, but apparently there is no such rule in the standard eslint set (?????), so I guess I'm not doing that. There's piecemeal ones - `no-return-assign` and `no-cond-assign` - but I don't really want to add rules for this unless I can do it wholesale.