### PR TITLE
typescript: use DOM.Iterable type library

### DIFF
--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -87,7 +87,7 @@ export default class Algorithm extends Builder {
       }
     }
 
-    for (const step of Array.from(node.querySelectorAll('li[id]'))) {
+    for (const step of node.querySelectorAll('li[id]')) {
       const entry: StepBiblioEntry = {
         type: 'step',
         id: step.id,
@@ -110,9 +110,10 @@ export default class Algorithm extends Builder {
 }
 
 function getStepNumbers(item: Element) {
+  const { indexOf } = Array.prototype;
   const counts = [];
   while (item.parentElement?.tagName === 'OL') {
-    counts.unshift(1 + Array.from(item.parentElement.children).indexOf(item));
+    counts.unshift(1 + indexOf.call(item.parentElement.children, item));
     item = item.parentElement.parentElement!;
   }
   return counts;

--- a/src/Example.ts
+++ b/src/Example.ts
@@ -42,7 +42,6 @@ export default class Example extends Builder {
 
     const ele = this.spec.doc.createElement('figure');
 
-    // @ts-ignore childNodes is iterable
     ele.append(...this.node.childNodes);
     this.node.append(ele);
 

--- a/src/Figure.ts
+++ b/src/Figure.ts
@@ -54,7 +54,6 @@ export default class Figure extends Builder {
 
     const ele = spec.doc.createElement('figure');
 
-    // @ts-ignore childNodes is iterable
     ele.append(...node.childNodes);
     node.append(ele);
 

--- a/src/header-parser.ts
+++ b/src/header-parser.ts
@@ -293,11 +293,7 @@ export function formatPreamble(
         });
         _for = spec.doc.createElement('div');
       }
-      para.append(
-        `The ${name} ${type} of `,
-        // @ts-ignore childNodes is iterable
-        ..._for.childNodes
-      );
+      para.append(`The ${name} ${type} of `, ..._for.childNodes);
       para.innerHTML += ` takes ${formattedParams}.`;
       break;
     }
@@ -321,15 +317,12 @@ export function formatPreamble(
     }
   }
   if (description != null) {
-    // @ts-ignore childNodes is iterable
-    const isJustElements = [...(description.childNodes as Iterable<Node>)].every(
+    const isJustElements = [...description.childNodes].every(
       n => n.nodeType === 1 || (n.nodeType === 3 && n.textContent?.trim() === '')
     );
     if (isJustElements) {
-      // @ts-ignore childNodes is iterable
-      paras.push(...description.childNodes);
+      paras.push(...(description.childNodes as Iterable<HTMLParagraphElement>));
     } else {
-      // @ts-ignore childNodes is iterable
       para.append(' ', ...description.childNodes);
     }
   }

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -53,7 +53,7 @@ export function collectNodes(
           if (title.trim() === 'Static Semantics: Early Errors') {
             let grammar = null;
             let lists: HTMLUListElement[] = [];
-            for (const child of node.children as any as Iterable<Element>) {
+            for (const child of node.children) {
               if (child.nodeName === 'EMU-GRAMMAR') {
                 if (grammar !== null) {
                   if (lists.length === 0) {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,7 +8,7 @@
         "stripInternal": true,
         "importsNotUsedAsValues": "error",
         "outDir": "../lib",
-        "lib": ["es5", "es2019", "dom"],
+        "lib": ["es5", "es2019", "dom", "dom.iterable"],
         "typeRoots": [
             "../node_modules/@types"
         ]


### PR DESCRIPTION
Enable `dom.iterable` in `tsconfig` and remove a few unnecessary `ts-ignore` comments, `as Iterable<Element>` assertions, and `Array.from` calls.
