### PR TITLE
fix two markEffects bugs

### DIFF
--- a/src/Meta.ts
+++ b/src/Meta.ts
@@ -36,7 +36,7 @@ export default class Meta extends Builder {
   static render(spec: Spec, node: HTMLElement) {
     // This builder turns <emu-meta> tags that aren't removed during effect
     // propagation on invocations into <span>s so they are rendered.
-    if (node.hasAttribute('effects')) {
+    if (node.hasAttribute('effects') && spec.opts.markEffects) {
       const classNames = node
         .getAttribute('effects')!
         .split(',')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,12 +102,14 @@ const build = debounce(async function build() {
       extraBiblios: [],
       toc: !args['no-toc'],
       oldToc: !!args['old-toc'],
-      markEffects: !!args['mark-effects'],
       lintSpec: !!args['lint-spec'],
       assets: args.assets as 'none' | 'inline' | 'external',
     };
     if (args.verbose) {
       opts.log = utils.logVerbose;
+    }
+    if (args['mark-effects']) {
+      opts.markEffects = true;
     }
     let warned = false;
 


### PR DESCRIPTION
Two bugs from https://github.com/tc39/ecmarkup/pull/426:

- `markEffects` in the document metadata wasn't respected when using the CLI
- `markEffects` wasn't gating emu-meta tags, only xrefs