### PR TITLE
switch from nomnom to command-line-args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -191,6 +191,18 @@
 			"integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
 			"dev": true
 		},
+		"@types/command-line-args": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
+			"integrity": "sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA==",
+			"dev": true
+		},
+		"@types/command-line-usage": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
+			"integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==",
+			"dev": true
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -225,12 +237,6 @@
 			"version": "13.13.52",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
 			"integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
-			"dev": true
-		},
-		"@types/nomnom": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@types/nomnom/-/nomnom-0.0.27.tgz",
-			"integrity": "sha1-0XK41iN8w1FN3LIyuhMmIdJKNrQ=",
 			"dev": true
 		},
 		"@types/tough-cookie": {
@@ -410,6 +416,11 @@
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
+		},
+		"array-back": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+			"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -623,6 +634,66 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"command-line-args": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+			"integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+			"requires": {
+				"array-back": "^3.1.0",
+				"find-replace": "^3.0.0",
+				"lodash.camelcase": "^4.3.0",
+				"typical": "^4.0.0"
+			}
+		},
+		"command-line-usage": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+			"integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+			"requires": {
+				"array-back": "^4.0.1",
+				"chalk": "^2.4.2",
+				"table-layout": "^1.0.1",
+				"typical": "^5.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"array-back": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+					"integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
 		"commander": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -721,6 +792,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
 			"integrity": "sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU="
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.4",
@@ -1156,6 +1232,14 @@
 				"to-regex-range": "^5.0.1"
 			}
 		},
+		"find-replace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+			"requires": {
+				"array-back": "^3.0.1"
+			}
+		},
 		"find-up": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1357,11 +1441,6 @@
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
-		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -1657,6 +1736,11 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -1860,37 +1944,6 @@
 						"tr46": "~0.0.3",
 						"webidl-conversions": "^3.0.0"
 					}
-				}
-			}
-		},
-		"nomnom": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-			"requires": {
-				"chalk": "~0.4.0",
-				"underscore": "~1.6.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-				},
-				"chalk": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
 				}
 			}
 		},
@@ -2165,6 +2218,11 @@
 				"find-up": "^1.0.0",
 				"read-pkg": "^1.0.0"
 			}
+		},
+		"reduce-flatten": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
 		},
 		"regenerator-runtime": {
 			"version": "0.13.9",
@@ -2539,6 +2597,29 @@
 				}
 			}
 		},
+		"table-layout": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+			"integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+			"requires": {
+				"array-back": "^4.0.1",
+				"deep-extend": "~0.6.0",
+				"typical": "^5.2.0",
+				"wordwrapjs": "^4.0.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+					"integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2623,17 +2704,17 @@
 			"integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
 			"dev": true
 		},
+		"typical": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+		},
 		"uglify-js": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
 			"integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
 			"dev": true,
 			"optional": true
-		},
-		"underscore": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-			"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 		},
 		"uri-js": {
 			"version": "4.4.1",
@@ -2733,6 +2814,22 @@
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
+		},
+		"wordwrapjs": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+			"integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+			"requires": {
+				"reduce-flatten": "^2.0.0",
+				"typical": "^5.2.0"
+			},
+			"dependencies": {
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
 	"license": "MIT",
 	"dependencies": {
 		"chalk": "^1.1.3",
+		"command-line-args": "^5.2.0",
+		"command-line-usage": "^6.1.1",
 		"dedent-js": "^1.0.1",
 		"ecmarkdown": "^7.0.0",
 		"eslint": "^7.29.0",
@@ -56,16 +58,16 @@
 		"html-escape": "^1.0.2",
 		"js-yaml": "^3.13.1",
 		"jsdom": "11.10.0",
-		"nomnom": "^1.8.1",
 		"prex": "^0.4.7",
 		"promise-debounce": "^1.0.1"
 	},
 	"devDependencies": {
 		"@types/chalk": "^0.4.31",
+		"@types/command-line-args": "^5.2.0",
+		"@types/command-line-usage": "^5.0.2",
 		"@types/js-yaml": "^3.12.1",
 		"@types/jsdom": "^11.12.0",
 		"@types/node": "^13.1.8",
-		"@types/nomnom": "0.0.27",
 		"@typescript-eslint/eslint-plugin": "^4.27.0",
 		"@typescript-eslint/parser": "^4.27.0",
 		"auto-changelog": "^1.16.2",

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1109,7 +1109,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
         type: 'global',
         ruleId: 'no-location',
         message:
-          "no spec location specified; biblio not generated. try --location or setting the location in the document's metadata block",
+          "no spec location specified; biblio not generated. try setting the location in the document's metadata block",
       });
       return {};
     }

