### PR TITLE
process gmod nodes as emd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -13,6 +13,6 @@ export interface Context {
   inNoAutolink: boolean;
   inNoEmd: boolean;
   inAlg: boolean;
-  startEmd: Node | null;
+  followingEmd: Node | null;
   currentId: string | null;
 }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -29,7 +29,12 @@ import Grammar from './Grammar';
 import Xref from './Xref';
 import Eqn from './Eqn';
 import Biblio from './Biblio';
-import { autolink, replacerForNamespace, NO_CLAUSE_AUTOLINK } from './autolinker';
+import {
+  autolink,
+  replacerForNamespace,
+  NO_CLAUSE_AUTOLINK,
+  YES_CLAUSE_AUTOLINK,
+} from './autolinker';
 import { lint } from './lint/lint';
 import { CancellationToken } from 'prex';
 import type { JSDOM } from 'jsdom';
@@ -37,6 +42,7 @@ import type { JSDOM } from 'jsdom';
 const DRAFT_DATE_FORMAT = { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' };
 const STANDARD_DATE_FORMAT = { year: 'numeric', month: 'long', timeZone: 'UTC' };
 const NO_EMD = new Set(['PRE', 'CODE', 'EMU-PRODUCTION', 'EMU-ALG', 'EMU-GRAMMAR', 'EMU-EQN']);
+const YES_EMD = new Set(['EMU-GMOD']); // these are processed even if they are nested in NO_EMD contexts
 
 interface VisitorMap {
   [k: string]: BuilderInterface;
@@ -397,7 +403,7 @@ export default class Spec {
       inNoAutolink: false,
       inAlg: false,
       inNoEmd: false,
-      startEmd: null,
+      followingEmd: null,
       currentId: null,
     };
 
@@ -1208,17 +1214,19 @@ async function loadImports(spec: Spec, rootElement: HTMLElement, rootPath: strin
 }
 
 async function walk(walker: TreeWalker, context: Context) {
-  // When we set either of these states we need to know to unset when we leave the element.
-  let changedInNoAutolink = false;
-  let changedInNoEmd = false;
+  let previousInNoAutolink = context.inNoAutolink;
+  let previousInNoEmd = context.inNoEmd;
   const { spec } = context;
 
   context.node = walker.currentNode as HTMLElement;
   context.tagStack.push(context.node);
 
-  if (context.node === context.startEmd) {
-    context.startEmd = null;
+  if (context.node === context.followingEmd) {
+    context.followingEmd = null;
     context.inNoEmd = false;
+    // inNoEmd is true because we're walking past the output of emd, rather than by being within a NO_EMD context
+    // so reset previousInNoEmd so we exit it properly
+    previousInNoEmd = false;
   }
 
   if (context.node.nodeType === 3) {
@@ -1231,16 +1239,16 @@ async function walk(walker: TreeWalker, context: Context) {
     if (!context.inNoEmd) {
       // new nodes as a result of emd processing should be skipped
       context.inNoEmd = true;
-      // inNoEmd is set to true when we walk to this node
       let node = context.node as Node | null;
       while (node && !node.nextSibling) {
         node = node.parentNode;
       }
 
       if (node) {
-        context.startEmd = node.nextSibling;
+        // inNoEmd will be set to false when we walk to this node
+        context.followingEmd = node.nextSibling;
       }
-      // else, inNoEmd will just continue to the end of the file
+      // else, there's no more nodes to process and inNoEmd does not need to be tracked
 
       utils.emdTextNode(context.spec, (context.node as unknown) as Text, namespace);
     }
@@ -1282,16 +1290,16 @@ async function walk(walker: TreeWalker, context: Context) {
     context.currentId = context.node.getAttribute('id');
   }
 
-  // See if we should stop auto-linking here.
-  if (NO_CLAUSE_AUTOLINK.has(context.node.nodeName) && !context.inNoAutolink) {
+  if (NO_CLAUSE_AUTOLINK.has(context.node.nodeName)) {
     context.inNoAutolink = true;
-    changedInNoAutolink = true;
+  } else if (YES_CLAUSE_AUTOLINK.has(context.node.nodeName)) {
+    context.inNoAutolink = false;
   }
 
-  // check if entering a noEmd tag
-  if (NO_EMD.has(context.node.nodeName) && !context.inNoEmd) {
+  if (NO_EMD.has(context.node.nodeName)) {
     context.inNoEmd = true;
-    changedInNoEmd = true;
+  } else if (YES_EMD.has(context.node.nodeName)) {
+    context.inNoEmd = false;
   }
 
   const visitor = visitorMap[context.node.nodeName];
@@ -1311,8 +1319,8 @@ async function walk(walker: TreeWalker, context: Context) {
   }
 
   if (visitor) visitor.exit(context);
-  if (changedInNoAutolink) context.inNoAutolink = false;
-  if (changedInNoEmd) context.inNoEmd = false;
+  context.inNoAutolink = previousInNoAutolink;
+  context.inNoEmd = previousInNoEmd;
   context.currentId = parentId;
   context.tagStack.pop();
 }

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -29,6 +29,7 @@ export const NO_CLAUSE_AUTOLINK = new Set([
   'SUB',
   'EMU-NOT-REF',
 ]);
+export const YES_CLAUSE_AUTOLINK = new Set(['EMU-GMOD']); // these are processed even if they are nested in NO_CLAUSE_AUTOLINK contexts
 
 export function autolink(
   node: Node,

--- a/test/baselines/reference/emd-in-grammar.html
+++ b/test/baselines/reference/emd-in-grammar.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<head><meta charset="utf-8"><script type="application/json" id="sdo-map">{}</script></head><body><div id="spec-container">
+
+<emu-clause id="sec-example">
+  <h1 class="first"><span class="secnum">1</span> Example</h1>
+  <emu-grammar type="definition"><emu-production name="Foo" type="lexical" id="prod-Foo">
+    <emu-nt><a href="#prod-Foo">Foo</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="14eb29da">
+        <emu-nt id="_ref_1"><a href="#prod-Bar">Bar</a></emu-nt>
+        <emu-gmod>but only if the <emu-xref aoid="AbstractOperation" id="_ref_0"><a href="#sec-abstract-operation">AbstractOperation</a></emu-xref> of <emu-nt id="_ref_2"><a href="#prod-Bar">Bar</a></emu-nt> is ≤ <var>variable</var></emu-gmod>
+    </emu-rhs>
+</emu-production>
+<emu-production name="Bar" type="lexical" collapsed="" id="prod-Bar">
+    <emu-nt><a href="#prod-Bar">Bar</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="9b56145b"><emu-t>example</emu-t></emu-rhs>
+</emu-production>
+</emu-grammar>
+
+  <emu-clause id="sec-abstract-operation" aoid="AbstractOperation">
+    <h1><span class="secnum">1.1</span> Static Semantics: AbstractOperation</h1>
+    <emu-grammar><emu-production name="Bar" type="lexical" collapsed="">
+    <emu-nt><a href="#prod-Bar">Bar</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="9b56145b"><emu-t>example</emu-t></emu-rhs>
+</emu-production>
+</emu-grammar>
+    <emu-alg><ol><li>Return 0.</li></ol></emu-alg>
+  </emu-clause>
+</emu-clause>
+</div></body>

--- a/test/baselines/reference/grammar.html
+++ b/test/baselines/reference/grammar.html
@@ -39,7 +39,7 @@
 <emu-production name="ButOnlyExample" type="lexical" id="prod-ButOnlyExample">
     <emu-nt><a href="#prod-ButOnlyExample">ButOnlyExample</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="5c6f47da">
         <emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt>
-        <emu-gmod>but only if the CapturingGroupNumber of <emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt> is &lt;= _NcapturingParens_</emu-gmod>
+        <emu-gmod>but only if the CapturingGroupNumber of <emu-nt><a href="https://tc39.es/ecma262/#prod-DecimalEscape">DecimalEscape</a></emu-nt> is &lt;= <var>NcapturingParens</var></emu-gmod>
     </emu-rhs>
 </emu-production>
 </emu-grammar>

--- a/test/emd-in-grammar.html
+++ b/test/emd-in-grammar.html
@@ -1,0 +1,23 @@
+<pre class=metadata>
+toc: false
+copyright: false
+assets: none
+</pre>
+
+<emu-clause id="sec-example">
+  <h1>Example</h1>
+  <emu-grammar type="definition">
+    Foo ::
+      Bar [> but only if the AbstractOperation of |Bar| is &le; _variable_]
+
+    Bar :: `example`
+  </emu-grammar>
+
+  <emu-clause id="sec-abstract-operation" aoid="AbstractOperation">
+    <h1>Static Semantics: AbstractOperation</h1>
+    <emu-grammar>Bar :: `example`</emu-grammar>
+    <emu-alg>
+      1. Return 0.
+    </emu-alg>
+  </emu-clause>
+</emu-clause>


### PR DESCRIPTION
See https://github.com/tc39/ecma262/issues/570. This will fix that issue once upstreamed.

First commit has no semantic effects; it's just simplifying some logic to make it easier to extend.

Second commit just adds a baseline with the as-of-upstream logic.

Third commit has the actual change.