### PR TITLE
stop trying to use the ecmarkdown parse tree from the linting phase

### DIFF
--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -34,14 +34,10 @@ export default class Algorithm extends Builder {
     ); // TODO use original slice, forward this from linter
 
     let emdTree;
-    if ('ecmarkdownTree' in node) {
-      emdTree = (node as any).ecmarkdownTree;
-    } else {
-      try {
-        emdTree = emd.parseAlgorithm(innerHTML);
-      } catch (e) {
-        warnEmdFailure(spec.warn, node, e);
-      }
+    try {
+      emdTree = emd.parseAlgorithm(innerHTML);
+    } catch (e) {
+      warnEmdFailure(spec.warn, node, e);
     }
     if (emdTree == null) {
       node.innerHTML = wrapEmdFailure(innerHTML);


### PR DESCRIPTION
I just noticed that https://github.com/tc39/ecmarkup/pull/385/commits/80959f08caff5f09f69bfac318848a140de8ab28 doesn't work when passing `--lint-spec`, because that option moves the initial parse to an earlier phase and saves the result.

This PR drops that attempt to save on work and instead unconditionally parses the html again. This doesn't materially affect runtime, since ecmarkdown parsing is a tiny fraction of overall runtime (I did three runs building the spec with `--lint-spec` before and after this change and got [15.899s, 15.902s, 15.474s] and [15.799s, 15.620s, 15.297s] respectively).

We should maybe revisit this logic at some point, but this is fine for now.

I also updated the tests to run all the baselines with `--lint-spec` to ensure enabling linting doesn't affect the build output so this can't happen again. This adds 2 seconds to the test suite (on my machine), for about 8s -> 10s, which is a price I'm willing to pay.