### PR TITLE
Put effects in biblio

### DIFF
--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -320,6 +320,7 @@ export interface AlgorithmBiblioEntry extends BiblioEntryBase {
   type: 'op';
   aoid: string;
   signature: null | Signature;
+  effects: string[];
   /*@internal*/ _node?: Element;
 }
 

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -40,7 +40,7 @@ export default class Clause extends Builder {
   notes: Note[];
   editorNotes: Note[];
   examples: Example[];
-  effects: string[];
+  readonly effects: string[]; // this is held by identity and mutated by Spec.ts
   signature: Signature | null;
 
   constructor(spec: Spec, node: HTMLElement, parent: Clause, number: string) {
@@ -221,7 +221,7 @@ export default class Clause extends Builder {
       this.aoid = name;
     }
 
-    this.effects = effects;
+    this.effects.push(...effects);
     for (const effect of effects) {
       if (!this.spec._effectWorklist.has(effect)) {
         this.spec._effectWorklist.set(effect, []);
@@ -348,6 +348,7 @@ export default class Clause extends Builder {
           aoid: clause.aoid,
           refId: clause.id,
           signature,
+          effects: clause.effects,
           _node: clause.node,
         };
         if (

--- a/src/Eqn.ts
+++ b/src/Eqn.ts
@@ -34,6 +34,7 @@ export default class Eqn extends Builder {
           aoid,
           id,
           signature: null,
+          effects: [],
         });
       } else {
         const clause = clauseStack[clauseStack.length - 1];
@@ -43,6 +44,7 @@ export default class Eqn extends Builder {
           aoid,
           refId: clauseId,
           signature: null,
+          effects: [],
         });
       }
     }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -251,13 +251,14 @@ function isEmuImportElement(node: Node): node is EmuImportElement {
   return node.nodeType === 1 && node.nodeName === 'EMU-IMPORT';
 }
 
+export type WorklistItem = { aoid: string | null; effects: string[] };
 export function maybeAddClauseToEffectWorklist(
   effectName: string,
   clause: Clause,
-  worklist: Clause[]
+  worklist: WorklistItem[]
 ) {
   if (
-    !worklist.includes(clause) &&
+    !worklist.some(i => i.aoid === clause.aoid) &&
     clause.canHaveEffect(effectName) &&
     !clause.effects.includes(effectName)
   ) {
@@ -300,7 +301,7 @@ export default class Spec {
   }[];
   _prodRefs: ProdRef[];
   _textNodes: { [s: string]: [TextNodeContext] };
-  _effectWorklist: Map<string, Clause[]>;
+  _effectWorklist: Map<string, WorklistItem[]>;
   _effectfulAOs: Map<string, string[]>;
   _emuMetasToRender: Set<HTMLElement>;
   _emuMetasToRemove: Set<HTMLElement>;
@@ -916,7 +917,7 @@ export default class Spec {
     }
   }
 
-  private propagateEffect(effectName: string, worklist: Clause[]) {
+  private propagateEffect(effectName: string, worklist: WorklistItem[]) {
     const usersOfAoid: Map<string, Set<Clause>> = new Map();
     for (const xref of this._xrefs) {
       if (xref.clause == null || xref.aoid == null) continue;
@@ -1328,6 +1329,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
             if (!this._effectWorklist.has(effect)) {
               this._effectWorklist.set(effect, []);
             }
+            this._effectWorklist.get(effect)!.push(entry);
           }
         }
       }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1322,7 +1322,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
     for (const biblio of biblios.concat(this.opts.extraBiblios ?? [])) {
       this.biblio.addExternalBiblio(biblio);
       for (const entry of biblio.entries) {
-        if (entry.type === 'op' && entry.effects.length > 0) {
+        if (entry.type === 'op' && entry.effects?.length > 0) {
           this._effectfulAOs.set(entry.aoid, entry.effects);
           for (const effect of entry.effects) {
             if (!this._effectWorklist.has(effect)) {

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -225,26 +225,28 @@ export default class Xref extends Builder {
         let effects = null;
         let classNames = null;
 
-        if (this.isInvocation) {
-          effects = spec.getEffectsByAoid(aoid);
-        }
-        if (this.addEffects !== null) {
-          if (effects !== null) {
-            effects = effects.concat(...this.addEffects);
-          } else {
-            effects = this.addEffects;
+        if (this.spec.opts.markEffects) {
+          if (this.isInvocation) {
+            effects = spec.getEffectsByAoid(aoid);
           }
-        }
+          if (this.addEffects !== null) {
+            if (effects !== null) {
+              effects = effects.concat(...this.addEffects);
+            } else {
+              effects = this.addEffects;
+            }
+          }
 
-        if (effects) {
-          if (this.suppressEffects !== null) {
-            effects = effects.filter(e => !this.suppressEffects!.includes(e));
-          }
-          if (effects.length !== 0) {
-            const parentClause = this.clause;
-            effects = parentClause ? effects.filter(e => parentClause.canHaveEffect(e)) : effects;
+          if (effects) {
+            if (this.suppressEffects !== null) {
+              effects = effects.filter(e => !this.suppressEffects!.includes(e));
+            }
             if (effects.length !== 0) {
-              classNames = effects.map(e => `e-${e}`).join(' ');
+              const parentClause = this.clause;
+              effects = parentClause ? effects.filter(e => parentClause.canHaveEffect(e)) : effects;
+              if (effects.length !== 0) {
+                classNames = effects.map(e => `e-${e}`).join(' ');
+              }
             }
           }
         }

--- a/src/args.ts
+++ b/src/args.ts
@@ -55,6 +55,11 @@ export const options = [
     description: 'Use the old table of contents styling',
   },
   {
+    name: 'mark-effects',
+    type: Boolean,
+    description: 'Render markers for effects like "user code" [UC]',
+  },
+  {
     name: 'lint-spec',
     type: Boolean,
     description: 'Enforce some style and correctness checks',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,6 +102,7 @@ const build = debounce(async function build() {
       extraBiblios: [],
       toc: !args['no-toc'],
       oldToc: !!args['old-toc'],
+      markEffects: !!args['mark-effects'],
       lintSpec: !!args['lint-spec'],
       assets: args.assets as 'none' | 'inline' | 'external',
     };

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -36,6 +36,7 @@ export interface Options {
   contributors?: string;
   toc?: boolean;
   oldToc?: boolean;
+  markEffects?: boolean;
   lintSpec?: boolean;
   cssOut?: string;
   jsOut?: string;

--- a/test/baselines/sources/effect-user-code.html
+++ b/test/baselines/sources/effect-user-code.html
@@ -2,6 +2,7 @@
 toc: false
 copyright: false
 assets: none
+markEffects: true
 </pre>
 
 <emu-clause id="sec-user-code" type="abstract operation">

--- a/test/biblio.js
+++ b/test/biblio.js
@@ -166,6 +166,7 @@ describe('Biblio', () => {
         assets: 'none',
         toc: false,
         extraBiblios: [spec1Biblio],
+        markEffects: true,
         location: 'https://example.com/spec2/',
         warn: e => {
           console.error('Error:', e);
@@ -179,5 +180,4 @@ describe('Biblio', () => {
       '<ol><li><emu-xref aoid="UserCode"><a href="https://example.com/spec/#sec-user-code" class="e-user-code">UserCode</a></emu-xref>().</li></ol>'
     );
   });
-
 });

--- a/test/biblio.js
+++ b/test/biblio.js
@@ -154,13 +154,21 @@ describe('Biblio', () => {
     let spec2 = await build(
       'root.html',
       () => `
-        <emu-clause id="d">
+        <emu-clause id="foo" aoid="Foo">
           <h1>Clause D</h1>
           <emu-alg>
             1. UserCode().
           </emu-alg>
         </emu-clause>
-      `,
+
+        <emu-clause id="r">
+          <h1>Clause R</h1>
+          <emu-alg id="calls-foo">
+            1. Foo().
+          </emu-alg>
+        </emu-clause>
+
+        `,
       {
         copyright: false,
         assets: 'none',
@@ -178,6 +186,10 @@ describe('Biblio', () => {
     assert.equal(
       renderedSpec2.document.querySelector('emu-alg').innerHTML,
       '<ol><li><emu-xref aoid="UserCode"><a href="https://example.com/spec/#sec-user-code" class="e-user-code">UserCode</a></emu-xref>().</li></ol>'
+    );
+    assert.equal(
+      renderedSpec2.document.querySelector('#calls-foo').innerHTML,
+      '<ol><li><emu-xref aoid="Foo" id="_ref_0"><a href="#foo" class="e-user-code">Foo</a></emu-xref>().</li></ol>'
     );
   });
 });


### PR DESCRIPTION
Based on https://github.com/tc39/ecmarkup/pull/425.

This makes the effects (right now, just "user code") be present in the exported biblio, for the benefit of other tooling and so that proposals can get the [UC] annotation.

However, because this requires additional work on behalf of consumers for the rendering to be accurate (namely, explicitly marking any roots of user code in their own text), this PR also makes the rendering opt-in. This is therefore a breaking change (because 262 will need to opt in to get its current behavior).