### PR TITLE
Ensure emu-meta tags are fenced by the same mechanisms that xrefs are

### DIFF
--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -86,6 +86,10 @@ export default class Clause extends Builder {
       this.buildStructuredHeader(header);
     }
     this.header = header;
+    if (header == null) {
+      this.title = 'UNKNOWN';
+      this.titleHTML = 'UNKNOWN';
+    }
   }
 
   buildStructuredHeader(header: Element) {
@@ -239,26 +243,6 @@ export default class Clause extends Builder {
 
   static exit({ node, spec, clauseStack, inAlg, currentId }: Context) {
     const clause = clauseStack[clauseStack.length - 1];
-
-    const header = clause.header;
-    if (header == null) {
-      clause.title = 'UNKNOWN';
-      clause.titleHTML = 'UNKNOWN';
-    } else {
-      const headerClone = header.cloneNode(true) as Element;
-      for (const a of headerClone.querySelectorAll('a')) {
-        a.replaceWith(...a.childNodes);
-      }
-      clause.titleHTML = headerClone.innerHTML;
-      clause.title = headerClone.textContent;
-      if (clause.number) {
-        const numElem = clause.spec.doc.createElement('span');
-        numElem.setAttribute('class', 'secnum');
-        numElem.textContent = clause.number;
-        header.insertBefore(clause.spec.doc.createTextNode(' '), header.firstChild);
-        header.insertBefore(numElem, header.firstChild);
-      }
-    }
 
     clause.buildExamples();
     clause.buildNotes();

--- a/src/H1.ts
+++ b/src/H1.ts
@@ -1,0 +1,30 @@
+import Builder from './Builder';
+import type { Context } from './Context';
+
+export default class H1 extends Builder {
+  static elements = ['H1'];
+
+  static async enter() {
+    // do nothing
+  }
+
+  static async exit({ spec, node, clauseStack }: Context) {
+    const parent = clauseStack[clauseStack.length - 1] || null;
+    if (parent === null || parent.header !== node) {
+      return;
+    }
+    const headerClone = node.cloneNode(true) as Element;
+    for (const a of headerClone.querySelectorAll('a')) {
+      a.replaceWith(...a.childNodes);
+    }
+    parent.titleHTML = headerClone.innerHTML;
+    parent.title = headerClone.textContent;
+    if (parent.number) {
+      const numElem = spec.doc.createElement('span');
+      numElem.setAttribute('class', 'secnum');
+      numElem.textContent = parent.number;
+      node.insertBefore(spec.doc.createTextNode(' '), node.firstChild);
+      node.insertBefore(numElem, node.firstChild);
+    }
+  }
+}

--- a/src/Meta.ts
+++ b/src/Meta.ts
@@ -3,7 +3,8 @@ import type { Context } from './Context';
 
 import Builder from './Builder';
 
-import { validateEffects } from './utils';
+import { validateEffects, doesEffectPropagateToParent } from './utils';
+import { maybeAddClauseToEffectWorklist } from './Spec';
 
 export default class Meta extends Builder {
   static elements = ['EMU-META'];
@@ -20,13 +21,13 @@ export default class Meta extends Builder {
         node
       );
       for (const effect of effects) {
-        if (!parent.effects.includes(effect)) {
-          parent.effects.push(effect);
-          if (!spec._effectWorklist.has(effect)) {
-            spec._effectWorklist.set(effect, []);
-          }
-          spec._effectWorklist.get(effect)!.push(parent);
+        if (!doesEffectPropagateToParent(node, effect)) {
+          continue;
         }
+        if (!spec._effectWorklist.has(effect)) {
+          spec._effectWorklist.set(effect, []);
+        }
+        maybeAddClauseToEffectWorklist(effect, parent, spec._effectWorklist.get(effect)!);
       }
     }
     spec._emuMetasToRender.add(node);

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -260,7 +260,11 @@ function isEmuImportElement(node: Node): node is EmuImportElement {
   return node.nodeType === 1 && node.nodeName === 'EMU-IMPORT';
 }
 
-function maybeAddClauseToEffectWorklist(effectName: string, clause: Clause, worklist: Clause[]) {
+export function maybeAddClauseToEffectWorklist(
+  effectName: string,
+  clause: Clause,
+  worklist: Clause[]
+) {
   if (
     !worklist.includes(clause) &&
     clause.canHaveEffect(effectName) &&

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -29,6 +29,7 @@ import Xref from './Xref';
 import Eqn from './Eqn';
 import Biblio from './Biblio';
 import Meta from './Meta';
+import H1 from './H1';
 import {
   autolink,
   replacerForNamespace,
@@ -78,6 +79,7 @@ const builders: BuilderInterface[] = [
   ProdRef,
   Note,
   Meta,
+  H1,
 ];
 
 const visitorMap = builders.reduce((map, T) => {

--- a/test/baselines/generated-reference/effect-user-code.html
+++ b/test/baselines/generated-reference/effect-user-code.html
@@ -131,6 +131,6 @@
 <emu-clause id="sec-call-fenced-effects" type="abstract operation" aoid="CallFencedEffects">
   <h1><span class="secnum">22</span> CallFencedEffects()</h1>
   <p>The abstract operation CallFencedEffects takes no arguments. Effects don't propagate past fences in parent steps. It performs the following steps when called:</p>
-  <emu-alg><ol><li><emu-xref aoid="FencedEffects" id="_ref_19"><a href="#sec-fenced-effects" class="e-user-code">FencedEffects</a></emu-xref>().</li></ol></emu-alg>
+  <emu-alg><ol><li><emu-xref aoid="FencedEffects" id="_ref_19"><a href="#sec-fenced-effects">FencedEffects</a></emu-xref>().</li></ol></emu-alg>
 </emu-clause>
 </div></body>

--- a/test/baselines/generated-reference/effect-user-code.html
+++ b/test/baselines/generated-reference/effect-user-code.html
@@ -125,12 +125,12 @@
 <emu-clause id="sec-fenced-effects" type="abstract operation" aoid="FencedEffects">
   <h1><span class="secnum">21</span> FencedEffects()</h1>
   <p>The abstract operation FencedEffects takes no arguments. Effects don't propagate past fences in parent steps. A fence must be at the beginning of a step. It performs the following steps when called:</p>
-  <emu-alg><ol><li fence-effects="user-code">Fence.<ol><li><emu-xref aoid="UserCode" id="_ref_18"><a href="#sec-user-code" class="e-user-code">UserCode</a></emu-xref>().</li></ol></li></ol></emu-alg>
+  <emu-alg><ol><li fence-effects="user-code">Fence.<ol><li><emu-xref aoid="UserCode" id="_ref_18"><a href="#sec-user-code" class="e-user-code">UserCode</a></emu-xref>().</li><li>Let <var>foo</var> be the result of <span class="e-user-code">evaluating <var>someUserCode</var></span>.</li></ol></li></ol></emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-call-fenced-effects" type="abstract operation" aoid="CallFencedEffects">
   <h1><span class="secnum">22</span> CallFencedEffects()</h1>
   <p>The abstract operation CallFencedEffects takes no arguments. Effects don't propagate past fences in parent steps. It performs the following steps when called:</p>
-  <emu-alg><ol><li><emu-xref aoid="FencedEffects" id="_ref_19"><a href="#sec-fenced-effects">FencedEffects</a></emu-xref>().</li></ol></emu-alg>
+  <emu-alg><ol><li><emu-xref aoid="FencedEffects" id="_ref_19"><a href="#sec-fenced-effects" class="e-user-code">FencedEffects</a></emu-xref>().</li></ol></emu-alg>
 </emu-clause>
 </div></body>

--- a/test/baselines/sources/effect-user-code.html
+++ b/test/baselines/sources/effect-user-code.html
@@ -231,6 +231,7 @@ assets: none
   <emu-alg>
     1. [fence-effects="user-code"] Fence.
       1. UserCode().
+      1. Let _foo_ be the result of evaluating _someUserCode_.
   </emu-alg>
 </emu-clause>
 


### PR DESCRIPTION
Previously emu-meta effects propagated through fences.

Note that the first commit is just moving when stuff happens, and has no effect on its own. It should probably be reviewed separately from the third commit, which has the actual changes.