### PR TITLE
Rename Xref#canHaveEffect to Xref#shouldPropagateEffect

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -691,7 +691,7 @@ export default class Spec {
     const usersOfAoid: Map<string, Set<Clause>> = new Map();
     for (const xref of this._xrefs) {
       if (xref.clause == null || xref.aoid == null) continue;
-      if (!xref.canHaveEffect(effectName)) continue;
+      if (!xref.shouldPropagateEffect(effectName)) continue;
 
       if (xref.hasAddedEffect(effectName)) {
         maybeAddClauseToEffectWorklist(effectName, xref.clause, worklist);

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -88,7 +88,7 @@ export default class Xref extends Builder {
     }
   }
 
-  canHaveEffect(effectName: string) {
+  shouldPropagateEffect(effectName: string) {
     if (!this.isInvocation) return false;
     if (this.clause) {
       // Xrefs nested inside Abstract Closures should not propagate the


### PR DESCRIPTION
The current name is misleading. An xref can have an effect but not propagate it (e.g. due to fences). The actual suppression is done in Xref#build().