### PR TITLE
Apply CSS containment to improve performance

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -412,6 +412,7 @@ emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-c
 
 emu-clause, emu-intro, emu-annex {
     display: block;
+    contains: content;
 }
 
 /* Figures and tables */


### PR DESCRIPTION
https://drafts.csswg.org/css-contain/

> Note: [contain: content](https://drafts.csswg.org/css-contain/#propdef-contain) is reasonably "safe" to apply widely; its effects are fairly minor in practice, and most content won’t run afoul of its restrictions. However, because it doesn’t apply [size containment](https://drafts.csswg.org/css-contain/#size-containment), the element can still respond to the size of its contents, which can cause layout-invalidation to percolate further up the tree than desired. Use contain: strict or contain: strict style when possible, to gain as much containment as you can.

I suggest investigating if we can be more aggressive about this. For example, use `content-visibility: auto` on mobile devices. This can slightly improve performance on mobile devices but the element out of the viewport will have height 0. (Generally, I don't think it's a serious problem cause people usually navigate through the menu or by search and they both work with `content-visibility`.)