### PR TITLE
Revert "ecmascript spelling (#407)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "10.0.1",
+	"version": "10.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "10.0.1",
+	"version": "10.0.2",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -135,10 +135,6 @@ const matchers = [
     pattern: /(÷|&divide;)/gu,
     message: 'division should be written as "/", not "÷", per ISO 80000-2',
   },
-  {
-    pattern: /[Ee]cma[Ss]cript/gu,
-    message: "it's spelled ECMAScript",
-  },
 ];
 
 export function collectSpellingDiagnostics(

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -535,30 +535,6 @@ windows:${M}\r
     );
   });
 
-  it('ECMAScript', async () => {
-    await assertLint(
-      positioned`
-        <p>${M}ecmascript</p>
-      `,
-      {
-        ruleId: 'spelling',
-        nodeType: 'html',
-        message: "it's spelled ECMAScript",
-      }
-    );
-
-    await assertLint(
-      positioned`
-        <p>${M}EcmaScript</p>
-      `,
-      {
-        ruleId: 'spelling',
-        nodeType: 'html',
-        message: "it's spelled ECMAScript",
-      }
-    );
-  });
-
   it('negative', async () => {
     await assertLintFree(`
       <p>


### PR DESCRIPTION
This reverts https://github.com/tc39/ecmarkup/pull/407, because right now it's applying inside of attribute values, which is wrong. We should fix the spellchecker and then reland this, but I'm backing it out for now.