### PR TITLE
[DO NOT MERGE YET] Improve rendering performance by chunking layout

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -16,6 +16,11 @@ body {
   overflow: hidden;
 }
 
+#spec-container > emu-clause {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 1000px;
+}
+
 body.oldtoc {
   margin: 0 auto;
 }
@@ -167,7 +172,7 @@ emu-note > div.note-contents > p:last-of-type {
 
 emu-table td code {
   white-space: normal;
-} 
+}
 
 emu-figure {
   display: block;
@@ -470,7 +475,7 @@ emu-production > ins, emu-production > del,
 emu-grammar > ins, emu-grammar > del {
   display: block;
 }
-emu-rhs > ins, emu-rhs > del { 
+emu-rhs > ins, emu-rhs > del {
   display: inline;
 }
 
@@ -699,10 +704,10 @@ tr.del > td {
   flex-grow: 0;
   flex-shrink: 0;
   width: 100%;
-  
+
   display: flex;
   flex-direction: column;
-  
+
   max-height: 300px;
 }
 
@@ -940,6 +945,6 @@ li.menu-search-result-term:before {
 
 @media print {
   #menu-toggle {
-    display: none; 
+    display: none;
   }
 }


### PR DESCRIPTION
This patch adds `content-visibility: auto` as described here:

- https://web.dev/content-visibility/
- https://www.youtube.com/watch?v=FFA-v-CIxJQ

Demo:
- Before: https://mathiasbynens.github.io/ecma262-layout-chunking/before.html
- After: https://mathiasbynens.github.io/ecma262-layout-chunking/after.html

This is supposed to improve load-time performance by only requiring layout for the visible top-level `emu-clauses` where applicable, in browsers that support `content-visibility`. While recording traces to quantify the improvement I bumped into https://bugs.chromium.org/p/chromium/issues/detail?id=1138128, which we’ll probably want to have fixed upstream before landing this.