### PR TITLE
Pin grammarkdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "9.6.2",
+	"version": "9.6.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "9.6.2",
+	"version": "9.6.3",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"ecmarkdown": "^6.0.2",
 		"eslint": "^7.29.0",
 		"fast-glob": "^3.2.7",
-		"grammarkdown": "^3.1.1",
+		"grammarkdown": "3.1.2",
 		"highlight.js": "11.0.1",
 		"html-escape": "^1.0.2",
 		"js-yaml": "^3.13.1",


### PR DESCRIPTION
We'll need to update the formatter to handle https://github.com/rbuckton/grammarkdown/pull/81. In the mean time, pin grammarkdown to the version before that PR.