### PR TITLE
Stop rejecting expanded-year dates as positive-signed real numbers

### DIFF
--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -42,7 +42,8 @@ const matchers = [
   },
   {
     // this needs its own rule to catch +0 as a real number
-    pattern: /(?<= )\+[0-9]/gu,
+    // (but not similar text such as expanded-year dates like +000000-01-01)
+    pattern: /(?<= )\+[0-9](?![0-9]*[+-])/gu,
     message: 'positive real numbers should not have a leading plus sign (+)',
   },
   {

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -553,6 +553,8 @@ windows:${M}\r
         *-0*<sub>𝔽</sub>
         *0*<sub>ℤ</sub>
         0
+        +000000-01-01T00:00:00Z
+        +275760-09-13T00:00:00Z
         behaviour
         array indices
         a non-negative integer


### PR DESCRIPTION
Fix #442