### PR TITLE
better errors for issues with clauses

### DIFF
--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -222,7 +222,7 @@ export default class Clause extends Builder {
 
     let nextNumber = '';
     if (node.nodeName !== 'EMU-INTRO') {
-      nextNumber = clauseNumberer.next(clauseStack.length, node.nodeName === 'EMU-ANNEX').value;
+      nextNumber = clauseNumberer.next(clauseStack, node);
     }
     const parent = clauseStack[clauseStack.length - 1] || null;
 

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -444,7 +444,7 @@ export default class Spec {
       importStack: [],
       clauseStack: [],
       tagStack: [],
-      clauseNumberer: ClauseNumbers(),
+      clauseNumberer: ClauseNumbers(this),
       inNoAutolink: false,
       inAlg: false,
       inNoEmd: false,

--- a/test/baselines/sources/malformed.bad.html
+++ b/test/baselines/sources/malformed.bad.html
@@ -1,7 +1,2 @@
-<emu-annex id="sec-annex">
-  <h1>Annex</h1>
-</emu-annex>
-<emu-clause id="sec-clause">
-  <h1>Clause</h1>
-  <p>A clause cannot follow an annex and therefore this is malformed.</p>
-</emu-clause>
+<!-- emu-import requires href -->
+<emu-import></emu-import>

--- a/test/clauseIds.js
+++ b/test/clauseIds.js
@@ -11,36 +11,17 @@ describe('clause id generation', () => {
   });
 
   specify('generating clause ids', () => {
-    assert.strictEqual(iter.next(0).value, '1');
-    assert.strictEqual(iter.next(1).value, '1.1');
-    assert.strictEqual(iter.next(1).value, '1.2');
-    assert.strictEqual(iter.next(2).value, '1.2.1');
-    assert.strictEqual(iter.next(0).value, '2');
-    assert.strictEqual(iter.next(0, true).value, 'A');
-    assert.strictEqual(iter.next(1, true).value, 'A.1');
-    assert.strictEqual(iter.next(1, true).value, 'A.2');
-    assert.strictEqual(iter.next(2, true).value, 'A.2.1');
-    assert.strictEqual(iter.next(0, true).value, 'B');
-  });
-
-  specify('error thrown for skipping clauses', () => {
-    assert.throws(() => {
-      iter.next(2);
-    }, /Skipped clause/);
-  });
-
-  specify('error thrown for non-annex following annex', () => {
-    assert.throws(() => {
-      iter.next(0);
-      iter.next(0, true);
-      iter.next(0);
-    }, /Clauses cannot follow annexes/);
-  });
-
-  specify('error thrown for annex not starting at depth 0', () => {
-    assert.throws(() => {
-      iter.next(0);
-      iter.next(1, true);
-    }, /First annex must be at depth 0/);
+    const CLAUSE = { nodeName: 'EMU-CLAUSE' };
+    const ANNEX = { nodeName: 'EMU-ANNEX' };
+    assert.strictEqual(iter.next([], CLAUSE), '1');
+    assert.strictEqual(iter.next([{}], CLAUSE), '1.1');
+    assert.strictEqual(iter.next([{}], CLAUSE), '1.2');
+    assert.strictEqual(iter.next([{}, {}], CLAUSE), '1.2.1');
+    assert.strictEqual(iter.next([], CLAUSE), '2');
+    assert.strictEqual(iter.next([], ANNEX), 'A');
+    assert.strictEqual(iter.next([{}], ANNEX), 'A.1');
+    assert.strictEqual(iter.next([{}], ANNEX), 'A.2');
+    assert.strictEqual(iter.next([{}, {}], ANNEX), 'A.2.1');
+    assert.strictEqual(iter.next([], ANNEX), 'B');
   });
 });

--- a/test/errors.js
+++ b/test/errors.js
@@ -812,4 +812,40 @@ ${M}      </pre>
       { lintSpec: true }
     );
   });
+
+  it('clause after annex', async () => {
+    await assertError(
+      positioned`
+       <emu-annex id="sec-a">
+        <h1>Annex</h1>
+        </emu-annex>
+        ${M}<emu-clause id="sec-c">
+          <h1>Clause</h1>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'clause-after-annex',
+        nodeType: 'emu-clause',
+        message: 'clauses cannot follow annexes',
+      }
+    );
+  });
+
+  it('nested annex', async () => {
+    await assertError(
+      positioned`
+        <emu-clause id="sec-c">
+          <h1>Clause</h1>
+          ${M}<emu-annex id="sec-a">
+            <h1>Annex</h1>
+          </emu-annex>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'annex-depth',
+        nodeType: 'emu-annex',
+        message: 'first annex must be at depth 0',
+      }
+    );
+  });
 });


### PR DESCRIPTION
Throwing errors gives no context for where the problem is, plus it prevents what could otherwise have been a recoverable build. Use the usual `spec.warn` mechanism instead.