### PR TITLE
support ins/del in emu-production tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/RHS.ts
+++ b/src/RHS.ts
@@ -35,25 +35,43 @@ export default class RHS extends Builder {
   }
 
   terminalify(parentNode: Element) {
+    // we store effects to perform later so the iteration doesn't get messed up
+    let pairs: { parent: Element; child: Text }[] = [];
     for (let i = 0; i < parentNode.childNodes.length; i++) {
       const node = parentNode.childNodes[i];
-
       if (node.nodeType === 3) {
-        const text = node.textContent!.trim();
-        const pieces = text.split(/\s/);
-
-        pieces.forEach(p => {
-          if (p.length === 0) {
-            return;
+        pairs.push({ parent: parentNode, child: node as Text });
+      } else if (
+        node.nodeType === 1 &&
+        (node.nodeName === 'INS' || node.nodeName === 'DEL' || node.nodeName === 'MARK')
+      ) {
+        for (let i = 0; i < node.childNodes.length; i++) {
+          const child = node.childNodes[i];
+          if (child.nodeType === 3) {
+            pairs.push({ parent: node as Element, child: child as Text });
           }
-          const est = this.spec.doc.createElement('emu-t');
-          est.textContent = p;
-
-          parentNode.insertBefore(est, node);
-        });
-
-        parentNode.removeChild(node);
+        }
       }
     }
+    for (let { parent, child } of pairs) {
+      this.wrapTerminal(parent, child);
+    }
+  }
+
+  private wrapTerminal(parentNode: Element, node: Text) {
+    const text = node.textContent!.trim();
+    const pieces = text.split(/\s/);
+
+    pieces.forEach(p => {
+      if (p.length === 0) {
+        return;
+      }
+      const est = this.spec.doc.createElement('emu-t');
+      est.textContent = p;
+
+      parentNode.insertBefore(est, node);
+    });
+
+    parentNode.removeChild(node);
   }
 }

--- a/test/baselines/reference/ins-nonterminal.html
+++ b/test/baselines/reference/ins-nonterminal.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<head><meta charset="utf-8"></head><body><div id="spec-container">
+
+<emu-production name="A" type="lexical" oneof="" id="prod-A">
+    <emu-nt><a href="#prod-A">A</a></emu-nt><emu-geq>::</emu-geq><emu-oneof>one of</emu-oneof><emu-rhs><del><emu-t>a</emu-t></del><emu-t>b</emu-t><emu-t>c</emu-t><mark><emu-t>d</emu-t></mark><ins><emu-t>e</emu-t><emu-t>f</emu-t></ins></emu-rhs>
+</emu-production>
+</div></body>

--- a/test/ins-nonterminal.html
+++ b/test/ins-nonterminal.html
@@ -1,0 +1,9 @@
+<pre class=metadata>
+toc: false
+copyright: false
+assets: none
+</pre>
+
+<emu-production name="A" type="lexical" oneof>
+    <emu-rhs><del>a</del> b c <mark>d</mark> <ins>e f</ins></emu-rhs>
+</emu-production>


### PR DESCRIPTION
Fixes https://github.com/tc39/ecmarkup/issues/247 (cc @rbuckton).

Now

```html
<emu-production name="A" type="lexical" oneof>
  <emu-rhs><del>a</del> b c <mark>d</mark> <ins>e f</ins></emu-rhs>
</emu-production>
```
is emitted as (modulo whitespace)

```html
<emu-production name="A" type="lexical" oneof="" id="prod-A">
  <emu-nt><a href="#prod-A">A</a></emu-nt>
  <emu-geq>::</emu-geq>
  <emu-oneof>one of</emu-oneof>
  <emu-rhs>
    <del><emu-t>a</emu-t></del>
    <emu-t>b</emu-t>
    <emu-t>c</emu-t>
    <mark><emu-t>d</emu-t></mark>
    <ins><emu-t>e</emu-t><emu-t>f</emu-t></ins>
  </emu-rhs>
</emu-production>
```
It looks kind of funny (see below), but that's an unrelated issue with how we emit grammar nodes (https://github.com/tc39/ecmarkup/issues/248).

<img width="173" alt="Screen Shot 2020-09-05 at 6 41 47 PM" src="https://user-images.githubusercontent.com/1653598/92316369-c90ef900-efa7-11ea-87ad-3f30cdd68be2.png">
