### PR TITLE
lint: enforce capitalization rules for NOTE and Assert

### DIFF
--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -17,6 +17,8 @@ Checks that every algorithm step has one of these forms:
 - `Repeat, until foo,` + substeps
 - `For each foo, bar.`
 - `For each foo, do` + substeps
+- `NOTE: Something.`
+- `Assert: Something.`
 - `Other.`
 - `Other:` + substeps
 */
@@ -286,6 +288,32 @@ export default function (report: Reporter, node: Element, algorithmSource: strin
           }
         }
       } else {
+        // these are not else-ifs because we still want to enforce the line-ending rules
+        if (/^(NOTE|Assert): [a-z]/.test(initialText)) {
+          let kind = initialText.match(/^(NOTE|Assert)/)![1];
+          report({
+            ruleId,
+            line: first.location!.start.line,
+            column: first.location!.start.column + kind.length + 2,
+            message: `the clause after "${kind}:" should begin with a capital letter`,
+          });
+        }
+        if (/^NOTE:/i.test(initialText) && !/^NOTE:/.test(initialText)) {
+          report({
+            ruleId,
+            line: first.location!.start.line,
+            column: first.location!.start.column,
+            message: `"NOTE:" should be fully capitalized`,
+          });
+        }
+        if (/^Assert:/i.test(initialText) && !/^Assert:/.test(initialText)) {
+          report({
+            ruleId,
+            line: first.location!.start.line,
+            column: first.location!.start.column,
+            message: `"Assert:" should be capitalized`,
+          });
+        }
         if (hasSubsteps) {
           if (!/:$/.test(last.contents)) {
             report({

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -110,6 +110,76 @@ describe('linting algorithms', () => {
       );
     });
 
+    it('NOTE:', async () => {
+      await assertLint(
+        positioned`<emu-alg>
+          1. NOTE: ${M}foo.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'the clause after "NOTE:" should begin with a capital letter',
+        }
+      );
+
+      await assertLint(
+        positioned`<emu-alg>
+          1. ${M}Note: Foo.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: '"NOTE:" should be fully capitalized',
+        }
+      );
+
+      await assertLint(
+        positioned`<emu-alg>
+          1. NOTE: Foo${M}
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected freeform line to end with "." (found "NOTE: Foo")',
+        }
+      );
+    });
+
+    it('Assert:', async () => {
+      await assertLint(
+        positioned`<emu-alg>
+          1. Assert: ${M}foo.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'the clause after "Assert:" should begin with a capital letter',
+        }
+      );
+
+      await assertLint(
+        positioned`<emu-alg>
+          1. ${M}ASSERT: Foo.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: '"Assert:" should be capitalized',
+        }
+      );
+
+      await assertLint(
+        positioned`<emu-alg>
+          1. Assert: Foo${M}
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected freeform line to end with "." (found "Assert: Foo")',
+        }
+      );
+    });
+
     it('pre', async () => {
       await assertLint(
         positioned`<emu-alg>
@@ -154,6 +224,12 @@ describe('linting algorithms', () => {
           1. For each foo, do bar.
           1. For each foo, do
             1. Substep.
+          1. NOTE: Foo.
+          1. NOTE: The following algorithm returns *true*:
+            1. Return *true*.
+          1. Assert: Foo.
+          1. Assert: The following algorithm returns *true*:
+            1. Return *true*.
           1. Other.
           1. Other:
             1. Substep.


### PR DESCRIPTION
Since I made this mistake in https://github.com/tc39/ecma262/pull/2374, I figured it needs a lint rule.

There are two places this is violated in ecma262 currently; I'll fix those as part of upstreaming this.