### PR TITLE
Lint for missing closing tags

### DIFF
--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -47,12 +47,7 @@ export function collectAlgorithmDiagnostics(
 
     let { source: importSource } = location;
     if (location.endTag == null) {
-      report({
-        type: 'node',
-        ruleId: 'missing-close-tag',
-        message: 'could not find closing tag for emu-alg',
-        node: algorithm.element,
-      });
+      // we'll warn for this in collect-tag-diagnostics; no need to do so here
       continue;
     }
 

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -96,12 +96,7 @@ export async function collectGrammarDiagnostics(
     let { source: importSource } = grammarLoc;
 
     if (grammarLoc.endTag == null) {
-      report({
-        type: 'node',
-        ruleId: 'missing-close-tag',
-        message: 'could not find closing tag for emu-grammar',
-        node: grammarEle,
-      });
+      // we'll warn for this in collect-tag-diagnostics; no need to do so here
       continue;
     }
 

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -93,12 +93,7 @@ export function collectNodes(
           let { source: importSource } = loc;
           if (loc.endTag == null) {
             failed = true;
-            report({
-              type: 'node',
-              ruleId: 'missing-close-tag',
-              message: 'could not find closing tag for emu-grammar',
-              node,
-            });
+            // we'll warn for this in collect-tag-diagnostics; no need to do so here
           } else {
             let start = loc.startTag.endOffset;
             let end = loc.endTag.startOffset;

--- a/src/lint/collect-tag-diagnostics.ts
+++ b/src/lint/collect-tag-diagnostics.ts
@@ -78,7 +78,7 @@ export function collectTagDiagnostics(
 
     if (!voidElements.has(name)) {
       let location = spec.locate(node);
-      if (location != null && location.startTag != null && location.endTag == null) {
+      if (location != null && location.endTag == null) {
         report({
           type: 'node',
           ruleId: 'missing-closing-tag',

--- a/src/lint/collect-tag-diagnostics.ts
+++ b/src/lint/collect-tag-diagnostics.ts
@@ -1,7 +1,5 @@
 import type { default as Spec, Warning } from '../Spec';
 
-const ruleId = 'valid-tags';
-
 let knownEmuTags = new Set([
   'emu-import',
   'emu-example',
@@ -31,6 +29,24 @@ let knownEmuTags = new Set([
   'emu-normative-optional', // used in ecma-402
 ]);
 
+// https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+let voidElements = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
 export function collectTagDiagnostics(
   report: (e: Warning) => void,
   spec: Spec,
@@ -44,7 +60,7 @@ export function collectTagDiagnostics(
     if (name.startsWith('emu-') && !knownEmuTags.has(name)) {
       report({
         type: 'node',
-        ruleId,
+        ruleId: 'valid-tags',
         message: `unknown "emu-" tag "${name}"`,
         node,
       });
@@ -54,10 +70,22 @@ export function collectTagDiagnostics(
       report({
         type: 'attr',
         attr: 'oldid',
-        ruleId,
+        ruleId: 'valid-tags',
         message: `"oldid" isn't a thing; did you mean "oldids"?`,
         node,
       });
+    }
+
+    if (!voidElements.has(name)) {
+      let location = spec.locate(node);
+      if (location != null && location.startTag != null && location.endTag == null) {
+        report({
+          type: 'node',
+          ruleId: 'missing-closing-tag',
+          message: `element is missing its closing tag`,
+          node,
+        });
+      }
     }
 
     let firstChild = lintWalker.firstChild();

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -25,6 +25,10 @@ export async function lint(
   spec: Spec,
   document: Document
 ) {
+  collectSpellingDiagnostics(report, sourceText, spec.imports);
+
+  collectTagDiagnostics(report, spec, document);
+
   let collection = collectNodes(report, sourceText, spec, document);
   if (!collection.success) {
     return;
@@ -43,10 +47,6 @@ export async function lint(
   collectAlgorithmDiagnostics(report, spec, sourceText, algorithms);
 
   collectHeaderDiagnostics(report, headers);
-
-  collectSpellingDiagnostics(report, sourceText, spec.imports);
-
-  collectTagDiagnostics(report, spec, document);
 
   // Stash intermediate results for later use
   // This isn't actually necessary for linting, but we might as well avoid redoing work later when we can.

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -572,7 +572,7 @@ windows:${M}\r
         Paragraphs with the open/close tags on their own line are OK.
       </p>
 
-      <p>Comparisons with positive zero are OK: _x_ &lt; *+0*<sub>𝔽</sub>, _x_ &le; *+0*<sub>𝔽</sub>, _x_ &gt; *+0*<sub>𝔽</sub>, _x_ &ge; *+0*<sub>𝔽</sub>
+      <p>Comparisons with positive zero are OK: _x_ &lt; *+0*<sub>𝔽</sub>, _x_ &le; *+0*<sub>𝔽</sub>, _x_ &gt; *+0*<sub>𝔽</sub>, _x_ &ge; *+0*<sub>𝔽</sub></p>
 
     `);
   });

--- a/test/lint-tags.js
+++ b/test/lint-tags.js
@@ -31,10 +31,30 @@ describe('tags', () => {
     );
   });
 
+  it('missing closing tag', async () => {
+    await assertLint(
+      positioned`
+        <emu-clause id="foo">
+          <h1>Example</h1>
+          ${M}<p>some text
+          <p>some other text</p>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'missing-closing-tag',
+        nodeType: 'p',
+        message: 'element is missing its closing tag',
+      }
+    );
+  });
+
   it('negative', async () => {
     await assertLintFree(`
       <emu-clause id="foo" oldids="bar">
         <h1>Example</h1>
+        <p>some text</p>
+        <br>
+        <p>some other text</p>
       </emu-clause>
     `);
   });

--- a/test/lint.js
+++ b/test/lint.js
@@ -134,6 +134,7 @@ describe('linting whole program', () => {
         positioned`
           <emu-clause id="foo">
             <h1>${M}something: ( )</h1>
+          </emu-clause>
         `,
         {
           ruleId: 'header-format',
@@ -149,6 +150,7 @@ describe('linting whole program', () => {
         positioned`
           <emu-clause id="foo">
             <h1>Exampl${M}e( )</h1>
+          </emu-clause>
         `,
         {
           ruleId: 'header-format',
@@ -163,6 +165,7 @@ describe('linting whole program', () => {
         positioned`
           <emu-clause id="foo">
             <h1>Example ${M}(_a_)</h1>
+          </emu-clause>
         `,
         {
           ruleId: 'header-format',
@@ -175,6 +178,7 @@ describe('linting whole program', () => {
         positioned`
           <emu-clause id="foo">
             <h1>Example ${M}( _a_ [ , <del>_b_</del> ] )</h1>
+          </emu-clause>
         `,
         {
           ruleId: 'header-format',

--- a/test/lint.js
+++ b/test/lint.js
@@ -266,9 +266,9 @@ describe('linting whole program', () => {
           <!--</emu-grammar>-->
         `,
         {
-          ruleId: 'missing-close-tag',
+          ruleId: 'missing-closing-tag',
           nodeType: 'emu-grammar',
-          message: 'could not find closing tag for emu-grammar',
+          message: 'element is missing its closing tag',
         }
       );
     });
@@ -281,9 +281,9 @@ describe('linting whole program', () => {
           <!--</emu-alg>-->
         `,
         {
-          ruleId: 'missing-close-tag',
+          ruleId: 'missing-closing-tag',
           nodeType: 'emu-alg',
-          message: 'could not find closing tag for emu-alg',
+          message: 'element is missing its closing tag',
         }
       );
     });


### PR DESCRIPTION
cf https://github.com/tc39/ecma262/commit/6ee57ceffaba8ef0512fe9cbe4be5697fb508b9f

Note that for some elements, in some circumstances, the close tag is formally [optional](https://html.spec.whatwg.org/multipage/syntax.html#syntax-tag-omission). Current convention in ecma262 is to include them anyway, so for the sake of consistency this rule enforces that they are present.