### PR TITLE
lint: add for-each-element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecmarkup",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -9,11 +9,13 @@ import { warnEmdFailure } from '../utils';
 import lintAlgorithmLineEndings from './rules/algorithm-line-endings';
 import lintAlgorithmStepNumbering from './rules/algorithm-step-numbering';
 import lintAlgorithmStepLabels from './rules/algorithm-step-labels';
+import lintForEachElement from './rules/for-each-element';
 
 let algorithmRules = [
   lintAlgorithmLineEndings,
   lintAlgorithmStepNumbering,
   lintAlgorithmStepLabels,
+  lintForEachElement,
 ];
 
 function composeObservers(...observers: Observer[]): Observer {

--- a/src/lint/rules/for-each-element.ts
+++ b/src/lint/rules/for-each-element.ts
@@ -1,0 +1,26 @@
+import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { Reporter } from '../algorithm-error-reporter-type';
+
+const ruleId = 'for-each-element';
+
+/*
+Checks that "For each" loops name a type or say "element" before the variable.
+*/
+export default function (report: Reporter): Observer {
+  return {
+    enter(node: EcmarkdownNode) {
+      if (node.name !== 'ordered-list-item' || node.contents.length < 2) {
+        return;
+      }
+      let [first, second] = node.contents;
+      if (first.name === 'text' && first.contents === 'For each ' && second.name === 'underscore') {
+        report({
+          ruleId,
+          line: second.location.start.line,
+          column: second.location.start.column,
+          message: 'expected "for each" to have a type name or "element" before the loop variable',
+        });
+      }
+    },
+  };
+}

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -272,4 +272,31 @@ describe('linting algorithms', () => {
       `);
     });
   });
+
+  describe('for each element', () => {
+    const ruleId = 'for-each-element';
+    it('rejects loops without types', async () => {
+      await assertLint(
+        positioned`
+        <emu-alg>
+          1. For each ${M}_x_ of _y_, do foo.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected "for each" to have a type name or "element" before the loop variable',
+        }
+      );
+    });
+
+    it('negative', async () => {
+      await assertLintFree(`
+        <emu-alg>
+          1. For each String _x_ of _y_, do foo.
+          1. For each element _x_ of _y_, do foo.
+          1. For each integer _x_ such that _x_ &in; _S_, do foo.
+        </emu-alg>
+      `);
+    });
+  });
 });


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/2152. This passes cleanly on that PR.

I didn't see a good way to lint for the other stuff in that PR without too high a risk of false positives, especially since "For each integer _x_ in the range [0, 10)" and so on need to remain legal. But I am happy to add more linting if there's things which reviewers think should be added.