### PR TITLE
add some lint rules for numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "4.1.3",
+	"version": "4.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "4.1.3",
+	"version": "4.2.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -8,15 +8,15 @@ let ruleId = 'spelling';
 // Note that these will be composed, so cannot contain backreferences
 let matchers = [
   {
-    pattern: /\*this\* object/giu,
+    pattern: /\*this\* object/gu,
     message: 'prefer "*this* value"',
   },
   {
-    pattern: /1's complement/giu,
+    pattern: /1's complement/gu,
     message: 'prefer "one\'s complement"',
   },
   {
-    pattern: /2's complement/giu,
+    pattern: /2's complement/gu,
     message: 'prefer "two\'s complement"',
   },
   {
@@ -24,8 +24,58 @@ let matchers = [
     message: 'the Number value 0 should be written "*+0*", to unambiguously exclude "*-0*"',
   },
   {
-    pattern: /behavior/giu,
+    pattern: /[+-]?(?:&[a-z]+;|0x[0-9A-Fa-f]+|[0-9]+(?:\.[0-9]+)?)<sub>𝔽<\/sub>/gu,
+    message: 'literal Number values should be bolded',
+  },
+  {
+    pattern: /[+-]?[0-9]+<sub>ℤ<\/sub>/gu,
+    message: 'literal BigInt values should be bolded',
+  },
+  {
+    pattern: /\*[+-]?(?:&[a-z]+;|0x[0-9A-Fa-f]+|[0-9]+(?:\.[0-9]+)?)\*(?!<sub>[𝔽ℤ]<\/sub>)/gu,
+    message:
+      'literal Number or BigInt values should be followed by <sub>𝔽</sub> or <sub>ℤ</sub> respectively',
+  },
+  {
+    pattern: /(?<=\*)\+(?:0x[1-9A-Fa-f]|[1-9])/gu,
+    message: 'positive numeric values other than 0 should not have a leading plus sign (+)',
+  },
+  {
+    // this needs its own rule to catch +0 as a real number
+    pattern: /(?<= )\+[0-9]/gu,
+    message: 'positive real numbers should not have a leading plus sign (+)',
+  },
+  {
+    pattern: /(?<![+-])&infin;/gu,
+    message: '&infin; should always be written with a leading + or -',
+  },
+  {
+    pattern: /(?<= )[+-]\*(?:&[a-z]+;|0x[0-9A-Fa-f]+|[0-9]+(?:\.[0-9]+)?)\*/gu,
+    message: 'the sign character for a numeric literal should be within the `*`s',
+  },
+  {
+    pattern: /(?<=\bmathematical value )for\b/gu,
+    message: 'the mathematical value "of", not "for"',
+  },
+  {
+    pattern: /(?<=\b[Nn]umber value )of\b/gu,
+    message: 'the Number value "for", not "of"',
+  },
+  {
+    pattern: /\bnumber value\b/gu,
+    message: '"Number value", not "number value"',
+  },
+  {
+    pattern: /[Bb]ehavior/gu,
     message: 'ECMA-262 uses Oxford spelling ("behaviour")',
+  },
+  {
+    pattern: /\b[Nn]onnegative\b/gu,
+    message: 'prefer "non-negative"',
+  },
+  {
+    pattern: /\b[Nn]onzero\b/gu,
+    message: 'prefer "non-zero"',
   },
   {
     pattern: /[Tt]he empty string/gu,
@@ -40,11 +90,11 @@ let matchers = [
     message: 'no more than one blank line is allowed',
   },
   {
-    pattern: /(?<=<emu-clause.*>\n)\n\s*<h1>/giu,
+    pattern: /(?<=<emu-clause.*>\n)\n\s*<h1>/gu,
     message: "there should not be a blank line between a clause's opening tag and its header",
   },
   {
-    pattern: /(?<=(^|[^\n])\n)\n+[ \t]*<\/emu-clause>/giu,
+    pattern: /(?<=(^|[^\n])\n)\n+[ \t]*<\/emu-clause>/gu,
     message:
       'there should not be a blank line between the last line of a clause and its closing tag',
   },
@@ -72,6 +122,10 @@ let matchers = [
   {
     pattern: /(?<=[^ \n]) +<\/(?!td|th|dd|dt|ins|del)/gu,
     message: 'tags should not contain trailing whitespace',
+  },
+  {
+    pattern: /(?<=&[lg][et]; ?\*)-0\*/gu,
+    message: 'comparisons against floating-point zero should use positive zero',
   },
 ];
 

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -45,12 +45,201 @@ describe('spelling', () => {
   it('*0*', async () => {
     await assertLint(
       positioned`
-        <emu-alg>1. If _x_ is ${M}*0*, then foo.</emu-alg>
+        <emu-alg>1. If _x_ is ${M}*0*<sub>𝔽</sub>, then foo.</emu-alg>
       `,
       {
         ruleId: 'spelling',
         nodeType: 'html',
         message: 'the Number value 0 should be written "*+0*", to unambiguously exclude "*-0*"',
+      }
+    );
+  });
+
+  it('numeric literal bolding', async () => {
+    await assertLint(
+      positioned`
+        <p>${M}+&infin;<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'literal Number values should be bolded',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>${M}42<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'literal Number values should be bolded',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>${M}0xDEADBEEF<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'literal Number values should be bolded',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>${M}-1<sub>ℤ</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'literal BigInt values should be bolded',
+      }
+    );
+  });
+
+  it('numeric literal subscripts', async () => {
+    await assertLint(
+      positioned`
+        <p>${M}*+&infin;*</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message:
+          'literal Number or BigInt values should be followed by <sub>𝔽</sub> or <sub>ℤ</sub> respectively',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>${M}*42*</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message:
+          'literal Number or BigInt values should be followed by <sub>𝔽</sub> or <sub>ℤ</sub> respectively',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>${M}*0xDEADBEEF*</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message:
+          'literal Number or BigInt values should be followed by <sub>𝔽</sub> or <sub>ℤ</sub> respectively',
+      }
+    );
+  });
+
+  it('leading plus sign', async () => {
+    await assertLint(
+      positioned`
+        <p>*${M}+1*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'positive numeric values other than 0 should not have a leading plus sign (+)',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>*${M}+0xDEADBEEF*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'positive numeric values other than 0 should not have a leading plus sign (+)',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>_x_ is ${M}+1</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'positive real numbers should not have a leading plus sign (+)',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>_x_ is ${M}+*1*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'the sign character for a numeric literal should be within the `*`s',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>_x_ is ${M}-*1*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'the sign character for a numeric literal should be within the `*`s',
+      }
+    );
+  });
+
+  it('&infin;', async () => {
+    await assertLint(
+      positioned`
+        <p>${M}&infin;</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: '&infin; should always be written with a leading + or -',
+      }
+    );
+  });
+
+  it('mathematical value of/number value for', async () => {
+    await assertLint(
+      positioned`
+        <p>Let _x_ be the mathematical value ${M}for _y_.</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'the mathematical value "of", not "for"',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>Let _x_ be the Number value ${M}of _y_.</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'the Number value "for", not "of"',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>Let _x_ be the ${M}number value for _y_.</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: '"Number value", not "number value"',
       }
     );
   });
@@ -64,6 +253,32 @@ describe('spelling', () => {
         ruleId: 'spelling',
         nodeType: 'html',
         message: 'ECMA-262 uses Oxford spelling ("behaviour")',
+      }
+    );
+  });
+
+  it('nonnegative', async () => {
+    await assertLint(
+      positioned`
+        <p>a ${M}nonnegative integer</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'prefer "non-negative"',
+      }
+    );
+  });
+
+  it('nonzero', async () => {
+    await assertLint(
+      positioned`
+        <p>a ${M}nonzero integer</p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'prefer "non-zero"',
       }
     );
   });
@@ -237,16 +452,74 @@ windows:${M}\r
     );
   });
 
+  it('comparison with *-0*', async () => {
+    await assertLint(
+      positioned`
+        <p>If _x_ &lt; *${M}-0*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'comparisons against floating-point zero should use positive zero',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>If _x_ &le; *${M}-0*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'comparisons against floating-point zero should use positive zero',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>If _x_ &gt; *${M}-0*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'comparisons against floating-point zero should use positive zero',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>If _x_ &ge; *${M}-0*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message: 'comparisons against floating-point zero should use positive zero',
+      }
+    );
+  });
+
   it('negative', async () => {
     await assertLintFree(`
       <p>
         the *this* value
         one's complement
         two's complement
-        *+0*
-        *-0*
+        *0xDEADBEEF*<sub>𝔽</sub>
+        *1*<sub>𝔽</sub>
+        +&infin;
+        -&infin;
+        *+&infin;*<sub>𝔽</sub>
+        *+0*<sub>𝔽</sub>
+        *+0x0*<sub>𝔽</sub>
+        *-0*<sub>𝔽</sub>
         *0*<sub>ℤ</sub>
+        0
         behaviour
+        a non-negative integer
+        a non-zero integer
+        Let _x_ be the mathematical value of _y_.
+        Let _y_ be the Number value for _x_.
+        IsNonNegativeInteger(_x_)
         the empty String
       </p>
       <p>One blank line is fine:</p>
@@ -274,6 +547,9 @@ windows:${M}\r
       <p>
         Paragraphs with the open/close tags on their own line are OK.
       </p>
+
+      <p>Comparisons with positive zero are OK: _x_ &lt; *+0*<sub>𝔽</sub>, _x_ &le; *+0*<sub>𝔽</sub>, _x_ &gt; *+0*<sub>𝔽</sub>, _x_ &ge; *+0*<sub>𝔽</sub>
+
     `);
   });
 });


### PR DESCRIPTION
Marked as draft until https://github.com/tc39/ecma262/pull/2007 is ready to land, since that PR is the thing which makes these conventions consistent.