### PR TITLE
Use raw grammar for production matching

### DIFF
--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -1,4 +1,5 @@
 import type { Context } from './Context';
+import type { SourceFile } from 'grammarkdown';
 
 import Builder from './Builder';
 import { collectNonterminalsFromGrammar } from './lint/utils';
@@ -7,13 +8,17 @@ import { CoreAsyncHost, CompilerOptions, Grammar as GrammarFile, EmitFormat } fr
 const endTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/i;
 const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/gi;
 
+export type AugmentedGrammarEle = HTMLElement & {
+  grammarkdownOut: string;
+  grammarSource: SourceFile;
+};
+
 /*@internal*/
 export default class Grammar extends Builder {
   static async enter({ spec, node, clauseStack }: Context) {
     if ('grammarkdownOut' in node) {
       // i.e., we already parsed this during an earlier phase
-      // @ts-ignore
-      node.innerHTML = node.grammarkdownOut;
+      node.innerHTML = (node as AugmentedGrammarEle).grammarkdownOut;
       return;
     }
 
@@ -80,7 +85,14 @@ export default class Grammar extends Builder {
       spec._ntStringRefs = spec._ntStringRefs.concat(nonterminals);
     }
     await grammar.emit(undefined, (file, source) => {
+      if (grammar.rootFiles.length !== 1) {
+        throw new Error(
+          `grammarkdown file count mismatch: ${grammar.rootFiles.length}. This is a bug in ecmarkup; please report it.`
+        );
+      }
       node.innerHTML = source;
+      (node as AugmentedGrammarEle).grammarkdownOut = source;
+      (node as AugmentedGrammarEle).grammarSource = grammar.rootFiles[0];
     });
   }
 

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -11,7 +11,7 @@ import {
   Parameter,
 } from 'grammarkdown';
 
-import { getProductions, rhsMatches, getLocationInGrammar } from './utils';
+import { getProductions, rhsMatches, getLocationInGrammarFile } from './utils';
 
 export async function collectGrammarDiagnostics(
   report: (e: Warning) => void,
@@ -133,7 +133,7 @@ export async function collectGrammarDiagnostics(
           // https://github.com/tc39/ecmarkup/issues/431
           continue;
         }
-        const { line, column } = getLocationInGrammar(grammar, production.pos);
+        const { line, column } = getLocationInGrammarFile(grammar.sourceFiles[0], production.pos);
         report({
           type: 'contents',
           ruleId: 'undefined-nonterminal',
@@ -146,7 +146,7 @@ export async function collectGrammarDiagnostics(
       }
       for (const rhs of rhses) {
         if (!originalRhses.some(o => rhsMatches(rhs, o))) {
-          const { line, column } = getLocationInGrammar(grammar, rhs.pos);
+          const { line, column } = getLocationInGrammarFile(grammar.sourceFiles[0], rhs.pos);
           report({
             type: 'contents',
             ruleId: 'undefined-nonterminal',
@@ -163,7 +163,10 @@ export async function collectGrammarDiagnostics(
               return;
             }
             if (s.symbol.kind === SyntaxKind.NoSymbolHereAssertion) {
-              const { line, column } = getLocationInGrammar(grammar, s.symbol.pos);
+              const { line, column } = getLocationInGrammarFile(
+                grammar.sourceFiles[0],
+                s.symbol.pos
+              );
               report({
                 type: 'contents',
                 ruleId: `NLTH-in-SDO`,
@@ -179,7 +182,10 @@ export async function collectGrammarDiagnostics(
           })(rhs.head);
 
           if (rhs.constraints !== undefined) {
-            const { line, column } = getLocationInGrammar(grammar, rhs.constraints.pos);
+            const { line, column } = getLocationInGrammarFile(
+              grammar.sourceFiles[0],
+              rhs.constraints.pos
+            );
             report({
               type: 'contents',
               ruleId: `guard-in-SDO`,

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -93,7 +93,7 @@ export async function collectGrammarDiagnostics(
   // Also filter out any "unused parameter" warnings for grammar productions for which the parameter is used in an early error or SDO
 
   const oneOffGrammars: { grammarEle: Element; grammar: GrammarFile }[] = [];
-  const actualGrammarProductions = getProductions(grammar);
+  const actualGrammarProductions = getProductions(grammar.rootFiles);
   const grammarsAndRules = [
     ...sdos.map(s => ({ grammar: s.grammar, rules: [s.alg], type: 'syntax-directed operation' })),
     ...earlyErrors.map(e => ({ grammar: e.grammar, rules: e.lists, type: 'early error' })),
@@ -122,7 +122,7 @@ export async function collectGrammarDiagnostics(
     );
     await grammar.parse();
     oneOffGrammars.push({ grammarEle, grammar });
-    const productions = getProductions(grammar);
+    const productions = getProductions(grammar.sourceFiles);
 
     for (const [name, { production, rhses }] of productions) {
       const originalRhses = actualGrammarProductions.get(name)?.rhses;

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -10,16 +10,17 @@ import type {
   ButNotSymbol,
   OneOfSymbol,
   ArgumentList,
+  SourceFile,
 } from 'grammarkdown';
 import type { Node as EcmarkdownNode } from 'ecmarkdown';
 
 import { Grammar as GrammarFile, SyntaxKind, skipTrivia, NodeVisitor } from 'grammarkdown';
 import * as emd from 'ecmarkdown';
 
-export function getProductions(grammar: GrammarFile) {
+export function getProductions(sourceFiles: readonly SourceFile[]) {
   const productions: Map<string, { production: Production; rhses: (RightHandSide | OneOfList)[] }> =
     new Map();
-  grammar.rootFiles.forEach(f =>
+  sourceFiles.forEach(f =>
     f.elements.forEach(e => {
       if (e.kind !== SyntaxKind.Production) {
         // The alternatives supported by Grammarkdown are imports and defines, which ecma-262 does not use.

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -171,8 +171,7 @@ function argumentListMatches(a: ArgumentList, b: ArgumentList) {
 }
 
 // this is only for use with single-file grammars
-export function getLocationInGrammar(grammar: GrammarFile, pos: number) {
-  const file = grammar.sourceFiles[0];
+export function getLocationInGrammarFile(file: SourceFile, pos: number) {
   const posWithoutWhitespace = skipTrivia(file.text, pos, file.text.length);
   const { line: gmdLine, character: gmdCharacter } = file.lineMap.positionAt(posWithoutWhitespace);
   // grammarkdown use 0-based line and column, we want 1-based
@@ -190,7 +189,7 @@ class CollectNonterminalsFromGrammar extends NodeVisitor {
   visitProduction(node: Production): Production {
     this.results.push({
       name: node.name.text!,
-      loc: getLocationInGrammar(this.grammar, node.name.pos),
+      loc: getLocationInGrammarFile(this.grammar.sourceFiles[0], node.name.pos),
     });
     return super.visitProduction(node);
   }
@@ -198,7 +197,7 @@ class CollectNonterminalsFromGrammar extends NodeVisitor {
   visitNonterminal(node: Nonterminal): Nonterminal {
     this.results.push({
       name: node.name.text!,
-      loc: getLocationInGrammar(this.grammar, node.name.pos),
+      loc: getLocationInGrammarFile(this.grammar.sourceFiles[0], node.name.pos),
     });
     return super.visitNonterminal(node);
   }

--- a/test/errors.js
+++ b/test/errors.js
@@ -1005,6 +1005,23 @@ ${M}      </pre>
           </emu-alg>
         </emu-clause>
       `);
+
+      await assertErrorFree(`
+        <emu-grammar type="definition">
+          Foo : \`a\` <ins>\`;\`</ins>
+        </emu-grammar>
+
+        <emu-clause id="sec-example" type="sdo">
+          <h1>Static Semantics: Example</h1>
+          <dl class='header'></dl>
+          <emu-grammar>
+            Foo : \`a\` <ins>\`;\`</ins>
+          </emu-grammar>
+          <emu-alg>
+            1. Return *true*.
+          </emu-alg>
+        </emu-clause>
+      `);
     });
 
     it('negative: external biblio', async () => {

--- a/test/errors.js
+++ b/test/errors.js
@@ -946,8 +946,8 @@ ${M}      </pre>
           <emu-clause id="sec-example" type="sdo">
             <h1>Static Semantics: Example</h1>
             <dl class='header'></dl>
-            ${M}<emu-grammar>
-              Foo : \`a\`
+            <emu-grammar>
+              ${M}Foo : \`a\`
             </emu-grammar>
             <emu-alg>
               1. Return *true*.
@@ -972,8 +972,8 @@ ${M}      </pre>
           <emu-clause id="sec-example" type="sdo">
             <h1>Static Semantics: Example</h1>
             <dl class='header'></dl>
-            ${M}<emu-grammar>
-              Foo : \`a\`
+            <emu-grammar>
+              Foo : ${M}\`a\`
             </emu-grammar>
             <emu-alg>
               1. Return *true*.
@@ -983,7 +983,7 @@ ${M}      </pre>
         {
           ruleId: 'grammar-shape',
           nodeType: 'emu-grammar',
-          message: 'could not find definition for rhs a',
+          message: 'could not find definition for rhs "a"',
         }
       );
     });


### PR DESCRIPTION
When building the SDO map we [look for matching productions](https://github.com/tc39/ecmarkup/blob/9e0ebcc9faca24c168f77bf0f7c9ce6fe8758378/src/Spec.ts#L1645). Prior to this PR that's done by matching on the output of grammarkdown. That duplicates logic and also fails to handle cases where nodes are wrapped in `<ins>`, etc.

This PR changes that logic to operate on the raw grammarkdown nodes, which hide the wrapping HTML tags where we don't need to worry about them, thus deduplicating some logic and also fixing https://github.com/tc39/ecmarkup/issues/448.

This requires associating the generated HTML elements with the underlying Grammarkdown objects. [For now](https://github.com/tc39/ecmarkup/issues/448) we do this in a slightly hacky way where we index two lists of RHSes and assume they agree, which works fine. It would be better to keep track of this information when creating the nodes in the first place.