### PR TITLE
suppress error for productions defined in biblio

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1624,6 +1624,12 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
           }
           const name = production.getAttribute('name')!;
           if (!productions.has(name)) {
+            if (this.biblio.byProductionName(name) != null) {
+              // in an ideal world we'd keep the full grammar in the biblio so we could check for a matching RHS, not just a matching LHS
+              // but, we're not in that world
+              // https://github.com/tc39/ecmarkup/issues/431
+              continue;
+            }
             this.warn({
               type: 'node',
               node: grammar,

--- a/test/errors.js
+++ b/test/errors.js
@@ -1000,5 +1000,43 @@ ${M}      </pre>
         </emu-clause>
       `);
     });
+
+    it('negative: external biblio', async () => {
+      let upstream = await emu.build(
+        'root.html',
+        () => `
+          <emu-grammar type="definition">
+            Foo : \`a\`
+          </emu-grammar>
+        `,
+        {
+          copyright: false,
+          location: 'https://example.com/spec/',
+          warn: e => {
+            console.error('Error:', e);
+            throw new Error(e.message);
+          },
+        }
+      );
+      let upstreamBiblio = upstream.exportBiblio();
+
+      await assertErrorFree(
+        `
+          <emu-clause id="sec-example" type="sdo">
+            <h1>Static Semantics: Example</h1>
+            <dl class='header'></dl>
+            <emu-grammar>
+              Foo : \`a\`
+            </emu-grammar>
+            <emu-alg>
+              1. Return *true*.
+            </emu-alg>
+          </emu-clause>
+        `,
+        {
+          extraBiblios: [upstreamBiblio],
+        }
+      );
+    });
   });
 });

--- a/test/errors.js
+++ b/test/errors.js
@@ -3,7 +3,7 @@
 let assert = require('assert');
 let emu = require('../lib/ecmarkup');
 
-let { lintLocationMarker: M, positioned, assertError } = require('./utils.js');
+let { lintLocationMarker: M, positioned, assertError, assertErrorFree } = require('./utils.js');
 
 describe('errors', () => {
   it('no contributors', async () => {
@@ -931,5 +931,74 @@ ${M}      </pre>
       },
       { asImport: 'only' }
     );
+  });
+
+  describe('SDO defined over unknown production', () => {
+    it('unknown production', async () => {
+      await assertError(
+        positioned`
+          <emu-clause id="sec-example" type="sdo">
+            <h1>Static Semantics: Example</h1>
+            <dl class='header'></dl>
+            ${M}<emu-grammar>
+              Foo : \`a\`
+            </emu-grammar>
+            <emu-alg>
+              1. Return *true*.
+            </emu-alg>
+          </emu-clause>
+        `,
+        {
+          ruleId: 'grammar-shape',
+          nodeType: 'emu-grammar',
+          message: 'could not find definition corresponding to production Foo',
+        }
+      );
+    });
+
+    it('unknown rhs', async () => {
+      await assertError(
+        positioned`
+          <emu-grammar type="definition">
+            Foo : \`b\`
+          </emu-grammar>
+
+          <emu-clause id="sec-example" type="sdo">
+            <h1>Static Semantics: Example</h1>
+            <dl class='header'></dl>
+            ${M}<emu-grammar>
+              Foo : \`a\`
+            </emu-grammar>
+            <emu-alg>
+              1. Return *true*.
+            </emu-alg>
+          </emu-clause>
+        `,
+        {
+          ruleId: 'grammar-shape',
+          nodeType: 'emu-grammar',
+          message: 'could not find definition for rhs a',
+        }
+      );
+    });
+
+    it('negative', async () => {
+      await assertErrorFree(`
+        <emu-grammar type="definition">
+          Foo : \`a\`
+        </emu-grammar>
+
+        <emu-clause id="sec-example" type="sdo">
+          <h1>Static Semantics: Example</h1>
+          <dl class='header'></dl>
+          <emu-grammar>
+            Foo : \`a\`
+          </emu-grammar>
+          <emu-alg>
+            1. Return *true*.
+          </emu-alg>
+        </emu-clause>
+      `);
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/tc39/ecmarkup/issues/366. Also adds tests for the error (in the first commit), which we neglected to do in https://github.com/tc39/ecmarkup/pull/276.

Note that this doesn't make `--lint-spec` work, which will require additional changes.