### PR TITLE
add copyable/searchable whitespace to rendered grammar nodes

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -204,9 +204,15 @@ emu-grammar[type="definition"] emu-production {
 
 emu-grammar.inline, emu-production.inline,
 emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
+emu-grammar[collapsed] emu-production emu-rhs {
     display: inline;
     padding-left: 1ex;
+    margin-left: 0;
+}
+
+emu-production[collapsed] emu-rhs {
+    display: inline;
+    padding-left: .5ex;
     margin-left: 0;
 }
 
@@ -216,11 +222,11 @@ emu-grammar[collapsed] emu-production, emu-production[collapsed] {
 
 emu-constraints {
     font-size: .75em;
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-gann emu-t:last-child,
@@ -230,13 +236,13 @@ emu-gann emu-nt:last-child {
 }
 
 emu-geq {
-    margin-left: 1ex;
+    margin-left: .5ex;
     font-weight: bold;
 }
 
 emu-oneof {
     font-weight: bold;
-    margin-left: 1ex;
+    margin-left: .5ex;
 }
 
 emu-nt {
@@ -251,7 +257,7 @@ emu-nt a, emu-nt a:visited {
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-t {
@@ -263,7 +269,7 @@ emu-t {
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-rhs {

--- a/docs/elements.css
+++ b/docs/elements.css
@@ -204,9 +204,15 @@ emu-grammar[type="definition"] emu-production {
 
 emu-grammar.inline, emu-production.inline,
 emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
+emu-grammar[collapsed] emu-production emu-rhs {
     display: inline;
     padding-left: 1ex;
+    margin-left: 0;
+}
+
+emu-production[collapsed] emu-rhs {
+    display: inline;
+    padding-left: .5ex;
     margin-left: 0;
 }
 
@@ -216,11 +222,11 @@ emu-grammar[collapsed] emu-production, emu-production[collapsed] {
 
 emu-constraints {
     font-size: .75em;
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-gann emu-t:last-child,
@@ -230,13 +236,13 @@ emu-gann emu-nt:last-child {
 }
 
 emu-geq {
-    margin-left: 1ex;
+    margin-left: .5ex;
     font-weight: bold;
 }
 
 emu-oneof {
     font-weight: bold;
-    margin-left: 1ex;
+    margin-left: .5ex;
 }
 
 emu-nt {
@@ -251,7 +257,7 @@ emu-nt a, emu-nt a:visited {
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-t {
@@ -263,7 +269,7 @@ emu-t {
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-rhs {

--- a/docs/index.html
+++ b/docs/index.html
@@ -398,7 +398,7 @@ toc: false
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
 
   <emu-production name="WhileStatement" id="prod-WhileStatement">
-    <emu-nt><a href="#prod-WhileStatement">WhileStatement</a></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-t>while</emu-t><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt><emu-t>)</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Statement">Statement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-WhileStatement">WhileStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs><emu-t>while</emu-t> <emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt> <emu-t>)</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Statement">Statement</a></emu-nt></emu-rhs>
   </emu-production>
 
   <b>ArgumentList</b>
@@ -408,7 +408,7 @@ toc: false
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
 
   <emu-production name="ArgumentList" id="prod-ArgumentList">
-    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
 
     <emu-rhs><emu-nt id="_ref_22"><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><emu-t>,</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
   </emu-production>
@@ -419,7 +419,7 @@ toc: false
   <span class="hljs-tag">&lt;<span class="hljs-name">emu-nt</span> <span class="hljs-attr">optional</span>&gt;</span>Expression<span class="hljs-tag">&lt;/<span class="hljs-name">emu-nt</span>&gt;</span> ) <span class="hljs-tag">&lt;<span class="hljs-name">emu-nt</span>&gt;</span>Statement<span class="hljs-tag">&lt;/<span class="hljs-name">emu-nt</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">emu-rhs</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
   <emu-production name="IterationStatement" id="prod-IterationStatement">
-    <emu-nt><a href="#prod-IterationStatement">IterationStatement</a></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-t>for</emu-t><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-LexicalDeclaration">LexicalDeclaration</a></emu-nt><emu-t>;</emu-t><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-t>;</emu-t><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-t>)</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Statement">Statement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-IterationStatement">IterationStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs><emu-t>for</emu-t> <emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-LexicalDeclaration">LexicalDeclaration</a></emu-nt> <emu-t>;</emu-t><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt> <emu-t>;</emu-t><emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt> <emu-t>)</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Statement">Statement</a></emu-nt></emu-rhs>
   </emu-production>
 
   <b>Identifier</b>
@@ -428,7 +428,7 @@ toc: false
   <span class="hljs-tag">&lt;<span class="hljs-name">emu-nt</span>&gt;</span>ReservedWord<span class="hljs-tag">&lt;/<span class="hljs-name">emu-nt</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">emu-gmod</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">emu-rhs</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
   <emu-production name="Identifier" type="lexical" id="prod-Identifier">
-    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt><emu-gmod>but not
+    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt> <emu-gmod>but not
     <emu-nt><a href="https://tc39.es/ecma262/#prod-ReservedWord">ReservedWord</a></emu-nt></emu-gmod></emu-rhs>
   </emu-production>
 
@@ -437,7 +437,7 @@ toc: false
   <span class="hljs-tag">&lt;<span class="hljs-name">emu-rhs</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">emu-gprose</span>&gt;</span>any Unicode code point<span class="hljs-tag">&lt;/<span class="hljs-name">emu-gprose</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">emu-rhs</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
   <emu-production name="SourceCharacter" type="lexical" id="prod-SourceCharacter">
-    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-gprose>any Unicode code point</emu-gprose></emu-rhs>
+    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs><emu-gprose>any Unicode code point</emu-gprose></emu-rhs>
   </emu-production>
 
   <b>ExpressionStatement</b>
@@ -452,12 +452,14 @@ toc: false
   <span class="hljs-tag">&lt;/<span class="hljs-name">emu-rhs</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
   <emu-production name="ExpressionStatement" params="Yield" id="prod-ExpressionStatement">
-    <emu-nt params="Yield"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield]</emu-params></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-gann>[lookahead ∉ {
+    <emu-nt params="Yield"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs>
+      <emu-gann>[lookahead ∉ {
         <emu-t>{</emu-t>,
         <emu-t>function</emu-t>,
         <emu-t>class</emu-t>,
         <emu-t>let [</emu-t>
-      }]</emu-gann></emu-rhs>
+      }]</emu-gann>
+    </emu-rhs>
   </emu-production>
 
   <b>DecimalDigit</b>
@@ -465,7 +467,7 @@ toc: false
   <span class="hljs-tag">&lt;<span class="hljs-name">emu-rhs</span>&gt;</span>0 1 2 3 4 5 6 7 8 9<span class="hljs-tag">&lt;/<span class="hljs-name">emu-rhs</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
   <emu-production name="DecimalDigit" type="lexical" oneof="" id="prod-DecimalDigit">
-    <emu-nt><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt><emu-geq>::</emu-geq><emu-oneof>one of</emu-oneof><emu-rhs><emu-t>0</emu-t><emu-t>1</emu-t><emu-t>2</emu-t><emu-t>3</emu-t><emu-t>4</emu-t><emu-t>5</emu-t><emu-t>6</emu-t><emu-t>7</emu-t><emu-t>8</emu-t><emu-t>9</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt> <emu-geq>::</emu-geq> <emu-oneof>one of</emu-oneof> <emu-rhs><emu-t>0</emu-t> <emu-t>1</emu-t> <emu-t>2</emu-t> <emu-t>3</emu-t> <emu-t>4</emu-t> <emu-t>5</emu-t> <emu-t>6</emu-t> <emu-t>7</emu-t> <emu-t>8</emu-t> <emu-t>9</emu-t></emu-rhs>
   </emu-production>
 
   <b>StatementList</b>
@@ -474,7 +476,7 @@ toc: false
   <span class="hljs-tag">&lt;<span class="hljs-name">emu-rhs</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">emu-nt</span>&gt;</span>ExpressionStatement<span class="hljs-tag">&lt;/<span class="hljs-name">emu-nt</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">emu-rhs</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">emu-production</span>&gt;</span></code></pre>
   <emu-production name="StatementList" params="Return, In" id="prod-StatementList">
-    <emu-nt params="Return, In"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-params>[Return, In]</emu-params></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs constraints="~Return"><emu-constraints>[~Return]</emu-constraints><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
+    <emu-nt params="Return, In"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-params>[Return, In]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs constraints="~Return"><emu-constraints>[~Return]</emu-constraints><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
     <emu-rhs><emu-nt id="_ref_23"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
   </emu-production>
 
@@ -578,7 +580,7 @@ toc: false
     <h3>Result:</h3>
     <p><emu-nt id="_ref_24"><a href="#prod-HoistableDeclaration">HoistableDeclaration</a></emu-nt> is modified as follows:</p>
     <emu-production name="HoistableDeclaration" id="prod-HoistableDeclaration">
-      <emu-nt><a href="#prod-HoistableDeclaration">HoistableDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
+      <emu-nt><a href="#prod-HoistableDeclaration">HoistableDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
       <emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-GeneratorDeclaration">GeneratorDeclaration</a></emu-nt></emu-rhs>
       <ins class="block"><emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-AsyncFunctionDeclaration">AsyncFunctionDeclaration</a></emu-nt></emu-rhs></ins>
     </emu-production>

--- a/src/Production.ts
+++ b/src/Production.ts
@@ -104,12 +104,15 @@ export default class Production extends Builder {
       geq.textContent = ':';
     }
 
+    node.insertBefore(spec.doc.createTextNode(' '), ntNode.nextSibling);
     node.insertBefore(geq, ntNode.nextSibling);
+    node.insertBefore(spec.doc.createTextNode(' '), ntNode.nextSibling);
 
     if (prod.oneOf) {
       const elem = spec.doc.createElement('emu-oneof');
       elem.textContent = 'one of';
       node.insertBefore(elem, geq.nextSibling);
+      node.insertBefore(spec.doc.createTextNode(' '), elem);
     }
 
     prod.rhses.forEach(rhs => rhs.build());

--- a/src/RHS.ts
+++ b/src/RHS.ts
@@ -53,15 +53,33 @@ export default class RHS extends Builder {
         }
       }
     }
+    let first = true;
     for (let { parent, child } of pairs) {
+      if (!first && !/^\s+$/.test(child.textContent ?? '')) {
+        if (parent === parentNode) {
+          parentNode.insertBefore(this.spec.doc.createTextNode(' '), child);
+        } else {
+          // put the space outside of `<ins>` (etc) tags
+          parentNode.insertBefore(this.spec.doc.createTextNode(' '), parent);
+        }
+      }
+      first = false;
       this.wrapTerminal(parent, child);
     }
   }
 
   private wrapTerminal(parentNode: Element, node: Text) {
-    const text = node.textContent!.trim();
+    const textContent = node.textContent!;
+    const text = textContent.trim();
+
+    if (text === '' && textContent.length > 0) {
+      // preserve intermediate whitespace
+      return;
+    }
+
     const pieces = text.split(/\s/);
 
+    let first = true;
     pieces.forEach(p => {
       if (p.length === 0) {
         return;
@@ -70,6 +88,10 @@ export default class RHS extends Builder {
       est.textContent = p;
 
       parentNode.insertBefore(est, node);
+      if (!first) {
+        parentNode.insertBefore(this.spec.doc.createTextNode(' '), est);
+      }
+      first = false;
     });
 
     parentNode.removeChild(node);

--- a/test/baselines/reference/duplicate-productions.html
+++ b/test/baselines/reference/duplicate-productions.html
@@ -1,14 +1,20 @@
 <!doctype html>
 <head><meta charset="utf-8"></head><body><div id="spec-container">
-<emu-production name="Prod"><emu-nt><a href="#prod-Prod">Prod</a></emu-nt><emu-geq>:</emu-geq></emu-production>
+<emu-production name="Prod"><emu-nt><a href="#prod-Prod">Prod</a></emu-nt> <emu-geq>:</emu-geq> </emu-production>
 <emu-grammar><emu-production name="GMD" type="lexical">
-    <emu-nt><a href="#prod-GMD">GMD</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a29056ec"><emu-nt>Test</emu-nt><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-GMD">GMD</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="a29056ec">
+        <emu-nt>Test</emu-nt>
+        <emu-t>bar</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 
-<emu-production name="Prod" primary="" id="prod-Prod"><emu-nt><a href="#prod-Prod">Prod</a></emu-nt><emu-geq>:</emu-geq></emu-production>
+<emu-production name="Prod" primary="" id="prod-Prod"><emu-nt><a href="#prod-Prod">Prod</a></emu-nt> <emu-geq>:</emu-geq> </emu-production>
 <emu-grammar primary=""><emu-production name="GMD" type="lexical" id="prod-GMD">
-    <emu-nt><a href="#prod-GMD">GMD</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a29056ec"><emu-nt>Test</emu-nt><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-GMD">GMD</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="a29056ec">
+        <emu-nt>Test</emu-nt>
+        <emu-t>bar</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 </div></body>

--- a/test/baselines/reference/grammar.html
+++ b/test/baselines/reference/grammar.html
@@ -3,32 +3,62 @@
 </head><body><div id="spec-container">
 
 <emu-grammar><emu-production name="FooTerminal" id="prod-FooTerminal">
-    <emu-nt><a href="#prod-FooTerminal">FooTerminal</a></emu-nt><emu-geq>:</emu-geq><ins><emu-rhs a="5422ad14"><emu-nt>Inserting</emu-nt><emu-t>anRHS</emu-t></emu-rhs></ins>
-    <del><emu-rhs a="34727095"><emu-nt>Deleting</emu-nt><emu-t>anRHS</emu-t></emu-rhs></del>
-    <emu-rhs a="18458a59"><emu-nt>Modifying</emu-nt><ins><emu-nt>Existing</emu-nt></ins><del><emu-nt>Old</emu-nt></del><emu-nt>Production</emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-FooTerminal">FooTerminal</a></emu-nt> <emu-geq>:</emu-geq> <ins><emu-rhs a="5422ad14">
+        <emu-nt>Inserting</emu-nt>
+        <emu-t>anRHS</emu-t>
+    </emu-rhs></ins>
+    <del><emu-rhs a="34727095">
+        <emu-nt>Deleting</emu-nt>
+        <emu-t>anRHS</emu-t>
+    </emu-rhs></del>
+    <emu-rhs a="18458a59">
+        <emu-nt>Modifying</emu-nt>
+        <ins><emu-nt>Existing</emu-nt></ins>
+        <del><emu-nt>Old</emu-nt></del>
+        <emu-nt>Production</emu-nt>
+    </emu-rhs>
 </emu-production>
 <ins><emu-production name="NewTerminal" id="prod-NewTerminal">
-    <emu-nt><a href="#prod-NewTerminal">NewTerminal</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="b1b8622b"><emu-t>t</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-NewTerminal">NewTerminal</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b1b8622b"><emu-t>t</emu-t></emu-rhs>
 </emu-production></ins>
 <emu-production name="LookaheadExample" type="lexical" id="prod-LookaheadExample">
-    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="d9a654c9"><emu-t>&amp;&amp;</emu-t><emu-t>n</emu-t><emu-gann>[lookahead ∉ { <emu-t>1</emu-t>, <emu-t>3</emu-t>, <emu-t>5</emu-t>, <emu-t>7</emu-t>, <emu-t>9</emu-t> }]</emu-gann><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt></emu-rhs>
-    <emu-rhs a="195cbc6c"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigit">DecimalDigit</a></emu-nt><emu-gann>[lookahead ∉ <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigit">DecimalDigit</a></emu-nt>]</emu-gann></emu-rhs>
+    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="d9a654c9">
+        <emu-t>&amp;&amp;</emu-t>
+        <emu-t>n</emu-t>
+        <emu-gann>[lookahead ∉ { <emu-t>1</emu-t>, <emu-t>3</emu-t>, <emu-t>5</emu-t>, <emu-t>7</emu-t>, <emu-t>9</emu-t> }]</emu-gann>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="195cbc6c">
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigit">DecimalDigit</a></emu-nt>
+        <emu-gann>[lookahead ∉ <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigit">DecimalDigit</a></emu-nt>]</emu-gann>
+    </emu-rhs>
 </emu-production>
 <emu-production name="HTMLEntitiesExample" type="lexical" id="prod-HTMLEntitiesExample">
-    <emu-nt><a href="#prod-HTMLEntitiesExample">HTMLEntitiesExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="23da2165"><emu-gprose>This is technically a “production”</emu-gprose></emu-rhs>
+    <emu-nt><a href="#prod-HTMLEntitiesExample">HTMLEntitiesExample</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="23da2165"><emu-gprose>This is technically a “production”</emu-gprose></emu-rhs>
 </emu-production>
 <emu-production name="ButOnlyExample" type="lexical" id="prod-ButOnlyExample">
-    <emu-nt><a href="#prod-ButOnlyExample">ButOnlyExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="5c6f47da"><emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt><emu-gmod>but only if the CapturingGroupNumber of <emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt> is &lt;= _NcapturingParens_</emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-ButOnlyExample">ButOnlyExample</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="5c6f47da">
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt>
+        <emu-gmod>but only if the CapturingGroupNumber of <emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt> is &lt;= _NcapturingParens_</emu-gmod>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 
 <p>Can also have inline productions like <emu-grammar><emu-production name="Atom" type="lexical" collapsed="" id="prod-Atom" class=" inline">
-    <emu-nt><a href="#prod-Atom">Atom</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="34eb148f"><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Disjunction">Disjunction</a></emu-nt><emu-t>)</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Atom">Atom</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="34eb148f">
+        <emu-t>(</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-Disjunction">Disjunction</a></emu-nt>
+        <emu-t>)</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>.</p>
 
 <emu-alg><ol><li>Can also have productions in steps.</li><li>Example is <emu-grammar><emu-production name="Atom" type="lexical" collapsed="" class=" inline">
-    <emu-nt><a href="#prod-Atom">Atom</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="34eb148f"><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Disjunction">Disjunction</a></emu-nt><emu-t>)</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Atom">Atom</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="34eb148f">
+        <emu-t>(</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-Disjunction">Disjunction</a></emu-nt>
+        <emu-t>)</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>.</li></ol></emu-alg>
 </div></body>

--- a/test/baselines/reference/imports.html
+++ b/test/baselines/reference/imports.html
@@ -9,7 +9,7 @@
   <h1><span class="secnum">1.1</span> Import 3</h1>
   wtf??
   <emu-grammar><emu-production name="A" collapsed="" id="prod-A">
-    <emu-nt><a href="#prod-A">A</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-A">A</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
 </emu-production>
 </emu-grammar>
 </emu-clause></emu-import>

--- a/test/baselines/reference/ins-nonterminal.html
+++ b/test/baselines/reference/ins-nonterminal.html
@@ -2,6 +2,6 @@
 <head><meta charset="utf-8"></head><body><div id="spec-container">
 
 <emu-production name="A" type="lexical" oneof="" id="prod-A">
-    <emu-nt><a href="#prod-A">A</a></emu-nt><emu-geq>::</emu-geq><emu-oneof>one of</emu-oneof><emu-rhs><del><emu-t>a</emu-t></del><emu-t>b</emu-t><emu-t>c</emu-t><mark><emu-t>d</emu-t></mark><ins><emu-t>e</emu-t><emu-t>f</emu-t></ins></emu-rhs>
+    <emu-nt><a href="#prod-A">A</a></emu-nt> <emu-geq>::</emu-geq> <emu-oneof>one of</emu-oneof> <emu-rhs><del><emu-t>a</emu-t></del> <emu-t>b</emu-t> <emu-t>c</emu-t> <mark><emu-t>d</emu-t></mark>  <ins><emu-t>e</emu-t> <emu-t>f</emu-t></ins></emu-rhs>
 </emu-production>
 </div></body>

--- a/test/baselines/reference/namespaces-productions.html
+++ b/test/baselines/reference/namespaces-productions.html
@@ -3,16 +3,16 @@
 <emu-intro id="intro" namespace="intro">
   <h1 class="first">Intro</h1>
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-intro-Foo">
-    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
     <emu-rhs a="ef94182a"><emu-t>baz</emu-t></emu-rhs>
 </emu-production>
 </emu-grammar>
   <emu-grammar><emu-production name="Foo" type="lexical" collapsed="">
-    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
 </emu-production>
 </emu-grammar>
   <emu-production name="Foo" type="lexical">
-    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
     <emu-rhs a="ef94182a"><emu-t>baz</emu-t></emu-rhs>
 </emu-production>
 </emu-intro>
@@ -20,19 +20,19 @@
 <emu-clause id="c">
   <h1><span class="secnum">1</span> C</h1>
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-Foo">
-    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
     <emu-rhs a="8c98539e"><emu-t>qux</emu-t></emu-rhs>
 </emu-production>
 <emu-production name="Statement" type="lexical" id="prod-Statement">
-    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="7a15a54c"><emu-t>overridden statement</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="7a15a54c"><emu-t>overridden statement</emu-t></emu-rhs>
 </emu-production>
 </emu-grammar>
   <emu-grammar><emu-production name="Foo" type="lexical" collapsed="">
-    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
 </emu-production>
 </emu-grammar>
   <emu-production name="Foo" type="lexical">
-    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="6f44da9e"><emu-t>bar</emu-t></emu-rhs>
     <emu-rhs a="8c98539e"><emu-t>qux</emu-t></emu-rhs>
 </emu-production>
 </emu-clause>

--- a/test/baselines/reference/namespaces.html
+++ b/test/baselines/reference/namespaces.html
@@ -3,24 +3,36 @@
 <emu-intro namespace="intro" aoid="SomeAlg" id="i1">
   <h1 class="first">Intro</h1>
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-intro-Foo">
-    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f944fd2f"><emu-t>bar</emu-t><emu-nt id="_ref_7"><a href="#prod-MainProd">MainProd</a></emu-nt><emu-t>baz</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-intro-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="f944fd2f">
+        <emu-t>bar</emu-t>
+        <emu-nt id="_ref_7"><a href="#prod-MainProd">MainProd</a></emu-nt>
+        <emu-t>baz</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 </emu-intro>
 <emu-clause id="c1">
   <h1><span class="secnum">1</span> Clause 1</h1>
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-Foo">
-    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f944fd2f"><emu-t>bar</emu-t><emu-nt id="_ref_8"><a href="#prod-MainProd">MainProd</a></emu-nt><emu-t>baz</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="f944fd2f">
+        <emu-t>bar</emu-t>
+        <emu-nt id="_ref_8"><a href="#prod-MainProd">MainProd</a></emu-nt>
+        <emu-t>baz</emu-t>
+    </emu-rhs>
 </emu-production>
 <emu-production name="MainProd" type="lexical" id="prod-MainProd">
-    <emu-nt><a href="#prod-MainProd">MainProd</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="201a6b30"><emu-nt id="_ref_9"><a href="#prod-Foo">Foo</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-MainProd">MainProd</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="201a6b30"><emu-nt id="_ref_9"><a href="#prod-Foo">Foo</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar>
   <emu-clause id="c11" namespace="clause">
     <h1><span class="secnum">1.1</span> Clause 1.1</h1>
 
     <emu-grammar><emu-production name="Foo" type="lexical" id="prod-clause-Foo">
-    <emu-nt><a href="#prod-clause-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f944fd2f"><emu-t>bar</emu-t><emu-nt id="_ref_10"><a href="#prod-MainProd">MainProd</a></emu-nt><emu-t>baz</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-clause-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="f944fd2f">
+        <emu-t>bar</emu-t>
+        <emu-nt id="_ref_10"><a href="#prod-MainProd">MainProd</a></emu-nt>
+        <emu-t>baz</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 
@@ -36,7 +48,11 @@
 <emu-annex id="annex1" namespace="annex">
   <h1><span class="secnum">A</span> Annex</h1>
   <emu-grammar><emu-production name="Foo" type="lexical" id="prod-annex-Foo">
-    <emu-nt><a href="#prod-annex-Foo">Foo</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f944fd2f"><emu-t>bar</emu-t><emu-nt id="_ref_11"><a href="#prod-annex-MainProd">MainProd</a></emu-nt><emu-t>baz</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-annex-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="f944fd2f">
+        <emu-t>bar</emu-t>
+        <emu-nt id="_ref_11"><a href="#prod-annex-MainProd">MainProd</a></emu-nt>
+        <emu-t>baz</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
   <emu-annex id="annex11" aoid="SomeAlg">
@@ -58,7 +74,7 @@
     <h1><span class="secnum">B.1</span> SomeAlg</h1>
   </emu-annex>
   <emu-grammar><emu-production name="MainProd" type="lexical" id="prod-annex-MainProd">
-    <emu-nt><a href="#prod-annex-MainProd">MainProd</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="201a6b30"><emu-nt id="_ref_13"><a href="#prod-annex-Foo">Foo</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-annex-MainProd">MainProd</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="201a6b30"><emu-nt id="_ref_13"><a href="#prod-annex-Foo">Foo</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar>
   <p><emu-xref aoid="SomeAlg" id="_ref_6"><a href="#annex21">SomeAlg</a></emu-xref> does things.</p>

--- a/test/baselines/reference/test.html
+++ b/test/baselines/reference/test.html
@@ -32,7 +32,7 @@
   <h1><span class="secnum">1.3.1</span> Import 3</h1>
   wtf??
   <emu-grammar><emu-production name="A" collapsed="" id="prod-A">
-    <emu-nt><a href="#prod-A">A</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-A">A</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
 </emu-production>
 </emu-grammar>
 </emu-clause></emu-import>
@@ -43,64 +43,77 @@
   <emu-note><span class="note">Note</span><div class="note-contents">Note!</div></emu-note>
 
   <emu-production name="WhileStatement" id="prod-WhileStatement">
-    <emu-nt><a href="#prod-WhileStatement">WhileStatement</a></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-t>while</emu-t><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt><emu-t>)</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Statement">Statement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-WhileStatement">WhileStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs><emu-t>while</emu-t> <emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt> <emu-t>)</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Statement">Statement</a></emu-nt></emu-rhs>
   </emu-production>
 
   <emu-production name="ArgumentList" id="prod-ArgumentList">
-    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="a"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
 
     <emu-rhs a="b"><emu-nt id="_ref_6"><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><emu-t>,</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
   </emu-production>
 
   <emu-production name="SourceCharacter" type="lexical" id="prod-SourceCharacter">
-    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-gprose>any Unicode code point</emu-gprose></emu-rhs>
+    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs><emu-gprose>any Unicode code point</emu-gprose></emu-rhs>
   </emu-production>
 
   <emu-production name="ExpressionStatement" params="Yield" id="prod-ExpressionStatement">
-    <emu-nt params="Yield"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield]</emu-params></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-gann>[lookahead ∉ {
+    <emu-nt params="Yield"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs>
+      <emu-gann>[lookahead ∉ {
         <emu-t>{</emu-t>,
         <emu-t>function</emu-t>,
         <emu-t>class</emu-t>,
         <emu-t>let [</emu-t>
-      }]</emu-gann></emu-rhs>
+      }]</emu-gann>
+    </emu-rhs>
   </emu-production>
 
   <emu-production name="StatementList" params="Return, In" id="prod-StatementList">
-    <emu-nt params="Return, In"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-params>[Return, In]</emu-params></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs constraints="~Return"><emu-constraints>[~Return]</emu-constraints><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
+    <emu-nt params="Return, In"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-params>[Return, In]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs constraints="~Return"><emu-constraints>[~Return]</emu-constraints><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
     <emu-rhs><emu-nt id="_ref_7"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
   </emu-production>
 
   <p>
     Inline production:
     <emu-production name="Identifier" type="lexical" collapsed="" id="prod-Identifier" class=" inline">
-      <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt><emu-gmod>but not
+      <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt> <emu-gmod>but not
       <emu-nt><a href="https://tc39.es/ecma262/#prod-ReservedWord">ReservedWord</a></emu-nt></emu-gmod></emu-rhs>
     </emu-production>
   </p>
 
   <emu-production name="EnumDeclaration" id="prod-EnumDeclaration">
-    <emu-nt><a href="#prod-EnumDeclaration">EnumDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-t optional="">const<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t><emu-t>enum</emu-t><emu-nt id="_ref_8"><a href="#prod-Identifier">Identifier</a></emu-nt><emu-t>{</emu-t><emu-nt optional="">EnumBody<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-t>}</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-EnumDeclaration">EnumDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs>
+      <emu-t optional="">const<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
+      <emu-t>enum</emu-t>
+      <emu-nt id="_ref_8"><a href="#prod-Identifier">Identifier</a></emu-nt>
+      <emu-t>{</emu-t>
+      <emu-nt optional="">EnumBody<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+      <emu-t>}</emu-t>
+    </emu-rhs>
   </emu-production>
   
   <!-- added for testing that prodref references first occurance -->
   <emu-production name="Identifier" type="lexical">
-    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-t>DummyIdentifier</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs><emu-t>DummyIdentifier</emu-t></emu-rhs>
   </emu-production>
 
   <emu-production name="Identifier" type="lexical" collapsed="" class=" inline">
-      <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt><emu-gmod>but not
+      <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt> <emu-gmod>but not
       <emu-nt><a href="https://tc39.es/ecma262/#prod-ReservedWord">ReservedWord</a></emu-nt></emu-gmod></emu-rhs>
     </emu-production>
   <emu-production name="ArgumentList" a="a" collapsed="">
-    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="a"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs></emu-production>
+    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs></emu-production>
 
   <emu-grammar><emu-production name="FooBar" collapsed="" id="prod-FooBar">
-    <emu-nt><a href="#prod-FooBar">FooBar</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="65ec8929"><emu-nt>Yeild</emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-FooBar">FooBar</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="65ec8929">
+        <emu-nt>Yeild</emu-nt>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 
   <emu-grammar><emu-production name="FooBarBaz" collapsed="" id="prod-FooBarBaz">
-    <emu-nt><a href="#prod-FooBarBaz">FooBarBaz</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="65ec8929"><emu-nt>Yeild</emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-FooBarBaz">FooBarBaz</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="65ec8929">
+        <emu-nt>Yeild</emu-nt>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 
@@ -116,7 +129,16 @@ test();</code></pre>
 
   <!-- test block collapsed emu-grammar -->
   <emu-grammar><emu-production name="FunctionDeclaration" collapsed="" id="prod-FunctionDeclaration">
-    <emu-nt><a href="#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="81739a57"><emu-t>function</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-BindingIdentifier">BindingIdentifier</a></emu-nt><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-FormalParameters">FormalParameters</a></emu-nt><emu-t>)</emu-t><emu-t>{</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionBody">FunctionBody</a></emu-nt><emu-t>}</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="81739a57">
+        <emu-t>function</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-BindingIdentifier">BindingIdentifier</a></emu-nt>
+        <emu-t>(</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-FormalParameters">FormalParameters</a></emu-nt>
+        <emu-t>)</emu-t>
+        <emu-t>{</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionBody">FunctionBody</a></emu-nt>
+        <emu-t>}</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 

--- a/test/baselines/reference/xref.html
+++ b/test/baselines/reference/xref.html
@@ -102,7 +102,10 @@
 </emu-clause>
 
 <emu-grammar><emu-production name="TestProduction" type="lexical" id="prod-TestProduction">
-    <emu-nt><a href="#prod-TestProduction">TestProduction</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="1"><emu-t>np</emu-t><emu-t>np</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-TestProduction">TestProduction</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="1">
+        <emu-t>np</emu-t>
+        <emu-t>np</emu-t>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 </div></body>


### PR DESCRIPTION
Fixes https://github.com/tc39/ecmarkup/issues/248.

I also tweaked the CSS so it renders pretty much identically, at least on the browsers I tried.

I attached a build of [ecma262](https://github.com/tc39/ecma262/tree/080c102ec86a4321ff262ec80bd35c71e0079adc) created from this branch, with assets included, so you can see for yourself. (You'll have to change the extension `.html` yourself; github doesn't let me upload a `.html` file directly.)

[spec-out.html.txt](https://github.com/tc39/ecmarkup/files/5611742/spec-out.html.txt)

