### PR TITLE
deps: add parse5 to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"eslint-config-prettier": "^6.10.1",
 		"eslint-plugin-prettier": "^3.1.2",
 		"mocha": "^5.2.0",
+		"parse5": "^4.0.0",
 		"prettier": "^2.0.4",
 		"safe-publish-latest": "^1.1.4",
 		"typescript": "^4.3.2"


### PR DESCRIPTION
`parse5` is imported from `src/Spec.ts` and `src/utils.ts` but was missing from `devDependencies`.

I used `pnpm` to install deps, which doesn't lift transitive dependencies like `npm` does.
