### PR TITLE
Lint for references to nonterminals which lack a definition

### DIFF
--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -1,5 +1,5 @@
 import type { Context } from './Context';
-import type { Node as EcmarkdownNode, OrderedListItemNode, Observer } from 'ecmarkdown';
+import type { Node as EcmarkdownNode, OrderedListItemNode } from 'ecmarkdown';
 import type { StepBiblioEntry } from './Biblio';
 
 import Builder from './Builder';
@@ -45,8 +45,13 @@ export default class Algorithm extends Builder {
     if (spec.opts.lintSpec && spec.locate(node) != null && !node.hasAttribute('example')) {
       let clause = clauseStack[clauseStack.length - 1];
       let namespace = clause ? clause.namespace : spec.namespace;
-      let nonterminals = collectNonterminalsFromEmd(emdTree).map(({ name, loc }) => ({ name, loc, node, namespace }));
-      spec._ntStringRefs = spec._ntStringRefs.concat(nonterminals)
+      let nonterminals = collectNonterminalsFromEmd(emdTree).map(({ name, loc }) => ({
+        name,
+        loc,
+        node,
+        namespace,
+      }));
+      spec._ntStringRefs = spec._ntStringRefs.concat(nonterminals);
     }
 
     const rawHtml = emd.emit(emdTree);

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -1,7 +1,7 @@
 import type { Context } from './Context';
 
 import Builder from './Builder';
-import { collectNonterminals } from './lint/utils';
+import { collectNonterminalsFromGrammar } from './lint/utils';
 import { CoreAsyncHost, CompilerOptions, Grammar as GrammarFile, EmitFormat } from 'grammarkdown';
 
 const endTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/i;
@@ -71,7 +71,7 @@ export default class Grammar extends Builder {
       // The `'grammarkdownOut' in node` check at the top means we don't do this for nodes which have already been covered by a separate linting pass
       let clause = clauseStack[clauseStack.length - 1];
       let namespace = clause ? clause.namespace : spec.namespace;
-      let nonterminals = collectNonterminals(grammar).map(({ name, loc }) => ({ name, loc, node, namespace }));
+      let nonterminals = collectNonterminalsFromGrammar(grammar).map(({ name, loc }) => ({ name, loc, node, namespace }));
       spec._ntStringRefs = spec._ntStringRefs.concat(nonterminals);
     }
     await grammar.emit(undefined, (file, source) => {

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -71,7 +71,12 @@ export default class Grammar extends Builder {
       // The `'grammarkdownOut' in node` check at the top means we don't do this for nodes which have already been covered by a separate linting pass
       let clause = clauseStack[clauseStack.length - 1];
       let namespace = clause ? clause.namespace : spec.namespace;
-      let nonterminals = collectNonterminalsFromGrammar(grammar).map(({ name, loc }) => ({ name, loc, node, namespace }));
+      let nonterminals = collectNonterminalsFromGrammar(grammar).map(({ name, loc }) => ({
+        name,
+        loc,
+        node,
+        namespace,
+      }));
       spec._ntStringRefs = spec._ntStringRefs.concat(nonterminals);
     }
     await grammar.emit(undefined, (file, source) => {

--- a/src/NonTerminal.ts
+++ b/src/NonTerminal.ts
@@ -30,7 +30,12 @@ export default class NonTerminal extends Builder {
     if (spec.opts.lintSpec && spec.locate(node) != null && !node.hasAttribute('example')) {
       let clause = clauseStack[clauseStack.length - 1];
       let namespace = clause ? clause.namespace : spec.namespace;
-      spec._ntStringRefs = spec._ntStringRefs.concat({ name: node.textContent!, loc: { line: 1, column: 1 }, node, namespace })
+      spec._ntStringRefs = spec._ntStringRefs.concat({
+        name: node.textContent!,
+        loc: { line: 1, column: 1 },
+        node,
+        namespace,
+      });
     }
   }
 

--- a/src/NonTerminal.ts
+++ b/src/NonTerminal.ts
@@ -26,6 +26,12 @@ export default class NonTerminal extends Builder {
     const namespace = clause ? clause.namespace : spec.namespace;
     const nt = new NonTerminal(spec, node, namespace);
     spec._ntRefs.push(nt);
+
+    if (spec.opts.lintSpec && spec.locate(node) != null && !node.hasAttribute('example')) {
+      let clause = clauseStack[clauseStack.length - 1];
+      let namespace = clause ? clause.namespace : spec.namespace;
+      spec._ntStringRefs = spec._ntStringRefs.concat({ name: node.textContent!, loc: { line: 1, column: 1 }, node, namespace })
+    }
   }
 
   build() {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -250,6 +250,7 @@ export default class Spec {
   _figureCounts: { [type: string]: number };
   _xrefs: Xref[];
   _ntRefs: NonTerminal[];
+  _ntStringRefs: { name: string, namespace: string | null}[];
   _prodRefs: ProdRef[];
   _textNodes: { [s: string]: [TextNodeContext] };
   private _fetch: (file: string, token: CancellationToken) => PromiseLike<string>;
@@ -288,6 +289,7 @@ export default class Spec {
     };
     this._xrefs = [];
     this._ntRefs = [];
+    this._ntStringRefs = [];
     this._prodRefs = [];
     this._textNodes = {};
 

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -250,7 +250,12 @@ export default class Spec {
   _figureCounts: { [type: string]: number };
   _xrefs: Xref[];
   _ntRefs: NonTerminal[];
-  _ntStringRefs: { name: string, loc: { line: number, column: number }, node: (Element | Text), namespace: string }[];
+  _ntStringRefs: {
+    name: string;
+    loc: { line: number; column: number };
+    node: Element | Text;
+    namespace: string;
+  }[];
   _prodRefs: ProdRef[];
   _textNodes: { [s: string]: [TextNodeContext] };
   private _fetch: (file: string, token: CancellationToken) => PromiseLike<string>;

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -112,7 +112,7 @@ export async function collectGrammarDiagnostics(
         grammarLoc.endTag.startOffset
       )
     );
-    let grammar = new GrammarFile([grammarHost.file], {}, grammarHost);
+    let grammar = new GrammarFile([grammarHost.file], { format: EmitFormat.ecmarkup, noChecks: true }, grammarHost);
     await grammar.parse();
     oneOffGrammars.push({ grammarEle, grammar });
     let productions = getProductions(grammar);

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -9,10 +9,9 @@ import {
   Diagnostics,
   Production,
   Parameter,
-  skipTrivia,
 } from 'grammarkdown';
 
-import { getProductions, rhsMatches } from './utils';
+import { getProductions, rhsMatches, getLocationInGrammar } from './utils';
 
 export async function collectGrammarDiagnostics(
   report: (e: Warning) => void,
@@ -117,20 +116,10 @@ export async function collectGrammarDiagnostics(
     oneOffGrammars.push({ grammarEle, grammar });
     let productions = getProductions(grammar);
 
-    function getLocationInGrammar(pos: number) {
-      let file = grammar.sourceFiles[0];
-      let posWithoutWhitespace = skipTrivia(file.text, pos, file.text.length);
-      let { line: gmdLine, character: gmdCharacter } = file.lineMap.positionAt(
-        posWithoutWhitespace
-      );
-      // grammarkdown use 0-based line and column, we want 1-based
-      return { line: gmdLine + 1, column: gmdCharacter + 1 };
-    }
-
     for (let [name, { production, rhses }] of productions) {
       let originalRhses = actualGrammarProductions.get(name)?.rhses;
       if (originalRhses === undefined) {
-        let { line, column } = getLocationInGrammar(production.pos);
+        let { line, column } = getLocationInGrammar(grammar, production.pos);
         report({
           type: 'contents',
           ruleId: 'undefined-nonterminal',
@@ -143,7 +132,7 @@ export async function collectGrammarDiagnostics(
       }
       for (let rhs of rhses) {
         if (!originalRhses.some(o => rhsMatches(rhs, o))) {
-          let { line, column } = getLocationInGrammar(rhs.pos);
+          let { line, column } = getLocationInGrammar(grammar, rhs.pos);
           report({
             type: 'contents',
             ruleId: 'undefined-nonterminal',
@@ -160,7 +149,7 @@ export async function collectGrammarDiagnostics(
               return;
             }
             if (s.symbol.kind === SyntaxKind.NoSymbolHereAssertion) {
-              let { line, column } = getLocationInGrammar(s.symbol.pos);
+              let { line, column } = getLocationInGrammar(grammar, s.symbol.pos);
               report({
                 type: 'contents',
                 ruleId: `NLTH-in-SDO`,
@@ -176,7 +165,7 @@ export async function collectGrammarDiagnostics(
           })(rhs.head);
 
           if (rhs.constraints !== undefined) {
-            let { line, column } = getLocationInGrammar(rhs.constraints.pos);
+            let { line, column } = getLocationInGrammar(grammar, rhs.constraints.pos);
             report({
               type: 'contents',
               ruleId: `guard-in-SDO`,

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -111,7 +111,11 @@ export async function collectGrammarDiagnostics(
         grammarLoc.endTag.startOffset
       )
     );
-    let grammar = new GrammarFile([grammarHost.file], { format: EmitFormat.ecmarkup, noChecks: true }, grammarHost);
+    let grammar = new GrammarFile(
+      [grammarHost.file],
+      { format: EmitFormat.ecmarkup, noChecks: true },
+      grammarHost
+    );
     await grammar.parse();
     oneOffGrammars.push({ grammarEle, grammar });
     let productions = getProductions(grammar);

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -1,6 +1,7 @@
 import type { default as Spec, Warning } from '../Spec';
 
 import type { Node as EcmarkdownNode } from 'ecmarkdown';
+import { getLocationInGrammar } from './utils';
 
 type CollectNodesReturnType =
   | {

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -1,7 +1,6 @@
 import type { default as Spec, Warning } from '../Spec';
 
 import type { Node as EcmarkdownNode } from 'ecmarkdown';
-import { getLocationInGrammar } from './utils';
 
 type CollectNodesReturnType =
   | {

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -30,7 +30,7 @@ export async function lint(
   }
   let { mainGrammar, headers, sdos, earlyErrors, algorithms } = collection;
 
-  let { grammar } = await collectGrammarDiagnostics(
+  let { grammar, oneOffGrammars } = await collectGrammarDiagnostics(
     report,
     spec,
     sourceText,
@@ -57,15 +57,15 @@ export async function lint(
     // @ts-ignore we are intentionally adding a property here
     node.grammarkdownOut = source;
   });
-  // for (let { grammarEle, grammar } of oneOffGrammars) {
-  //   grammar.emitSync(undefined, (file, source) => {
-  //     if ('grammarkdownOut' in grammarEle) {
-  //       throw new Error('unexpectedly regenerating grammarkdown output');
-  //     }
-  //     // @ts-ignore we are intentionally adding a property here
-  //     grammarEle.grammarkdownOut = source;
-  //   });
-  // }
+  for (let { grammarEle, grammar } of oneOffGrammars) {
+    await grammar.emit(undefined, (file, source) => {
+      if ('grammarkdownOut' in grammarEle) {
+        throw new Error('unexpectedly regenerating grammarkdown output');
+      }
+      // @ts-ignore we are intentionally adding a property here
+      grammarEle.grammarkdownOut = source;
+    });
+  }
   for (let pair of algorithms) {
     if ('tree' in pair) {
       // @ts-ignore we are intentionally adding a property here

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -1,13 +1,10 @@
 import type { default as Spec, Warning } from '../Spec';
-import type { Production, Nonterminal } from 'grammarkdown';
 
 import { collectNodes } from './collect-nodes';
 import { collectGrammarDiagnostics } from './collect-grammar-diagnostics';
 import { collectSpellingDiagnostics } from './collect-spelling-diagnostics';
 import { collectAlgorithmDiagnostics } from './collect-algorithm-diagnostics';
 import { collectHeaderDiagnostics } from './collect-header-diagnostics';
-
-import { NodeVisitor } from 'grammarkdown';
 
 /*
 Currently this checks
@@ -69,30 +66,11 @@ export async function lint(
       grammarEle.grammarkdownOut = source;
     });
   }
+
   for (let pair of algorithms) {
     if ('tree' in pair) {
       // @ts-ignore we are intentionally adding a property here
       pair.element.ecmarkdownTree = pair.tree;
     }
   }
-
-  // Stash referenced nonterminals to check definedness later
-  // We only bother with this for non-definition things because grammarkdown's checks will cover the main grammar
-  let nonterminals = [];
-  class CollectingVisitor extends NodeVisitor {
-    visitProduction(node: Production): Production {
-      console.log(node.name);
-      return super.visitProduction(node);
-    }
-
-    visitNonterminal(node: Nonterminal): Nonterminal {
-      console.log(node);
-      return super.visitNonterminal(node);
-    }
-  }
-  let visitor = new CollectingVisitor;
-  grammar.rootFiles.forEach(f => {
-    visitor.visitEach(f.elements);
-    return;
-  });
 }

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -1,10 +1,13 @@
 import type { default as Spec, Warning } from '../Spec';
+import type { Production, Nonterminal } from 'grammarkdown';
 
 import { collectNodes } from './collect-nodes';
 import { collectGrammarDiagnostics } from './collect-grammar-diagnostics';
 import { collectSpellingDiagnostics } from './collect-spelling-diagnostics';
 import { collectAlgorithmDiagnostics } from './collect-algorithm-diagnostics';
 import { collectHeaderDiagnostics } from './collect-header-diagnostics';
+
+import { NodeVisitor } from 'grammarkdown';
 
 /*
 Currently this checks
@@ -72,4 +75,24 @@ export async function lint(
       pair.element.ecmarkdownTree = pair.tree;
     }
   }
+
+  // Stash referenced nonterminals to check definedness later
+  // We only bother with this for non-definition things because grammarkdown's checks will cover the main grammar
+  let nonterminals = [];
+  class CollectingVisitor extends NodeVisitor {
+    visitProduction(node: Production): Production {
+      console.log(node.name);
+      return super.visitProduction(node);
+    }
+
+    visitNonterminal(node: Nonterminal): Nonterminal {
+      console.log(node);
+      return super.visitNonterminal(node);
+    }
+  }
+  let visitor = new CollectingVisitor;
+  grammar.rootFiles.forEach(f => {
+    visitor.visitEach(f.elements);
+    return;
+  });
 }

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -12,7 +12,7 @@ import type {
   ArgumentList,
 } from 'grammarkdown';
 
-import { Grammar as GrammarFile, SyntaxKind } from 'grammarkdown';
+import { Grammar as GrammarFile, SyntaxKind, skipTrivia } from 'grammarkdown';
 
 export function getProductions(grammar: GrammarFile) {
   let productions: Map<
@@ -167,4 +167,15 @@ function argumentListMatches(a: ArgumentList, b: ArgumentList) {
       return ae.operatorToken.kind === be.operatorToken.kind && ae.name.text === be.name.text;
     })
   );
+}
+
+// this is only for use with single-file grammars
+export function getLocationInGrammar(grammar: GrammarFile, pos: number) {
+  let file = grammar.sourceFiles[0];
+  let posWithoutWhitespace = skipTrivia(file.text, pos, file.text.length);
+  let { line: gmdLine, character: gmdCharacter } = file.lineMap.positionAt(
+    posWithoutWhitespace
+  );
+  // grammarkdown use 0-based line and column, we want 1-based
+  return { line: gmdLine + 1, column: gmdCharacter + 1 };
 }

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -175,28 +175,32 @@ function argumentListMatches(a: ArgumentList, b: ArgumentList) {
 export function getLocationInGrammar(grammar: GrammarFile, pos: number) {
   let file = grammar.sourceFiles[0];
   let posWithoutWhitespace = skipTrivia(file.text, pos, file.text.length);
-  let { line: gmdLine, character: gmdCharacter } = file.lineMap.positionAt(
-    posWithoutWhitespace
-  );
+  let { line: gmdLine, character: gmdCharacter } = file.lineMap.positionAt(posWithoutWhitespace);
   // grammarkdown use 0-based line and column, we want 1-based
   return { line: gmdLine + 1, column: gmdCharacter + 1 };
 }
 
 class CollectNonterminalsFromGrammar extends NodeVisitor {
   declare grammar: GrammarFile;
-  declare results: { name: string, loc: { line: number, column: number } }[];
+  declare results: { name: string; loc: { line: number; column: number } }[];
   constructor(grammar: GrammarFile) {
     super();
     this.grammar = grammar;
     this.results = [];
   }
   visitProduction(node: Production): Production {
-    this.results.push({ name: node.name.text!, loc: getLocationInGrammar(this.grammar, node.name.pos) });
+    this.results.push({
+      name: node.name.text!,
+      loc: getLocationInGrammar(this.grammar, node.name.pos),
+    });
     return super.visitProduction(node);
   }
 
   visitNonterminal(node: Nonterminal): Nonterminal {
-    this.results.push({ name: node.name.text! , loc: getLocationInGrammar(this.grammar, node.name.pos) });
+    this.results.push({
+      name: node.name.text!,
+      loc: getLocationInGrammar(this.grammar, node.name.pos),
+    });
     return super.visitNonterminal(node);
   }
 }
@@ -209,7 +213,9 @@ export function collectNonterminalsFromGrammar(grammar: GrammarFile) {
   return visitor.results;
 }
 
-export function collectNonterminalsFromEmd(emdNode: EcmarkdownNode | EcmarkdownNode[]): { name: string, loc: { line: number, column: number } }[] {
+export function collectNonterminalsFromEmd(
+  emdNode: EcmarkdownNode | EcmarkdownNode[]
+): { name: string; loc: { line: number; column: number } }[] {
   if (Array.isArray(emdNode)) {
     return emdNode.flatMap(collectNonterminalsFromEmd);
   }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,7 +8,7 @@
         "stripInternal": true,
         "importsNotUsedAsValues": "error",
         "outDir": "../lib",
-        "lib": ["es5", "es2015", "dom"],
+        "lib": ["es5", "es2019", "dom"],
         "typeRoots": [
             "../node_modules/@types"
         ]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import type { MarkupData } from 'parse5';
-import type { Node as EcmarkdownNode } from 'ecmarkdown';
 
 import type Spec from './Spec';
 
@@ -53,8 +52,13 @@ export function emdTextNode(spec: Spec, node: Text, namespace: string) {
   try {
     let parts = emd.parseFragment(c);
     if (spec.opts.lintSpec && loc != null) {
-      let nonterminals = collectNonterminalsFromEmd(parts).map(({ name, loc }) => ({ name, loc, node, namespace }));
-      spec._ntStringRefs = spec._ntStringRefs.concat(nonterminals)
+      let nonterminals = collectNonterminalsFromEmd(parts).map(({ name, loc }) => ({
+        name,
+        loc,
+        node,
+        namespace,
+      }));
+      spec._ntStringRefs = spec._ntStringRefs.concat(nonterminals);
     }
     processed = emd.emit(parts);
   } catch (e) {
@@ -198,4 +202,3 @@ export function attrValueLocation(
     return { line: attrLoc.line, column: attrLoc.col + (tagText.match(matcher)?.[0].length ?? 0) };
   }
 }
-

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -159,7 +159,7 @@ describe('linting algorithms', () => {
             1. Substep.
           1. Let _constructorText_ be the source text
           <pre><code class="javascript">constructor() {}</code></pre>
-          1. Set _constructor_ to ParseText(_constructorText_, |MethodDefinition[~Yield, ~Await]|).
+          1. Set _constructor_ to ParseText(_constructorText_, _methodDefinition_).
           1. <mark>A highlighted line.</mark>
           1. <ins>Amend the spec with this.</ins>
           1. <del>Remove this from the spec.</del>

--- a/test/lint.js
+++ b/test/lint.js
@@ -319,8 +319,45 @@ describe('linting whole program', () => {
       );
     });
 
+    it('in algorithm', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _s_ be |${M}Example|.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'undefined-nonterminal',
+          nodeType: 'emu-alg',
+          message: 'could not find a definition for nonterminal Example',
+        }
+      );
+    });
+
+    it('in SDO', async () => {
+      await assertLint(
+        positioned`
+          <emu-grammar type="definition">
+            Statement: \`;\`
+          </emu-grammar>
+          <emu-clause id="example">
+            <h1>Something</h1>
+            <emu-grammar>Statement: \`;\`</emu-grammar>
+            <emu-alg>
+              1. Let _s_ be |${M}Statements|.
+            </emu-alg>
+          </emu-clause>
+        `,
+        {
+          ruleId: 'undefined-nonterminal',
+          nodeType: 'emu-alg',
+          message: 'could not find a definition for nonterminal Statements',
+        }
+      );
+    });
+
     it('negative', async () => {
-    await assertLintFree(`
+      await assertLintFree(`
         <emu-grammar type="definition">
           Example1: \`;\`
           Example2: Example1
@@ -331,7 +368,10 @@ describe('linting whole program', () => {
         <emu-grammar>
           Example2: Example1
         </emu-grammar>
-    `);
+        <emu-alg>
+          1. Let _s_ be |Example1|.
+        </emu-alg>
+      `);
     });
   });
 });

--- a/test/lint.js
+++ b/test/lint.js
@@ -369,6 +369,19 @@ describe('linting whole program', () => {
       );
     });
 
+    it('in literal emu-nt', async () => {
+      await assertLint(
+        positioned`
+          <p>Discuss: <emu-nt>${M}Example</emu-nt>.</p>
+        `,
+        {
+          ruleId: 'undefined-nonterminal',
+          nodeType: 'emu-nt',
+          message: 'could not find a definition for nonterminal Example',
+        }
+      );
+    });
+
     it('negative', async () => {
       await assertLintFree(`
         <emu-grammar type="definition">
@@ -385,6 +398,7 @@ describe('linting whole program', () => {
           1. Let _s_ be |Example1|.
         </emu-alg>
         <p>Discuss: |Example1|.</p>
+        <p>Discuss: <emu-nt>Example1</emu-nt>.</p>
       `);
     });
   });

--- a/test/lint.js
+++ b/test/lint.js
@@ -356,6 +356,19 @@ describe('linting whole program', () => {
       );
     });
 
+    it('in prose', async () => {
+      await assertLint(
+        positioned`
+          <p>Discuss: |${M}Example|.</p>
+        `,
+        {
+          ruleId: 'undefined-nonterminal',
+          nodeType: 'text',
+          message: 'could not find a definition for nonterminal Example',
+        }
+      );
+    });
+
     it('negative', async () => {
       await assertLintFree(`
         <emu-grammar type="definition">
@@ -371,6 +384,7 @@ describe('linting whole program', () => {
         <emu-alg>
           1. Let _s_ be |Example1|.
         </emu-alg>
+        <p>Discuss: |Example1|.</p>
       `);
     });
   });

--- a/test/lint.js
+++ b/test/lint.js
@@ -284,4 +284,54 @@ describe('linting whole program', () => {
       );
     });
   });
+
+  describe('nonterminal definedness', () => {
+    it('in LHS', async () => {
+      await assertLint(
+        positioned`
+          <emu-grammar>
+            ${M}Example: \`;\`
+          </emu-grammar>
+        `,
+        {
+          ruleId: 'undefined-nonterminal',
+          nodeType: 'emu-grammar',
+          message: 'could not find a definition for nonterminal Example',
+        }
+      );
+    });
+
+    it('in RHS', async () => {
+      await assertLint(
+        positioned`
+          <emu-grammar type="definition">
+            Example: \`;\`
+          </emu-grammar>
+          <emu-grammar>
+            Example: ${M}Undefined
+          </emu-grammar>
+        `,
+        {
+          ruleId: 'undefined-nonterminal',
+          nodeType: 'emu-grammar',
+          message: 'could not find a definition for nonterminal Undefined',
+        }
+      );
+    });
+
+    it('negative', async () => {
+    await assertLintFree(`
+        <emu-grammar type="definition">
+          Example1: \`;\`
+          Example2: Example1
+        </emu-grammar>
+        <emu-grammar>
+          Example1: \`;\`
+        </emu-grammar>
+        <emu-grammar>
+          Example2: Example1
+        </emu-grammar>
+    `);
+    });
+  });
 });


### PR DESCRIPTION
Based on https://github.com/tc39/ecmarkup/pull/281. Marked as a draft until that lands and this is rebased.