### PR TITLE
change rule for comparisons against -0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ecmarkup",
-	"version": "10.0.2",
+	"version": "11.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ecmarkup",
-			"version": "9.8.1",
+			"version": "11.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "10.0.2",
+	"version": "11.0.0",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -128,8 +128,17 @@ const matchers = [
     message: 'tags should not contain trailing whitespace',
   },
   {
-    pattern: /(?<=&[lg][et]; ?\*)-0\*/gu,
-    message: 'comparisons against floating-point zero should use positive zero',
+    pattern: /(?<=&lt; ?\*)\+0\*/gu,
+    message: '"less than" comparisons against floating-point zero should use negative zero',
+  },
+  {
+    pattern: /(?<=&gt; ?\*)-0\*/gu,
+    message: '"greater than" comparisons against floating-point zero should use positive zero',
+  },
+  {
+    pattern: /(?<=&[lg]e; ?\*)[+-]0\*/gu,
+    message:
+      'comparisons against floating-point zero should use strict comparisons (< or >); guard the equals case with "is"',
   },
   {
     pattern: /(÷|&divide;)/gu,

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -465,26 +465,15 @@ windows:${M}\r
     );
   });
 
-  it('comparison with *-0*', async () => {
+  it('comparison with *+/-0*', async () => {
     await assertLint(
       positioned`
-        <p>If _x_ &lt; *${M}-0*<sub>𝔽</sub></p>
+        <p>If _x_ &lt; *${M}+0*<sub>𝔽</sub></p>
       `,
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'comparisons against floating-point zero should use positive zero',
-      }
-    );
-
-    await assertLint(
-      positioned`
-        <p>If _x_ &le; *${M}-0*<sub>𝔽</sub></p>
-      `,
-      {
-        ruleId: 'spelling',
-        nodeType: 'html',
-        message: 'comparisons against floating-point zero should use positive zero',
+        message: '"less than" comparisons against floating-point zero should use negative zero',
       }
     );
 
@@ -495,18 +484,31 @@ windows:${M}\r
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'comparisons against floating-point zero should use positive zero',
+        message: '"greater than" comparisons against floating-point zero should use positive zero',
       }
     );
 
     await assertLint(
       positioned`
-        <p>If _x_ &ge; *${M}-0*<sub>𝔽</sub></p>
+        <p>If _x_ &le; *${M}-0*<sub>𝔽</sub></p>
       `,
       {
         ruleId: 'spelling',
         nodeType: 'html',
-        message: 'comparisons against floating-point zero should use positive zero',
+        message:
+          'comparisons against floating-point zero should use strict comparisons (< or >); guard the equals case with "is"',
+      }
+    );
+
+    await assertLint(
+      positioned`
+        <p>If _x_ &ge; *${M}+0*<sub>𝔽</sub></p>
+      `,
+      {
+        ruleId: 'spelling',
+        nodeType: 'html',
+        message:
+          'comparisons against floating-point zero should use strict comparisons (< or >); guard the equals case with "is"',
       }
     );
   });
@@ -586,7 +588,7 @@ windows:${M}\r
         Paragraphs with the open/close tags on their own line are OK.
       </p>
 
-      <p>Comparisons with positive zero are OK: _x_ &lt; *+0*<sub>𝔽</sub>, _x_ &le; *+0*<sub>𝔽</sub>, _x_ &gt; *+0*<sub>𝔽</sub>, _x_ &ge; *+0*<sub>𝔽</sub></p>
+      <p>Comparisons with appropriately-signed zero are OK: _x_ &lt; *-0*<sub>𝔽</sub>, _x_ &gt; *+0*<sub>𝔽</sub>.</p>
 
     `);
   });


### PR DESCRIPTION
I'm calling this major because it will break the build if you're using `--strict`, although we're not always consistent about that.

Includes version bump commit, so please **rebase**, not squash.