### PR TITLE
cleanup some mess I left in autolink

### DIFF
--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -107,20 +107,15 @@ function isCommonAbstractOp(op: string) {
 }
 
 function lookAheadBeyond(entry: BiblioEntry) {
-  if (entry.type === 'term') {
-    if (/^\w/.test(entry.key!)) {
-      return '\\b(?!\\.\\w|%%|\\]\\])';
-    } else {
-      return '';
-    }
-  } else {
-    // type is "op"
-    if (isCommonAbstractOp(entry.key!)) {
-      return '\\b(?=\\()';
-    } else {
-      return '\\b(?!\\.\\w|%%|\\]\\])';
-    }
+  if (entry.type === 'op' && isCommonAbstractOp(entry.key!)) {
+    // must be followed by parentheses
+    return '\\b(?=\\()';
   }
+  if (entry.type !== 'term' || /^\w/.test(entry.key!)) {
+    // must not be followed by `.word` or `%%` or `]]`
+    return '\\b(?!\\.\\w|%%|\\]\\])';
+  }
+  return '';
 }
 
 // returns a regexp string where each space can be many spaces or line breaks.
@@ -223,8 +218,5 @@ function regexpForList(autolinkmap: AutoLinkMap, autolinkkeys: string[], positio
     resultAlternatives.unshift('\\b' + regexpUnion(wordStartAlternatives));
   }
 
-  // prettier-ignore
-  return position === 0
-    ? resultAlternatives.join('|')
-    : regexpUnion(resultAlternatives);
+  return regexpUnion(resultAlternatives);
 }

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -144,24 +144,21 @@ function regexpUnion(alternatives: string[]) {
   return `(?:${alternatives.join('|')})`;
 }
 
-// binary search for the longest common prefix in an array of strings
-function longestCommonPrefix(items: string[], offset: number = 0) {
-  let result = '';
-  let low = offset;
-  let high = items[0].length;
-  OUTER: while (low < high) {
-    const end = high - ((high - low) >>> 1);
-    const prefix = items[0].slice(offset, end);
+// Search a non-empty array of string `items` for the longest common
+// substring starting at position `beginIndex`. The part of each string
+// before `beginIndex` is ignored, and is not included in the result.
+function longestCommonPrefix(items: string[], beginIndex: number = 0) {
+  let endIndex = beginIndex;
+  OUTER: while (endIndex < items[0].length) {
+    const char = items[0][endIndex];
     for (let i = 1; i < items.length; ++i) {
-      if (!items[i].startsWith(prefix, offset)) {
-        high = end - 1;
-        continue OUTER;
+      if (char !== items[i][endIndex]) {
+        break OUTER;
       }
     }
-    low = end;
-    result = prefix;
+    ++endIndex;
   }
-  return result;
+  return items[0].slice(beginIndex, endIndex);
 }
 
 function regexpForList(autolinkmap: AutoLinkMap, autolinkkeys: string[], position: number) {


### PR DESCRIPTION
Follow-up to #340, implements some changes suggested by @gibson042 

I've replaced my dubious implementation of `longestCommonPrefix` with a **KISS** alternative. The binary search variant was 1) kinda overkill, and 2) poorly implemented — bad estimate of max length at the beginning, and then repeatedly comparing whole prefixes including the parts that were already known to be equal across the whole array.

The new linear algorithm is hopefully much easier to understand, and quite possibly even more efficient for the use case expecting very short prefixes. Strictly speaking it's *O(result.length * items.length)*, which looks quadratic, but that product is always <= `items.join().length`, so the worst-case complexity is linear with respect to the total size of input in characters.
