### PR TITLE
update grammarkdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,13 +1153,12 @@
 			"dev": true
 		},
 		"grammarkdown": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-2.2.1.tgz",
-			"integrity": "sha512-r4UlwHBgr/zXF8wQ+j87HZOGIa+hnHMF9vMYjHNigS3kH48qlv/jiek409DG70cDavSI3CqBvDMjco1eILw4Lw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.1.1.tgz",
+			"integrity": "sha512-z7v8HVTc0LtWiGz+1w2lK3QBkha2DsczMrtxprBi7o31wxqgryE5BqKfVvMmUjJPMo+dY0572Z1vBG0r9wlmOQ==",
 			"requires": {
 				"@esfx/async-canceltoken": "^1.0.0-pre.13",
-				"@esfx/cancelable": "^1.0.0-pre.13",
-				"prex": "^0.4.7"
+				"@esfx/cancelable": "^1.0.0-pre.13"
 			}
 		},
 		"growl": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"chalk": "^1.1.3",
 		"ecmarkdown": "^6.0.0",
 		"eslint": "^6.8.0",
-		"grammarkdown": "^2.2.1",
+		"grammarkdown": "^3.1.1",
 		"highlight.js": "^9.17.1",
 		"html-escape": "^1.0.2",
 		"js-yaml": "^3.13.1",

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -20,7 +20,7 @@ function findLabeledSteps(root: EcmarkdownNode) {
 
 /*@internal*/
 export default class Algorithm extends Builder {
-  static enter(context: Context) {
+  static async enter(context: Context) {
     context.inAlg = true;
     const { spec, node } = context;
 

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -35,7 +35,7 @@ export default class Builder {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static enter(context: Context): void {
+  static async enter(context: Context) {
     throw new Error('Builder not implemented');
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -105,7 +105,7 @@ export default class Clause extends Builder {
     this.header.appendChild(utilsElem);
   }
 
-  static enter({ spec, node, clauseStack, clauseNumberer }: Context) {
+  static async enter({ spec, node, clauseStack, clauseNumberer }: Context) {
     if (!node.id) {
       spec.warn({
         type: 'node',

--- a/src/Dfn.ts
+++ b/src/Dfn.ts
@@ -5,7 +5,7 @@ import Builder from './Builder';
 
 /*@internal*/
 export default class Dfn extends Builder {
-  static enter({ spec, node, clauseStack }: Context) {
+  static async enter({ spec, node, clauseStack }: Context) {
     const parentClause = clauseStack[clauseStack.length - 1];
     if (!parentClause) return;
 

--- a/src/Eqn.ts
+++ b/src/Eqn.ts
@@ -37,7 +37,7 @@ export default class Eqn extends Builder {
     }
   }
 
-  static enter(context: Context) {
+  static async enter(context: Context) {
     const { spec, node, clauseStack } = context;
     const clause = clauseStack[clauseStack.length - 1];
     const id = clause ? clause.id : ''; // TODO: no eqns outside of clauses, eh?

--- a/src/Example.ts
+++ b/src/Example.ts
@@ -20,7 +20,7 @@ export default class Example extends Builder {
     }
   }
 
-  static enter({ spec, node, clauseStack }: Context) {
+  static async enter({ spec, node, clauseStack }: Context) {
     const clause = clauseStack[clauseStack.length - 1];
     if (!clause) return; // don't process examples outside of clauses
     clause.examples.push(new Example(spec, node, clause));

--- a/src/Figure.ts
+++ b/src/Figure.ts
@@ -46,7 +46,7 @@ export default class Figure extends Builder {
     }
   }
 
-  static enter({ spec, node }: Context) {
+  static async enter({ spec, node }: Context) {
     const figure = new Figure(spec, node);
     if (figure.captionElem && figure.captionElem.parentNode) {
       figure.captionElem.parentNode.removeChild(figure.captionElem);

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -8,7 +8,7 @@ const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/gi;
 
 /*@internal*/
 export default class Grammar extends Builder {
-  static enter({ spec, node }: Context) {
+  static async enter({ spec, node }: Context) {
     if ('grammarkdownOut' in node) {
       // i.e., we already parsed this during the lint phase
       // @ts-ignore
@@ -62,7 +62,7 @@ export default class Grammar extends Builder {
       noChecks: true,
     };
 
-    node.innerHTML = GrammarFile.convert(
+    node.innerHTML = await GrammarFile.convert(
       content,
       options,
       /*hostFallback*/ undefined,

--- a/src/H1.ts
+++ b/src/H1.ts
@@ -4,7 +4,7 @@ import Builder from './Builder';
 
 /*@internal*/
 export default class H1 extends Builder {
-  static enter({ node, clauseStack }: Context) {
+  static async enter({ node, clauseStack }: Context) {
     const clause = clauseStack[clauseStack.length - 1];
     if (clause && !clause.header) {
       clause.header = node as HTMLHeadingElement;

--- a/src/NonTerminal.ts
+++ b/src/NonTerminal.ts
@@ -21,7 +21,7 @@ export default class NonTerminal extends Builder {
     this.namespace = namespace;
   }
 
-  static enter({ spec, node, clauseStack }: Context) {
+  static async enter({ spec, node, clauseStack }: Context) {
     const clause = clauseStack[clauseStack.length - 1];
     const namespace = clause ? clause.namespace : spec.namespace;
     const nt = new NonTerminal(spec, node, namespace);

--- a/src/Note.ts
+++ b/src/Note.ts
@@ -25,7 +25,7 @@ export default class Note extends Builder {
     }
   }
 
-  static enter({ spec, node, clauseStack }: Context) {
+  static async enter({ spec, node, clauseStack }: Context) {
     const clause = clauseStack[clauseStack.length - 1];
 
     // TODO reconsider

--- a/src/ProdRef.ts
+++ b/src/ProdRef.ts
@@ -19,7 +19,7 @@ export default class ProdRef extends Builder {
     this.name = node.getAttribute('name')!;
   }
 
-  static enter({ node, spec, clauseStack }: Context) {
+  static async enter({ node, spec, clauseStack }: Context) {
     const clause = clauseStack[clauseStack.length - 1];
     const namespace = clause ? clause.namespace : spec.namespace;
     const prodref = new ProdRef(spec, node, namespace);

--- a/src/Production.ts
+++ b/src/Production.ts
@@ -86,7 +86,7 @@ export default class Production extends Builder {
     }
   }
 
-  static enter({ spec, node, clauseStack }: Context) {
+  static async enter({ spec, node, clauseStack }: Context) {
     const ntNode = spec.doc.createElement('emu-nt');
     const clause = clauseStack[clauseStack.length - 1];
     const prod = new Production(spec, node, clause ? clause.namespace : spec.namespace);

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -394,12 +394,12 @@ export default class Spec {
       if (source === undefined) {
         throw new Error('Cannot lint when source text is not available');
       }
-      lint(this.warn, source, this, document);
+      await lint(this.warn, source, this, document);
     }
 
     const walker = document.createTreeWalker(document.body, 1 | 4 /* elements and text nodes */);
 
-    walk(walker, context);
+    await walk(walker, context);
 
     this.setReplacementAlgorithmOffsets();
 
@@ -1004,7 +1004,7 @@ async function loadImports(spec: Spec, rootElement: HTMLElement, rootPath: strin
   }
 }
 
-function walk(walker: TreeWalker, context: Context) {
+async function walk(walker: TreeWalker, context: Context) {
   // When we set either of these states we need to know to unset when we leave the element.
   let changedInNoAutolink = false;
   let changedInNoEmd = false;
@@ -1091,12 +1091,14 @@ function walk(walker: TreeWalker, context: Context) {
   }
 
   const visitor = visitorMap[context.node.nodeName];
-  if (visitor) visitor.enter(context);
+  if (visitor) {
+    await visitor.enter(context);
+  }
 
   const firstChild = walker.firstChild();
   if (firstChild) {
     while (true) {
-      walk(walker, context);
+      await walk(walker, context);
       const next = walker.nextSibling();
       if (!next) break;
     }

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -32,7 +32,7 @@ export default class Xref extends Builder {
     this.id = node.getAttribute('id')!;
   }
 
-  static enter({ node, spec, clauseStack }: Context) {
+  static async enter({ node, spec, clauseStack }: Context) {
     const href = node.getAttribute('href')!;
     const aoid = node.getAttribute('aoid')!;
     const parentClause = clauseStack[clauseStack.length - 1];

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -18,7 +18,7 @@ Currently this checks
 There's more to do:
 https://github.com/tc39/ecmarkup/issues/173
 */
-export function lint(
+export async function lint(
   report: (err: Warning) => void,
   sourceText: string,
   spec: Spec,
@@ -30,7 +30,7 @@ export function lint(
   }
   let { mainGrammar, headers, sdos, earlyErrors, algorithms } = collection;
 
-  let { grammar } = collectGrammarDiagnostics(
+  let { grammar } = await collectGrammarDiagnostics(
     report,
     spec,
     sourceText,
@@ -48,7 +48,7 @@ export function lint(
   // Stash intermediate results for later use
   // This isn't actually necessary for linting, but we might as well avoid redoing work later when we can.
 
-  grammar.emitSync(undefined, (file, source) => {
+  await grammar.emit(undefined, (file, source) => {
     let name = +file.split('.')[0];
     let node = mainGrammar[name].element;
     if ('grammarkdownOut' in node) {

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -114,7 +114,7 @@ function symbolMatches(a: LexicalSymbol, b: LexicalSymbol): boolean {
   }
   switch (a.kind) {
     case SyntaxKind.Terminal:
-      return a.text === (b as Terminal).text;
+      return a.literal.text === (b as Terminal).literal.text;
     case SyntaxKind.Nonterminal:
       if (a.argumentList !== undefined) {
         if ((b as Nonterminal).argumentList === undefined) {

--- a/test/baselines/reference/duplicate-productions.html
+++ b/test/baselines/reference/duplicate-productions.html
@@ -3,10 +3,12 @@
 <emu-production name="Prod"><emu-nt><a href="#prod-Prod">Prod</a></emu-nt><emu-geq>:</emu-geq></emu-production>
 <emu-grammar><emu-production name="GMD" type="lexical">
     <emu-nt><a href="#prod-GMD">GMD</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a29056ec"><emu-nt>Test</emu-nt><emu-t>bar</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 
 <emu-production name="Prod" primary="" id="prod-Prod"><emu-nt><a href="#prod-Prod">Prod</a></emu-nt><emu-geq>:</emu-geq></emu-production>
 <emu-grammar primary=""><emu-production name="GMD" type="lexical" id="prod-GMD">
     <emu-nt><a href="#prod-GMD">GMD</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a29056ec"><emu-nt>Test</emu-nt><emu-t>bar</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 </div></body>

--- a/test/baselines/reference/grammar.html
+++ b/test/baselines/reference/grammar.html
@@ -16,13 +16,16 @@
 </emu-production>
 <emu-production name="HTMLEntitiesExample" type="lexical" id="prod-HTMLEntitiesExample">
     <emu-nt><a href="#prod-HTMLEntitiesExample">HTMLEntitiesExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="23da2165"><emu-gprose>This is technically a “production”</emu-gprose></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 
 <p>Can also have inline productions like <emu-grammar><emu-production name="Atom" type="lexical" collapsed="" id="prod-Atom" class=" inline">
     <emu-nt><a href="#prod-Atom">Atom</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="34eb148f"><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Disjunction">Disjunction</a></emu-nt><emu-t>)</emu-t></emu-rhs>
-</emu-production></emu-grammar>.</p>
+</emu-production>
+</emu-grammar>.</p>
 
 <emu-alg><ol><li>Can also have productions in steps.</li><li>Example is <emu-grammar><emu-production name="Atom" type="lexical" collapsed="" class=" inline">
     <emu-nt><a href="#prod-Atom">Atom</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="34eb148f"><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Disjunction">Disjunction</a></emu-nt><emu-t>)</emu-t></emu-rhs>
-</emu-production></emu-grammar>.</li></ol></emu-alg>
+</emu-production>
+</emu-grammar>.</li></ol></emu-alg>
 </div></body>

--- a/test/baselines/reference/imports.html
+++ b/test/baselines/reference/imports.html
@@ -10,7 +10,8 @@
   wtf??
   <emu-grammar><emu-production name="A" collapsed="" id="prod-A">
     <emu-nt><a href="#prod-A">A</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 </emu-clause></emu-import>
 </emu-clause></emu-import>
 <emu-import href="imports/import2.html"><emu-clause id="import2">

--- a/test/baselines/reference/namespaces-productions.html
+++ b/test/baselines/reference/namespaces-productions.html
@@ -5,10 +5,12 @@
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-intro-Foo">
     <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
     <emu-rhs a="ef94182a"><emu-t>baz</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
   <emu-grammar><emu-production name="Foo" type="lexical" collapsed="">
     <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
   <emu-production name="Foo" type="lexical">
     <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
     <emu-rhs a="ef94182a"><emu-t>baz</emu-t></emu-rhs>
@@ -23,10 +25,12 @@
 </emu-production>
 <emu-production name="Statement" type="lexical" id="prod-Statement">
     <emu-nt><a href="#prod-Statement">Statement</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="7a15a54c"><emu-t>overridden statement</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
   <emu-grammar><emu-production name="Foo" type="lexical" collapsed="">
     <emu-nt><a href="#prod-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
   <emu-production name="Foo" type="lexical">
     <emu-nt><a href="#prod-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
     <emu-rhs a="8c98539e"><emu-t>qux</emu-t></emu-rhs>

--- a/test/baselines/reference/namespaces.html
+++ b/test/baselines/reference/namespaces.html
@@ -4,7 +4,8 @@
   <h1 class="first">Intro</h1>
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-intro-Foo">
     <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f944fd2f"><emu-t>bar</emu-t><emu-nt id="_ref_7"><a href="#prod-MainProd">MainProd</a></emu-nt><emu-t>baz</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 </emu-intro>
 <emu-clause id="c1">
   <h1><span class="secnum">1</span> Clause 1</h1>
@@ -13,13 +14,15 @@
 </emu-production>
 <emu-production name="MainProd" type="lexical" id="prod-MainProd">
     <emu-nt><a href="#prod-MainProd">MainProd</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="201a6b30"><emu-nt id="_ref_9"><a href="#prod-Foo">Foo</a></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
   <emu-clause id="c11" namespace="clause">
     <h1><span class="secnum">1.1</span> Clause 1.1</h1>
 
     <emu-grammar><emu-production name="Foo" type="lexical" id="prod-clause-Foo">
     <emu-nt><a href="#prod-clause-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f944fd2f"><emu-t>bar</emu-t><emu-nt id="_ref_10"><a href="#prod-MainProd">MainProd</a></emu-nt><emu-t>baz</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 
     <emu-clause id="c111" aoid="SomeAlg">
       <h1><span class="secnum">1.1.1</span> SomeAlg</h1>
@@ -34,7 +37,8 @@
   <h1><span class="secnum">A</span> Annex</h1>
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-annex-Foo">
     <emu-nt><a href="#prod-annex-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f944fd2f"><emu-t>bar</emu-t><emu-nt id="_ref_11"><a href="#prod-annex-MainProd">MainProd</a></emu-nt><emu-t>baz</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
   <emu-annex id="annex11" aoid="SomeAlg">
     <h1><span class="secnum">A.1</span> SomeAlg</h1>
   </emu-annex>
@@ -55,7 +59,8 @@
   </emu-annex>
   <emu-grammar><emu-production name="MainProd" type="lexical" id="prod-annex-MainProd">
     <emu-nt><a href="#prod-annex-MainProd">MainProd</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="201a6b30"><emu-nt id="_ref_13"><a href="#prod-annex-Foo">Foo</a></emu-nt></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
   <p><emu-xref aoid="SomeAlg" id="_ref_6"><a href="#annex21">SomeAlg</a></emu-xref> does things.</p>
 </emu-annex>
 </div></body>

--- a/test/baselines/reference/test.html
+++ b/test/baselines/reference/test.html
@@ -33,7 +33,8 @@
   wtf??
   <emu-grammar><emu-production name="A" collapsed="" id="prod-A">
     <emu-nt><a href="#prod-A">A</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 </emu-clause></emu-import>
 </emu-clause></emu-import>
 
@@ -93,20 +94,18 @@
   <emu-production name="ArgumentList" a="a" collapsed="">
     <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="a"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs></emu-production>
 
-  <emu-grammar><emu-production name="FooBar" params="Yeild" type="lexical" id="prod-FooBar">
-    <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs>
-    <emu-rhs a="b"><emu-t>baz</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+  <emu-grammar><emu-production name="FooBar" collapsed="" id="prod-FooBar">
+    <emu-nt><a href="#prod-FooBar">FooBar</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="65ec8929"><emu-nt>Yeild</emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
 
-  <emu-grammar><emu-production name="FooBarBaz" params="Yeild" type="regexp" id="prod-FooBarBaz">
-    <emu-nt params="Yeild"><a href="#prod-FooBarBaz">FooBarBaz</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>:::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs>
-    <emu-rhs a="b"><emu-t>baz</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+  <emu-grammar><emu-production name="FooBarBaz" collapsed="" id="prod-FooBarBaz">
+    <emu-nt><a href="#prod-FooBarBaz">FooBarBaz</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="65ec8929"><emu-nt>Yeild</emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
 
-  <emu-production name="FooBar" params="Yeild" type="lexical" a="a" collapsed="">
-    <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs></emu-production>
-  <p>Inline prodref: <emu-production name="FooBar" params="Yeild" type="lexical" a="a" collapsed="" class=" inline">
-    <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs></emu-production></p>
+  <emu-prodref name="FooBar" a="a" collapsed=""></emu-prodref>
+  <p>Inline prodref: <emu-prodref name="FooBar" a="a" collapsed="" class=" inline"></emu-prodref></p>
 
   <pre><code class="language-javascript hljs"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">test</span>(<span class="hljs-params"></span>) </span>{ };
 test();</code></pre>
@@ -118,7 +117,8 @@ test();</code></pre>
   <!-- test block collapsed emu-grammar -->
   <emu-grammar><emu-production name="FunctionDeclaration" collapsed="" id="prod-FunctionDeclaration">
     <emu-nt><a href="#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="81739a57"><emu-t>function</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-BindingIdentifier">BindingIdentifier</a></emu-nt><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-FormalParameters">FormalParameters</a></emu-nt><emu-t>)</emu-t><emu-t>{</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionBody">FunctionBody</a></emu-nt><emu-t>}</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 
   <p>Test <emu-nt params="WithParams">NonTerminal<emu-mods><emu-params>[WithParams]</emu-params></emu-mods></emu-nt> and <emu-nt optional="">NonTerminal<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>.</p>
 </emu-clause>

--- a/test/baselines/reference/xref.html
+++ b/test/baselines/reference/xref.html
@@ -103,5 +103,6 @@
 
 <emu-grammar><emu-production name="TestProduction" type="lexical" id="prod-TestProduction">
     <emu-nt><a href="#prod-TestProduction">TestProduction</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="1"><emu-t>np</emu-t><emu-t>np</emu-t></emu-rhs>
-</emu-production></emu-grammar>
+</emu-production>
+</emu-grammar>
 </div></body>


### PR DESCRIPTION
Grammarkdown had a 3.0 release a while back, which drops the ability to synchronously process grammars. This PR is mostly just sprinkling some `async`/`await`s, plus a couple of very minor tweaks.