### PR TITLE
use real source text for emu-grammar nodes in main document

### DIFF
--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -24,7 +24,7 @@ export default class Grammar extends Builder {
     // If the source text is available, we should use it since `innerHTML` serializes the
     // DOM tree beneath the node. This can result in odd behavior when the syntax is malformed
     // in a way that parse5 does not understand, but grammarkdown could possibly recover.
-    if (location && location.source) {
+    if (location) {
       if (location.startTag && location.endTag) {
         // the parser was able to find a matching end tag.
         const start = location.startTag.endOffset as number;
@@ -45,7 +45,7 @@ export default class Grammar extends Builder {
       }
     } else {
       // no source text, so read innerHTML as a fallback.
-      content = node.innerHTML;
+      content = node.innerHTML.replace(/&gt;/g, '>');
     }
 
     if (possiblyMalformed) {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -143,9 +143,7 @@ function wrapWarn(source: string, spec: Spec, warn: (err: EcmarkupError) => void
           let loc = spec.locate(e.node);
           if (loc) {
             file = loc.file;
-            if (loc.source != null) {
-              source = loc.source;
-            }
+            source = loc.source;
             ({ line, col: column } = loc);
           }
           nodeType = 'text';
@@ -153,9 +151,7 @@ function wrapWarn(source: string, spec: Spec, warn: (err: EcmarkupError) => void
           let loc = spec.locate(e.node as Element);
           if (loc) {
             file = loc.file;
-            if (loc.source != null) {
-              source = loc.source;
-            }
+            source = loc.source;
             ({ line, col: column } = loc.startTag);
           }
           nodeType = (e.node as Element).tagName.toLowerCase();
@@ -165,9 +161,7 @@ function wrapWarn(source: string, spec: Spec, warn: (err: EcmarkupError) => void
         let loc = spec.locate(e.node);
         if (loc) {
           file = loc.file;
-          if (loc.source != null) {
-            source = loc.source;
-          }
+          source = loc.source;
           ({ line, column } = utils.attrValueLocation(source, loc, e.attr));
         }
         nodeType = e.node.tagName.toLowerCase();
@@ -180,9 +174,7 @@ function wrapWarn(source: string, spec: Spec, warn: (err: EcmarkupError) => void
           let loc = spec.locate(e.node);
           if (loc) {
             file = loc.file;
-            if (loc.source != null) {
-              source = loc.source;
-            }
+            source = loc.source;
             line = loc.line + nodeRelativeLine - 1;
             column = nodeRelativeLine === 1 ? loc.col + nodeRelativeColumn - 1 : nodeRelativeColumn;
           }
@@ -191,9 +183,7 @@ function wrapWarn(source: string, spec: Spec, warn: (err: EcmarkupError) => void
           let loc = spec.locate(e.node);
           if (loc) {
             file = loc.file;
-            if (loc.source != null) {
-              source = loc.source;
-            }
+            source = loc.source;
             // We have to adjust both for start of tag -> end of tag and end of tag -> passed position
             // TODO switch to using loc.startTag.end{Line,Col} once parse5 can be upgraded
             let tagSrc = source.slice(loc.startTag.startOffset, loc.startTag.endOffset);
@@ -241,7 +231,7 @@ export default class Spec {
   opts: Options;
   rootPath: string;
   rootDir: string;
-  sourceText: string | undefined;
+  sourceText: string;
   namespace: string;
   biblio: Biblio;
   dom: any; /* JSDOM types are not updated, this is the jsdom DOM object */
@@ -268,8 +258,8 @@ export default class Spec {
     rootPath: string,
     fetch: (file: string, token: CancellationToken) => PromiseLike<string>,
     dom: any,
-    opts?: Options,
-    sourceText?: string, // TODO we need not support this being undefined
+    opts: Options,
+    sourceText: string,
     token = CancellationToken.none
   ) {
     opts = opts || {};
@@ -444,7 +434,7 @@ export default class Spec {
 
   public locate(
     node: Element | Node
-  ): ({ file?: string; source?: string } & MarkupData.ElementLocation) | undefined {
+  ): ({ file?: string; source: string } & MarkupData.ElementLocation) | undefined {
     let pointer: Element | Node | null = node;
     while (pointer != null) {
       if (isEmuImportElement(pointer)) {
@@ -457,6 +447,7 @@ export default class Spec {
       if (loc) {
         // we can't just spread `loc` because not all properties are own/enumerable
         return {
+          source: this.sourceText,
           startTag: loc.startTag,
           endTag: loc.endTag,
           startOffset: loc.startOffset,

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -53,7 +53,7 @@ export async function build(
 ): Promise<Spec> {
   const html = await fetch(path, token);
   const dom = utils.htmlToDom(html);
-  const spec = new Spec(path, fetch, dom, opts, /*sourceText*/ html, token);
+  const spec = new Spec(path, fetch, dom, opts ?? {}, /*sourceText*/ html, token);
   await spec.build();
   return spec;
 }

--- a/test/baselines/reference/grammar.html
+++ b/test/baselines/reference/grammar.html
@@ -17,6 +17,9 @@
 <emu-production name="HTMLEntitiesExample" type="lexical" id="prod-HTMLEntitiesExample">
     <emu-nt><a href="#prod-HTMLEntitiesExample">HTMLEntitiesExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="23da2165"><emu-gprose>This is technically a “production”</emu-gprose></emu-rhs>
 </emu-production>
+<emu-production name="ButOnlyExample" type="lexical" id="prod-ButOnlyExample">
+    <emu-nt><a href="#prod-ButOnlyExample">ButOnlyExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="5c6f47da"><emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt><emu-gmod>but only if the CapturingGroupNumber of <emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt> is &lt;= _NcapturingParens_</emu-gmod></emu-rhs>
+</emu-production>
 </emu-grammar>
 
 <p>Can also have inline productions like <emu-grammar><emu-production name="Atom" type="lexical" collapsed="" id="prod-Atom" class=" inline">

--- a/test/baselines/reference/grammar.html
+++ b/test/baselines/reference/grammar.html
@@ -11,7 +11,7 @@
     <emu-nt><a href="#prod-NewTerminal">NewTerminal</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="b1b8622b"><emu-t>t</emu-t></emu-rhs>
 </emu-production></ins>
 <emu-production name="LookaheadExample" type="lexical" id="prod-LookaheadExample">
-    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="62981417"><emu-t>&amp;&amp;</emu-t><emu-t>n</emu-t><emu-gann>[lookahead ∉ { <emu-t>1</emu-t>, <emu-t>3</emu-t>, <emu-t>5</emu-t>, <emu-t>7</emu-t>, <emu-t>9</emu-t> }]</emu-gann><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="d9a654c9"><emu-t>&amp;&amp;</emu-t><emu-t>n</emu-t><emu-gann>[lookahead ∉ { <emu-t>1</emu-t>, <emu-t>3</emu-t>, <emu-t>5</emu-t>, <emu-t>7</emu-t>, <emu-t>9</emu-t> }]</emu-gann><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt></emu-rhs>
     <emu-rhs a="195cbc6c"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigit">DecimalDigit</a></emu-nt><emu-gann>[lookahead ∉ <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigit">DecimalDigit</a></emu-nt>]</emu-gann></emu-rhs>
 </emu-production>
 <emu-production name="HTMLEntitiesExample" type="lexical" id="prod-HTMLEntitiesExample">

--- a/test/grammar.html
+++ b/test/grammar.html
@@ -22,6 +22,9 @@ assets: none
 
   HTMLEntitiesExample ::
     > This is technically a &ldquo;production&rdquo;
+
+  ButOnlyExample ::
+    DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &lt;= _NcapturingParens_]
 </emu-grammar>
 
 <p>Can also have inline productions like <emu-grammar>Atom :: `(` Disjunction `)`</emu-grammar>.</p>


### PR DESCRIPTION
Fixes #266.

The issue was that https://github.com/tc39/ecmarkup/pull/254 was inadvertently causing the rendering of `emu-grammar` nodes in the main document to use the `.innerHTML` rather than the real source, meaning it was passing `[...] DecimalEscape [&gt; but only [...]` to grammarkdown. Grammarkdown then silently dropped it. (Which is surprising to me; I'd expect at least an error. cc @rbuckton.)

This fixes the issue from #254 and also makes the fallback path robust against this.