### PR TITLE
Link "min" and "max" even when not followed by parentheses

### DIFF
--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -139,9 +139,7 @@ export interface AutoLinkMap {
 }
 
 function isCommonAbstractOp(op: string) {
-  return (
-    op === 'Call' || op === 'Set' || op === 'Type' || op === 'UTC' || op === 'min' || op === 'max'
-  );
+  return op === 'Call' || op === 'Set' || op === 'Type' || op === 'UTC';
 }
 
 function lookAheadBeyond(key: string, entry: BiblioEntry) {


### PR DESCRIPTION
Unlike "Call" and "Set" and "UTC", they are not used in either ECMA-262 or ECMA-402 except in reference to the specific corresponding operation, and it's weird that they aren't linked at the end of [Mathematical Operations](https://tc39.es/ecma262/multipage/notational-conventions.html#sec-mathematical-operations) in the way that "abs" and "floor" are.