### PR TITLE
support ins/del in structured headers

### DIFF
--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -103,7 +103,16 @@ export default class Clause extends Builder {
     if (type === 'sdo' && (formattedHeader ?? header.innerHTML).includes('(')) {
       // SDOs are rendered without parameter lists in the header, for the moment
       const currentHeader = formattedHeader ?? header.innerHTML;
-      header.innerHTML = currentHeader.substring(0, currentHeader.indexOf('(')).trim();
+      header.innerHTML = (
+        currentHeader.substring(0, currentHeader.indexOf('(')) +
+        currentHeader.substring(currentHeader.lastIndexOf(')') + 1)
+      ).trim();
+      if (
+        header.children.length === 1 &&
+        ['INS', 'DEL', 'MARK'].includes(header.children[0].tagName)
+      ) {
+        header.children[0].innerHTML = header.children[0].innerHTML.trim();
+      }
     } else if (formattedHeader != null) {
       header.innerHTML = formattedHeader;
     }

--- a/test/baselines/generated-reference/structured-headers.html
+++ b/test/baselines/generated-reference/structured-headers.html
@@ -11,15 +11,27 @@
   <emu-alg><ol><li>Algorithm steps go here.</li></ol></emu-alg>
 </emu-clause>
 
+<emu-clause id="sec-exampleao2" type="abstract operation" aoid="ExampleAO2">
+  <h1><span class="secnum">2</span> <ins>ExampleAO2 ( param )</ins></h1>
+  <p>The abstract operation ExampleAO2 takes argument param (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>). It performs the following steps when called:</p>
+  <emu-alg><ol><li>Algorithm steps go here.</li></ol></emu-alg>
+</emu-clause>
+
+<emu-clause id="sec-exampleao3" type="abstract operation" aoid="ExampleAO3">
+  <h1><span class="secnum">3</span> ExampleAO3 ( <del>param</del> )</h1>
+  <p>The abstract operation ExampleAO3 takes argument <del>param (an <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>)</del>. It performs the following steps when called:</p>
+  <emu-alg><ol><li>Algorithm steps go here.</li></ol></emu-alg>
+</emu-clause>
+
 <emu-clause id="sec-example-grammar">
-  <h1><span class="secnum">2</span> This and That</h1>
+  <h1><span class="secnum">4</span> This and That</h1>
   <emu-grammar type="definition"><emu-production name="PrimaryExpression" id="prod-PrimaryExpression">
     <emu-nt><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jo4mwtvh" id="prod-Joc9-5i9"><emu-t>this</emu-t></emu-rhs>
     <emu-rhs a="_ditw-4g" id="prod-QC7Z2SC4"><emu-t>that</emu-t></emu-rhs>
 </emu-production>
 </emu-grammar>
   <emu-clause id="sec-isthis" type="sdo" aoid="IsThis">
-    <h1><span class="secnum">2.1</span> IsThis</h1>
+    <h1><span class="secnum">4.1</span> IsThis</h1>
     <p>The <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> IsThis takes no arguments. It is an example. It is defined piecewise over the following productions:</p>
     <emu-grammar><emu-production name="PrimaryExpression" collapsed="">
     <emu-nt><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jo4mwtvh" id="prod-oDKnYE2s"><emu-t>this</emu-t></emu-rhs>
@@ -33,7 +45,7 @@
     <emu-alg><ol><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
   </emu-clause>
   <emu-clause id="sec-isthat" type="sdo" aoid="IsThat">
-    <h1><span class="secnum">2.2</span> IsThat</h1>
+    <h1><span class="secnum">4.2</span> IsThat</h1>
     <p>The <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> IsThat takes argument <var>ignored</var> (an example). It is defined piecewise over the following productions:</p>
     <emu-grammar><emu-production name="PrimaryExpression" collapsed="">
     <emu-nt><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jo4mwtvh" id="prod-QDgm4qgx"><emu-t>this</emu-t></emu-rhs>

--- a/test/baselines/sources/structured-headers.html
+++ b/test/baselines/sources/structured-headers.html
@@ -23,6 +23,32 @@
   </emu-alg>
 </emu-clause>
 
+<emu-clause id="sec-exampleao2" type="abstract operation">
+  <h1>
+    <ins>ExampleAO2 (
+      param : an integer,
+    )</ins>
+  </h1>
+  <dl class='header'>
+  </dl>
+  <emu-alg>
+    1. Algorithm steps go here.
+  </emu-alg>
+</emu-clause>
+
+<emu-clause id="sec-exampleao3" type="abstract operation">
+  <h1>
+    ExampleAO3 (
+      <del>param : an integer,</del>
+    )
+  </h1>
+  <dl class='header'>
+  </dl>
+  <emu-alg>
+    1. Algorithm steps go here.
+  </emu-alg>
+</emu-clause>
+
 <emu-clause id="sec-example-grammar">
   <h1>This and That</h1>
   <emu-grammar type="definition">


### PR DESCRIPTION
Fixes #350. Also adds support for `ins`/`del` around individual parameters, which does

<details>
<summary>the right thing.</summary>
<img width="783" alt="Screen Shot 2021-09-11 at 9 02 46 PM" src="https://user-images.githubusercontent.com/1653598/132971711-5b1ce1db-075d-4700-acc4-1d46ada4fbb7.png">
</details>

Based on #358; marked as a draft until that lands.
