### PR TITLE
avoid replacing a node while walking through its children

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -306,6 +306,7 @@ export default class Spec {
   _effectWorklist: Map<string, Clause[]>;
   _effectfulAOs: Map<string, Clause>;
   _emuMetasToRender: Set<HTMLElement>;
+  _emuMetasToRemove: Set<HTMLElement>;
   refsByClause: { [refId: string]: [string] };
 
   private _fetch: (file: string, token: CancellationToken) => PromiseLike<string>;
@@ -351,6 +352,7 @@ export default class Spec {
     this._effectWorklist = new Map();
     this._effectfulAOs = new Map();
     this._emuMetasToRender = new Set();
+    this._emuMetasToRemove = new Set();
     this.refsByClause = Object.create(null);
 
     this.processMetadata();
@@ -480,7 +482,12 @@ export default class Spec {
     this._xrefs.forEach(xref => xref.build());
     this.log('Linking non-terminal references...');
     this._ntRefs.forEach(nt => nt.build());
-    this._emuMetasToRender.forEach(node => Meta.render(this, node));
+    this._emuMetasToRender.forEach(node => {
+      Meta.render(this, node);
+    });
+    this._emuMetasToRemove.forEach(node => {
+      node.replaceWith(...node.childNodes);
+    });
 
     if (this.opts.lintSpec) {
       this._ntStringRefs.forEach(({ name, loc, node, namespace }) => {

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -67,10 +67,7 @@ export default class Xref extends Builder {
       }
 
       spec._emuMetasToRender.delete(node.parentElement);
-
-      // Strip an outer <emu-meta> if present
-      const children = node.parentElement.childNodes;
-      node.parentElement.replaceWith(...children);
+      spec._emuMetasToRemove.add(node.parentElement);
     }
 
     // Invocations prefixed with ! supress the 'user-code' effect by


### PR DESCRIPTION
This causes [inscrutable bad things to happen](https://github.com/tc39/ecma262/runs/4478299183?check_suite_focus=true).

Instead, defer the removal to later, after we're finished walking.

Hard to write a test for it though.