### PR TITLE
~constants~ should not autolink

### DIFF
--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -11,6 +11,7 @@ let escape: (_: string) => string = require('html-escape');
 export const NO_CLAUSE_AUTOLINK = new Set([
   'PRE',
   'CODE',
+  'EMU-CONST',
   'EMU-PRODUCTION',
   'EMU-GRAMMAR',
   'EMU-XREF',


### PR DESCRIPTION
This is necessary so that if you happen to have a constant with the same name as an abstract operation, the former will not be treated as a reference to the latter.

(This comes up with, for example, `~ConstructorMethod~` as the return value of [ClassElementKind](https://tc39.es/ecma262/#sec-static-semantics-classelementkind) together with [ConstructorMethod](https://tc39.es/ecma262/#sec-static-semantics-constructormethod) as a syntax-directed operation. That particular example is only an issue if SDOs [are treated as abstract operations](https://github.com/tc39/ecma262/pull/2271) for the purposes of autolinking.)