### PR TITLE
lint: some checks for legal tags/attributes

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -23,7 +23,7 @@ export default class Builder {
     if (nodeId !== null) {
       if (spec.nodeIds.has(nodeId)) {
         spec.warn({
-          type: 'attr',
+          type: 'attr-value',
           attr: 'id',
           ruleId: 'duplicate-id',
           message: `<${node.tagName.toLowerCase()}> has duplicate id ${JSON.stringify(nodeId)}`,

--- a/src/Note.ts
+++ b/src/Note.ts
@@ -72,7 +72,7 @@ export default class Note extends Builder {
       label = "Editor's Note";
     } else {
       this.spec.warn({
-        type: 'attr',
+        type: 'attr-value',
         attr: 'type',
         ruleId: 'invalid-note',
         message: `unknown note type ${JSON.stringify(this.type)}`,

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -100,6 +100,13 @@ export type Warning =
       message: string;
     }
   | {
+      type: 'attr-value';
+      node: Element;
+      attr: string;
+      ruleId: string;
+      message: string;
+    }
+  | {
       type: 'contents';
       node: Text | Element;
       ruleId: string;
@@ -158,6 +165,16 @@ function wrapWarn(source: string, spec: Spec, warn: (err: EcmarkupError) => void
         }
         break;
       case 'attr': {
+        let loc = spec.locate(e.node);
+        if (loc) {
+          file = loc.file;
+          source = loc.source;
+          ({ line, column } = utils.attrLocation(source, loc, e.attr));
+        }
+        nodeType = e.node.tagName.toLowerCase();
+        break;
+      }
+      case 'attr-value': {
         let loc = spec.locate(e.node);
         if (loc) {
           file = loc.file;
@@ -924,7 +941,7 @@ export default class Spec {
         let targetEntry = this.biblio.byId(target);
         if (targetEntry == null) {
           this.warn({
-            type: 'attr',
+            type: 'attr-value',
             attr: 'replaces-step',
             ruleId: 'invalid-replacement',
             message: `could not find step ${JSON.stringify(target)}`,
@@ -932,7 +949,7 @@ export default class Spec {
           });
         } else if (targetEntry.type !== 'step') {
           this.warn({
-            type: 'attr',
+            type: 'attr-value',
             attr: 'replaces-step',
             ruleId: 'invalid-replacement',
             message: `expected algorithm to replace a step, not a ${targetEntry.type}`,

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -78,7 +78,7 @@ export default class Xref extends Builder {
     if (href) {
       if (href[0] !== '#') {
         spec.warn({
-          type: 'attr',
+          type: 'attr-value',
           attr: 'href',
           ruleId: 'invalid-xref',
           message: `xref to anything other than a fragment id is not supported (is ${JSON.stringify(
@@ -94,7 +94,7 @@ export default class Xref extends Builder {
       this.entry = spec.biblio.byId(id);
       if (!this.entry) {
         spec.warn({
-          type: 'attr',
+          type: 'attr-value',
           attr: 'href',
           ruleId: 'xref-not-found',
           message: `can't find clause, production, note or example with id ${JSON.stringify(id)}`,
@@ -148,7 +148,7 @@ export default class Xref extends Builder {
       let namespaceSuffix =
         namespace === '<no location>' ? '' : ` in namespace ${JSON.stringify(namespace)}`;
       spec.warn({
-        type: 'attr',
+        type: 'attr-value',
         attr: 'aoid',
         ruleId: 'xref-not-found',
         message: `can't find abstract op with aoid ${JSON.stringify(aoid)}` + namespaceSuffix,
@@ -262,7 +262,7 @@ function buildStepLink(spec: Spec, xref: Element, entry: Biblio.StepBiblioEntry)
     let applicable = bullets[Math.min(i, 5)];
     if (s > applicable.length) {
       spec.warn({
-        type: 'attr',
+        type: 'attr-value',
         ruleId: 'high-step-number',
         message: `ecmarkup does not know how to deal with step numbers as high as ${s}; if you need this, open an issue on ecmarkup`,
         node: xref,

--- a/src/lint/collect-tag-diagnostics.ts
+++ b/src/lint/collect-tag-diagnostics.ts
@@ -1,0 +1,75 @@
+import type { default as Spec, Warning } from '../Spec';
+
+const ruleId = 'valid-tags';
+
+let knownEmuTags = new Set([
+  'emu-import',
+  'emu-example',
+  'emu-intro',
+  'emu-clause',
+  'emu-annex',
+  'emu-biblio',
+  'emu-xref',
+  'emu-prodref',
+  'emu-not-ref',
+  'emu-note',
+  'emu-eqn',
+  'emu-table',
+  'emu-figure',
+  'emu-caption',
+  'emu-grammar',
+  'emu-alg',
+  'emu-var',
+  'emu-val',
+  'emu-production',
+  'emu-rhs',
+  'emu-nt',
+  'emu-t',
+  'emu-gann',
+  'emu-gprose',
+  'emu-gmod',
+  'emu-normative-optional', // used in ecma-402
+  'emu-see-also-para', // TODO
+]);
+
+export function collectTagDiagnostics(
+  report: (e: Warning) => void,
+  spec: Spec,
+  document: Document
+) {
+  let lintWalker = document.createTreeWalker(document.body, 1 /* elements */);
+  function visit() {
+    let node: Element = lintWalker.currentNode as Element;
+    let name = node.tagName.toLowerCase();
+
+    if (name.startsWith('emu-') && !knownEmuTags.has(name)) {
+      report({
+        type: 'node',
+        ruleId,
+        message: `unknown "emu-" tag "${name}"`,
+        node,
+      });
+    }
+
+    if (node.hasAttribute('oldid')) {
+      report({
+        type: 'attr',
+        attr: 'oldid',
+        ruleId,
+        message: `"oldid" isn't a thing; did you mean "oldids"?`,
+        node,
+      });
+    }
+
+    let firstChild = lintWalker.firstChild();
+    if (firstChild) {
+      while (true) {
+        visit();
+        let next = lintWalker.nextSibling();
+        if (!next) break;
+      }
+      lintWalker.parentNode();
+    }
+  }
+  visit();
+}

--- a/src/lint/collect-tag-diagnostics.ts
+++ b/src/lint/collect-tag-diagnostics.ts
@@ -29,7 +29,6 @@ let knownEmuTags = new Set([
   'emu-gprose',
   'emu-gmod',
   'emu-normative-optional', // used in ecma-402
-  'emu-see-also-para', // TODO
 ]);
 
 export function collectTagDiagnostics(

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -5,6 +5,7 @@ import { collectGrammarDiagnostics } from './collect-grammar-diagnostics';
 import { collectSpellingDiagnostics } from './collect-spelling-diagnostics';
 import { collectAlgorithmDiagnostics } from './collect-algorithm-diagnostics';
 import { collectHeaderDiagnostics } from './collect-header-diagnostics';
+import { collectTagDiagnostics } from './collect-tag-diagnostics';
 
 /*
 Currently this checks
@@ -44,6 +45,8 @@ export async function lint(
   collectHeaderDiagnostics(report, headers);
 
   collectSpellingDiagnostics(report, sourceText, spec.imports);
+
+  collectTagDiagnostics(report, spec, document);
 
   // Stash intermediate results for later use
   // This isn't actually necessary for linting, but we might as well avoid redoing work later when we can.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,6 +187,19 @@ export function offsetToLineAndColumn(string: string, offset: number) {
   return { line: line + 1, column: column + 1 };
 }
 
+export function attrLocation(
+  source: string | undefined,
+  loc: MarkupData.ElementLocation,
+  attr: string
+) {
+  let attrLoc = loc.startTag.attrs[attr];
+  if (attrLoc == null) {
+    return { line: loc.startTag.line, column: loc.startTag.col };
+  } else {
+    return { line: attrLoc.line, column: attrLoc.col };
+  }
+}
+
 export function attrValueLocation(
   source: string | undefined,
   loc: MarkupData.ElementLocation,

--- a/test/lint-tags.js
+++ b/test/lint-tags.js
@@ -19,7 +19,7 @@ describe('tags', () => {
   it('oldid', async () => {
     await assertLint(
       positioned`
-        <emu-clause id="foo" oldid="${M}bar">
+        <emu-clause id="foo" ${M}oldid="bar">
           <h1>Example</h1>
         </emu-clause>
       `,

--- a/test/lint-tags.js
+++ b/test/lint-tags.js
@@ -1,0 +1,41 @@
+'use strict';
+
+let { assertLint, assertLintFree, positioned, lintLocationMarker: M } = require('./utils.js');
+
+describe('tags', () => {
+  it('unknown "emu-" tags', async () => {
+    await assertLint(
+      positioned`
+        ${M}<emu-not-a-thing>Foo</emu-not-a-thing>
+      `,
+      {
+        ruleId: 'valid-tags',
+        nodeType: 'emu-not-a-thing',
+        message: 'unknown "emu-" tag "emu-not-a-thing"',
+      }
+    );
+  });
+
+  it('oldid', async () => {
+    await assertLint(
+      positioned`
+        <emu-clause id="foo" oldid="${M}bar">
+          <h1>Example</h1>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'valid-tags',
+        nodeType: 'emu-clause',
+        message: '"oldid" isn\'t a thing; did you mean "oldids"?',
+      }
+    );
+  });
+
+  it('negative', async () => {
+    await assertLintFree(`
+      <emu-clause id="foo" oldids="bar">
+        <h1>Example</h1>
+      </emu-clause>
+    `);
+  });
+});


### PR DESCRIPTION
- lint against unrecognized `emu-` tags
- lint for use of "oldid" (should be "oldids")

~This includes `emu-see-also-para` as a valid tag because it appears in 262, but ecmarkup doesn't know what that is, so I'm probably just going to remove it from 262 and drop it here.~ Edit: https://github.com/tc39/ecma262/pull/2271 drops all occurrences of this tag, so it's no longer included here.