### PR TITLE
Version 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "6.1.0",
+	"version": "7.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "6.1.0",
+	"version": "7.0.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",


### PR DESCRIPTION
Marked as major because the inclusion of https://github.com/tc39/ecmarkup/pull/298 is arguably breaking, and also https://github.com/tc39/ecmarkup/pull/301 adds some new restrictions on which combinations of CLI arguments are acceptable.