### PR TITLE
Stop rejecting +HH:MM UTC offsets as positive-signed real numbers

### DIFF
--- a/src/lint/collect-spelling-diagnostics.ts
+++ b/src/lint/collect-spelling-diagnostics.ts
@@ -42,8 +42,9 @@ const matchers = [
   },
   {
     // this needs its own rule to catch +0 as a real number
-    // (but not similar text such as expanded-year dates like +000000-01-01)
-    pattern: /(?<= )\+[0-9](?![0-9]*[+-])/gu,
+    // (but not similar text such as expanded-year dates like +000000-01-01
+    // or UTC offsets like +00:00)
+    pattern: /(?<=^|\s)\+[0-9](?![0-9]*[-:])/gu,
     message: 'positive real numbers should not have a leading plus sign (+)',
   },
   {

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -554,6 +554,7 @@ windows:${M}\r
         0
         +000000-01-01T00:00:00Z
         +275760-09-13T00:00:00Z
+        +00:00
         behaviour
         array indices
         a non-negative integer


### PR DESCRIPTION
Ref 9ebc462eedd56958f5a54d621b29d510fb631eae