### PR TITLE
support for SOURCE_DATE_EPOCH

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -64,7 +64,7 @@ ecmarkup spec.html out.html
       <tr><td>status</td><td>Status of specification. Can be `proposal`, `draft`, or `standard`. Default is `proposal`.</td></tr>
       <tr><td>stage</td><td>Stage of proposal. Must be a number if provided, but is optional. Sets `version` to `Stage N Draft`, but can be overridden.</td></tr>
       <tr><td>version</td><td>Version of specification, for example `6&lt;sup>th&lt;/sup> Edition` or `Draft 1`. Optional.</td></tr>
-      <tr><td>date</td><td>Date the spec was generated. Used for various pieces of boilerplate that include dates. Defaults to today's date.</td></tr>
+      <tr><td>date</td><td>Date the spec was generated. Used for various pieces of boilerplate that include dates. Defaults to the value of <a href="https://reproducible-builds.org/docs/source-date-epoch/">the SOURCE_DATE_EPOCH environment variable</a> (as a number of second since the Unix epoch) if it exists, otherwise defaults to today's date.</td></tr>
       <tr><td>shortname</td><td>Shortname of specification, for example `ECMA-262` or `ECMA-402`.</td></tr>
       <tr><td>location</td><td>URL of this specification. Use in conjunction with the biblio file to enable external specs to reference this one.</td></tr>
       <tr><td>copyright</td><td>Emit copyright and software license information. Boolean, default true.</td></tr>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -150,6 +150,14 @@ const build = debounce(async function build() {
       warnings.push(err);
     };
 
+    if (process.env.SOURCE_DATE_EPOCH) {
+      const ts = +process.env.SOURCE_DATE_EPOCH;
+      if (ts !== Math.floor(ts)) {
+        fail(`SOURCE_DATE_EPOCH value ${process.env.SOURCE_DATE_EPOCH} is not valid`);
+      }
+      opts.date = new Date(ts * 1000);
+    }
+
     const spec = await ecmarkup.build(args.files[0], utils.readFile, opts);
 
     if (args.verbose) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,10 +151,11 @@ const build = debounce(async function build() {
     };
 
     if (process.env.SOURCE_DATE_EPOCH) {
-      const ts = +process.env.SOURCE_DATE_EPOCH;
-      if (ts !== Math.floor(ts)) {
-        fail(`SOURCE_DATE_EPOCH value ${process.env.SOURCE_DATE_EPOCH} is not valid`);
+      const sde = process.env.SOURCE_DATE_EPOCH.trim();
+      if (!/^[0-9]+/.test(sde)) {
+        fail(`SOURCE_DATE_EPOCH value ${sde} is not valid`);
       }
+      const ts = +sde;
       opts.date = new Date(ts * 1000);
     }
 


### PR DESCRIPTION
Fixes #390, cc @ljharb.

This lets you do e.g. `SOURCE_DATE_EPOCH=$(date -r in.emu '+%s') ecmarkup in.emu out.html` to set the date in the rendered specification to the last modified date of `in.emu`, for reproducible builds.