--- a/src/arg-parser.ts
+++ b/src/arg-parser.ts
@@ -1,0 +1,103 @@
+import type { OptionDefinition } from 'command-line-usage';
+import * as commandLineArgs from 'command-line-args';
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(1);
+}
+
+export function parse<T extends readonly OptionDefinition[]>(
+  options: T,
+  printHelp: () => void
+): ArgsFromOptions<T> {
+  const def = options.find(o => o.defaultOption);
+  if (!def?.multiple) {
+    // this is just so I don't have to think about how to handle `--` in other cases
+    // not an inherent limitation
+    throw new Error('ecmarkup arg-parser requires a default option for now');
+  }
+
+  const argv = process.argv.slice(2);
+
+  let notParsed: string[] = [];
+  const dashDashIndex = argv.indexOf('--');
+  if (dashDashIndex !== -1) {
+    notParsed = argv.splice(dashDashIndex + 1);
+    argv.pop();
+  }
+
+  let args: ArgsFromOptions<T>;
+  try {
+    // @ts-ignore the types are wrong about mutability
+    args = commandLineArgs(options, { argv });
+  } catch (e: any) {
+    if (e?.name === 'UNKNOWN_OPTION') {
+      fail(`Unknown option ${e.optionName}`);
+    }
+    throw e;
+  }
+
+  // @ts-ignore it's fine
+  args[def.name] = (args[def.name] || []).concat(notParsed);
+
+  if (
+    (args as unknown as { help?: boolean }).help ||
+    (argv.length === 0 && notParsed.length === 0)
+  ) {
+    printHelp();
+    process.exit(0);
+  }
+
+  return args;
+}
+
+// here follows some typescript shenangans for infering the type of of the parsed arguments from the argument specification
+
+type Multiples<T> = T extends unknown
+  ? Extract<T, { multiple: true } | { lazyMultiple: true }>
+  : never;
+type Defaulted<T> = T extends unknown ? Extract<T, { defaultValue: unknown }> : never;
+type Optional<T> = T extends unknown ? Exclude<T, Multiples<T> | Defaulted<T>> : never;
+
+type ReturnTypeOrNull<T> = T extends (...args: unknown[]) => unknown ? ReturnType<T> : null;
+// prettier-ignore
+type ArgTypeForKey<T extends readonly OptionDefinition[], key extends string> =
+  ReturnTypeOrNull<Extract<T[number], { name: key; type?: unknown }>['type']>;
+
+// spread is from https://stackoverflow.com/a/49683575
+type OptionalPropertyNames<T> = {
+  [K in keyof T]-?: {} extends { [P in K]: T[K] } ? K : never;
+}[keyof T];
+
+type SpreadProperties<L, R, K extends keyof L & keyof R> = {
+  [P in K]: L[P] | Exclude<R[P], undefined>;
+};
+
+type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
+
+type SpreadTwo<L, R> = Id<
+  Pick<L, Exclude<keyof L, keyof R>> &
+    Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
+    Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &
+    SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>
+>;
+
+type Spread<A extends readonly unknown[]> = A extends [infer L, ...infer R]
+  ? SpreadTwo<L, Spread<R>>
+  : unknown;
+
+// this type is wrong: if you specify the flag but omit the argument you get `null`, not the default value
+// you should check those manually
+type ArgsFromOptions<T extends readonly OptionDefinition[]> = Spread<
+  [
+    {
+      [key in Multiples<T[number]>['name']]: ArgTypeForKey<T, key>[];
+    },
+    {
+      [key in Defaulted<T[number]>['name']]: ArgTypeForKey<T, key>;
+    },
+    {
+      [key in Optional<T[number]>['name']]?: ArgTypeForKey<T, key>;
+    }
+  ]
+>;

--- a/src/arg-parser.ts
+++ b/src/arg-parser.ts
@@ -51,7 +51,7 @@ export function parse<T extends readonly OptionDefinition[]>(
   return args;
 }
 
