### PR TITLE
lint: forbid use of "then" in single-line "If" algorithm steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -20,7 +20,7 @@ Checks that every algorithm step has one of these forms:
 - `Other.`
 - `Other:` + substeps
 */
-export default function (report: Reporter, node: Element): Observer {
+export default function (report: Reporter, node: Element, algorithmSource: string): Observer {
   if (node.getAttribute('type') === 'example') {
     return {};
   }
@@ -172,6 +172,19 @@ export default function (report: Reporter, node: Element): Observer {
             }
           }
         } else {
+          let lineSource = algorithmSource.slice(
+            first.location!.start.offset,
+            last.location!.end.offset
+          );
+          let ifThenMatch = lineSource.match(/^If[^,\n]+, then /);
+          if (ifThenMatch != null) {
+            report({
+              ruleId,
+              line: first.location!.start.line,
+              column: first.location!.start.column + ifThenMatch[0].length - 5,
+              message: `single-line "If" steps should not have a "then"`,
+            });
+          }
           if (!/(?:\.|\.\)|:)$/.test(last.contents)) {
             report({
               ruleId,

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -5,7 +5,7 @@ let { assertLint, assertLintFree, lintLocationMarker: M, positioned } = require(
 const nodeType = 'emu-alg';
 
 describe('linting algorithms', () => {
-  describe('line endings', () => {
+  describe('line style', () => {
     const ruleId = 'algorithm-line-style';
 
     it('simple', async () => {
@@ -65,6 +65,19 @@ describe('linting algorithms', () => {
           ruleId,
           nodeType,
           message: 'expected "If" without substeps to end with "." or ":" (found ", then")',
+        }
+      );
+    });
+
+    it('inline if-then', async () => {
+      await assertLint(
+        positioned`<emu-alg>
+          1. If _x_, ${M}then do something.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'single-line "If" steps should not have a "then"',
         }
       );
     });

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -45,7 +45,7 @@ describe('spelling', () => {
   it('*0*', async () => {
     await assertLint(
       positioned`
-        <emu-alg>1. If _x_ is ${M}*0*<sub>𝔽</sub>, then foo.</emu-alg>
+        <emu-alg>1. If _x_ is ${M}*0*<sub>𝔽</sub>, do foo.</emu-alg>
       `,
       {
         ruleId: 'spelling',


### PR DESCRIPTION
There are 1578 `1. If _foo_, do _bar_.` steps in ecma262 master, and only 16 `1. If _foo_, then do _bar_.`. This forbids the latter form. I'll remove those 16 occurrences as part of landing this.

Includes version bump commit, so please **rebase**, not squash.