### PR TITLE
Tweak autolinker

### DIFF
--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -109,9 +109,26 @@ export default class Biblio {
       while (current) {
         const entries = current._byType[type] || [];
         for (const entry of entries) {
-          if (!seen.has(entry.key)) {
-            seen.add(entry.key);
-            result[entry.key] = entry;
+          if (entry.key === 'type') {
+            // this is a dumb kludge necessitated by ecma262 dfn'ing both "type" and "Type"
+            // the latter originally masked the former, so that it didn't actually end up linking all usages of the word "type"
+            // we've changed the logic a bit so that masking no longer happens, and consequently the autolinker adds a bunch of spurious links
+            // this can be removed once ecma262 no longer dfn's it and we update ecma262-biblio.json
+            continue;
+          }
+
+          const key = entry.key.replace(/\s+/g, ' ');
+          const keys = [key];
+          if (/^[a-z]/.test(key)) {
+            // include capitalized variant of words starting with lowercase letter
+            keys.push(key[0].toUpperCase() + key.slice(1));
+          }
+
+          for (const key of keys) {
+            if (!seen.has(key)) {
+              seen.add(key);
+              result[key] = entry;
+            }
           }
         }
         current = current._parent;

--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -107,7 +107,6 @@ export default class Biblio {
       const seen = new Set<string>();
       let current = this._nsToEnvRec[ns];
       while (current) {
-        // const entries = (current._byType['term'] || []).concat(current._byType['op'] || []);
         const entries = current._byType[type] || [];
         for (const entry of entries) {
           if (!seen.has(entry.key)) {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -587,7 +587,6 @@ export default class Spec {
     };
 
     let counter = 0;
-    const counterMap: Map<string, number> = new Map;
     this._xrefs.forEach(xref => {
       let entry = xref.entry;
       if (!entry || entry.namespace === 'global') return;
@@ -597,14 +596,7 @@ export default class Spec {
       }
 
       if (!xref.id) {
-        // revert me: this was just to get more-stable biblios
-        const t = xref.node.textContent ?? '';
-        if (!counterMap.has(t)) {
-          counterMap.set(t, 0);
-        }
-        const c = counterMap.get(t)!;
-        counterMap.set(t, c + 1);
-        const id = `_ref_${t}_${c}`;
+        const id = `_ref_${counter++}`;
         xref.node.setAttribute('id', id);
         xref.id = id;
       }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -587,6 +587,7 @@ export default class Spec {
     };
 
     let counter = 0;
+    const counterMap: Map<string, number> = new Map;
     this._xrefs.forEach(xref => {
       let entry = xref.entry;
       if (!entry || entry.namespace === 'global') return;
@@ -596,7 +597,14 @@ export default class Spec {
       }
 
       if (!xref.id) {
-        const id = `_ref_${counter++}`;
+        // revert me: this was just to get more-stable biblios
+        const t = xref.node.textContent ?? '';
+        if (!counterMap.has(t)) {
+          counterMap.set(t, 0);
+        }
+        const c = counterMap.get(t)!;
+        counterMap.set(t, c + 1);
+        const id = `_ref_${t}_${c}`;
         xref.node.setAttribute('id', id);
         xref.id = id;
       }

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -86,13 +86,9 @@ export function replacerForNamespace(
 ): { replacer: RegExp; autolinkmap: AutoLinkMap } {
   const autolinkmap: AutoLinkMap = {};
 
-  biblio
-    .inScopeByType(namespace, 'term')
-    .forEach(entry => (autolinkmap[narrowSpace(entry.key.toLowerCase())] = entry));
-
-  biblio
-    .inScopeByType(namespace, 'op')
-    .forEach(entry => (autolinkmap[narrowSpace(entry.key.toLowerCase())] = entry));
+  Object.entries(biblio.getDefinedWords(namespace)).forEach(([key, entry]) => {
+    autolinkmap[narrowSpace(key.toLowerCase())] = entry;
+  });
 
   const replacer = new RegExp(
     regexpPatternForAutolinkKeys(autolinkmap, Object.keys(autolinkmap), 0),
@@ -113,7 +109,7 @@ function isCommonAbstractOp(op: string) {
 }
 
 function lookAheadBeyond(entry: BiblioEntry) {
-  if (entry.type === 'op' && isCommonAbstractOp(entry.key)) {
+  if (isCommonAbstractOp(entry.key)) {
     // must be followed by parentheses
     return '\\b(?=\\()';
   }

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -84,31 +84,7 @@ export function replacerForNamespace(
   namespace: string,
   biblio: Biblio
 ): { replacer: RegExp; autolinkmap: AutoLinkMap } {
-  const autolinkmap: AutoLinkMap = {};
-
-  Object.entries(biblio.getDefinedWords(namespace)).forEach(([key, entry]) => {
-    // if (narrowSpace(key.toLowerCase()) !== narrowSpace(key)) {
-    //   if (autolinkmap[narrowSpace(key.toLowerCase())]) {
-    //     console.log('dupe', key);
-    //   }
-    // }
-
-    // this is a dumb kludge necessitated by ecma262 dfn'ing both "type" and "Type"
-    // the latter originally masked the former, so that it didn't actually end up linking all usages of the word "type"
-    // we've changed the logic a bit so that masking no longer happens, and consequently the autolinker adds a bunch of spurious links
-    // this can be removed once ecma262 no longer dfn's it and we update ecma262-biblio
-    if (key === 'type') {
-      return;
-    }
-
-    if (/^[a-z]/.test(key)) {
-      // include capitalized variant of words
-      // starting with lowercase letter
-      autolinkmap[narrowSpace(key[0].toUpperCase() + key.slice(1))] = entry;
-    }
-
-    autolinkmap[narrowSpace(key)] = entry;
-  });
+  const autolinkmap: AutoLinkMap = biblio.getDefinedWords(namespace);
 
   const replacer = new RegExp(
     regexpPatternForAutolinkKeys(autolinkmap, Object.keys(autolinkmap), 0),

--- a/test/biblio.js
+++ b/test/biblio.js
@@ -57,7 +57,7 @@ describe('Biblio', () => {
     assert(str.indexOf('aoid2') === -1);
   });
 
-  describe('inScopeByType', () => {
+  describe('getDefinedWords', () => {
     specify('de-dupes by key', () => {
       const opEntry1 = {
         type: 'op',
@@ -74,8 +74,8 @@ describe('Biblio', () => {
       biblio.add(opEntry1, location);
       biblio.add(opEntry2, 'global');
 
-      let results = biblio.inScopeByType(location, 'op');
-      assert.equal(results[0], opEntry1);
+      let results = biblio.getDefinedWords(location);
+      assert.equal(results.aoid, opEntry1);
     });
   });
 });


### PR DESCRIPTION
Basically, instead of having a `inScopeByType` method which is only called by the autolinker, instead have a `getDefinedWords` method which returns the appropriate mapping. 

Also, instead of the mapping having exclusively lowercased entries and calling `.toLowerCase` before looking stuff up in it, just have both the all-lowercase and first-letter-capitalized versions of terms which start with a lowercase letter. 

Unfortunately the original behavior was masking the fact that ecma262 defines `"type"`, which it uses all over the place without actually wanting it to be linked to that definition - it also defines `"Type"`, and the lowercasing meant that the latter entirely clobbered the former so that it didn't end up getting linked. With the new logic, that clobbering would no longer happen, and we'd add a bunch of spurious links. I've added a kludge to stop that until we update ecma262 and ecma262-biblio to not have `"type"` defined.

I've confirmed this generates the same biblio on ecma262. It's purely a refactoring, unless you consider the methods on the `Biblio` class to be part of the public API.

---

The actual motivation for this PR is to make it the biblio's responsibility for handling entries with multiple keys, so that it will be easier to introduce `<dfn variants="whatever">` later.