-// here follows some typescript shenangans for infering the type of of the parsed arguments from the argument specification
+// here follows some typescript shenanigans for inferring the type of of the parsed arguments from the argument specification
 
 type Multiples<T> = T extends unknown
   ? Extract<T, { multiple: true } | { lazyMultiple: true }>

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,64 +1,97 @@
-import * as path from 'path';
-import * as nomnom from 'nomnom';
-
-export const argParser = nomnom
-  .script('ecmarkup')
-  .help('Compile ecmarkup documents to html by passing your input file and output file.')
-  .options({
-    help: { abbr: 'h', flag: true, help: 'Display this help message' },
-    watch: { abbr: 'w', flag: true, help: 'Rebuild when files change' },
-    biblio: { abbr: 'b', metavar: 'FILE', help: 'Write a biblio file to FILE' },
-    ecma262Biblio: {
-      full: 'ecma-262-biblio',
-      flag: true,
-      default: true,
-      help: 'Load ECMA-262 biblio file',
-    },
-    assets: { choices: ['none', 'inline', 'external'], help: 'Link to css and js assets' },
-    cssOut: { full: 'css-out', metavar: 'FILE', help: 'Write Emu CSS dependencies to FILE' },
-    jsOut: { full: 'js-out', metavar: 'FILE', help: 'Write Emu JS dependencies to FILE' },
-    toc: { flag: true, help: "Don't include the table of contents" },
-    oldToc: { full: 'old-toc', flag: true, help: 'Use the old table of contents styling' },
-    lintSpec: {
-      full: 'lint-spec',
-      flag: true,
-      default: false,
-      help: 'Enforce some style and correctness checks',
-    },
-    lintFormatter: {
-      full: 'lint-formatter',
-      metavar: 'FORMAT',
-      default: 'codeframe',
-      help: 'The linting output formatter. Either the name of a built-in eslint formatter or the package name of an installed eslint compatible formatter.',
-    },
-    multipage: {
-      flag: true,
-      help: 'Generate a multipage version of the spec. Cannot be used with --js-out or --css-out.',
-    },
-    strict: {
-      flag: true,
-      default: false,
-      help: 'Exit with an error if there are warnings. Cannot be used with --watch.',
-    },
-    verbose: { flag: true, default: false, help: 'Display document build progress' },
-    version: {
-      abbr: 'v',
-      flag: true,
-      help: 'Display version info',
-      callback: printVersion,
-    },
-    infile: {
-      position: 0,
-      help: 'Input ecmarkup file',
-      required: true,
-    },
-    outfile: {
-      position: 1,
-      help: 'Output html or biblio file',
-    },
-  });
-
-function printVersion() {
-  const p = require(path.resolve(__dirname, '..', 'package.json'));
-  return 'ecmarkup v' + p.version;
-}
+export const options = [
+  {
+    name: 'help',
+    alias: 'h',
+    type: Boolean,
+    description: 'Display this help message',
+  },
+  {
+    name: 'watch',
+    alias: 'w',
+    type: Boolean,
+    description: 'Rebuild when files change',
+  },
+  {
+    name: 'biblio',
+    alias: 'b',
+    type: String,
+    typeLabel: '{underline file}',
+    description: 'Path to where the biblio.json should be written',
+  },
+  {
+    name: 'no-ecma-262-biblio',
+    type: Boolean,
+    description: 'Disable loading of built-in ECMA-262 biblio file',
+  },
+  {
+    name: 'assets',
+    type: String,
+    typeLabel: 'none|inline|external', // TODO I don't think we actually distinguish between inline and external
+    description: 'Link to css and js assets (default: inline, unless --multipage)',
+    defaultValue: 'inline',
+  },
+  {
+    name: 'css-out',
+    type: String,
+    typeLabel: '{underline file}',
+    description: 'Path to a file where the CSS assets should be written',
+  },
+  {
+    name: 'js-out',
+    type: String,
+    typeLabel: '{underline file}',
+    description: 'Path to a file where the JS assets should be written',
+  },
+  {
+    name: 'no-toc',
+    type: Boolean,
+    description: "Don't include the table of contents",
+  },
+  {
+    name: 'old-toc',
+    type: Boolean,
+    description: 'Use the old table of contents styling',
+  },
+  {
+    name: 'lint-spec',
+    type: Boolean,
+    description: 'Enforce some style and correctness checks',
+  },
+  {
+    // TODO this isn't just for lints, it's for all errors
+    name: 'lint-formatter',
+    type: String,
+    typeLabel: '{underline formatter}',
+    defaultValue: 'codeframe',
+    description:
+      'The linting output formatter; either the name of a built-in eslint formatter or the package name of an installed eslint compatible formatter (default: codeframe)',
+  },
+  {
+    name: 'multipage',
+    type: Boolean,
+    description:
+      'Generate a multipage version of the spec. Cannot be used with --js-out or --css-out.',
+  },
+  {
+    name: 'strict',
+    type: Boolean,
+    description: 'Exit with an error if there are warnings. Cannot be used with --watch.',
+  },
+  {
+    name: 'verbose',
+    type: Boolean,
+    description: 'Display document build progress',
+  },
+  {
+    name: 'version',
+    alias: 'v',
+    type: Boolean,
+    description: 'Display version info',
+  },
+  {
+    name: 'files',
+    type: String,
+    multiple: true,
+    defaultOption: true,
+  },
+] as const;


### PR DESCRIPTION
Fixes #348.

This is a breaking change because nomnom allowed you to pass arbitrary other arguments without failing, whereas this library will exit with an error (which is much more user-friendly). I have some other breaking changes I want to get in at the same time as this, so I'm going to leave this open until I get those done.