### PR TITLE
teach linter about emu-meta tags

### DIFF
--- a/src/lint/collect-tag-diagnostics.ts
+++ b/src/lint/collect-tag-diagnostics.ts
@@ -1,6 +1,7 @@
 import type { default as Spec, Warning } from '../Spec';
 
 const knownEmuTags = new Set([
+  'emu-meta',
   'emu-import',
   'emu-example',
   'emu-intro',


### PR DESCRIPTION
This got left out of https://github.com/tc39/ecmarkup/pull/362.