### PR TITLE
perf: build more efficient RegExp for autolink

### DIFF
--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -106,10 +106,6 @@ function isCommonAbstractOp(op: string) {
   );
 }
 
-function isCommonTerm(op: string) {
-  return op === 'List' || op === 'Reference' || op === 'Record';
-}
-
 function lookAheadBeyond(entry: BiblioEntry) {
   if (entry.type === 'term') {
     if (/^\w/.test(entry.key!)) {


### PR DESCRIPTION
Profiling showed that `ecmarkup` spends ~45% of runtime in a huge regex in autolink.

The issue was that the regex was just a flat union of alternatives, with no memory of common prefixes, so it kept backtracking after 
each failed branch and rematching `\b` over and over.

This PR groups alternatives with common prefixes, in order to limit the amount of backtracking. Running time on my laptop reduced from ~50s down to ~30s.
