### PR TITLE
Expression parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"command-line-args": "^5.2.0",
 				"command-line-usage": "^6.1.1",
 				"dedent-js": "^1.0.1",
-				"ecmarkdown": "^7.0.0",
+				"ecmarkdown": "^7.1.0",
 				"eslint-formatter-codeframe": "^7.32.1",
 				"fast-glob": "^3.2.7",
 				"grammarkdown": "^3.2.0",
@@ -1115,9 +1115,9 @@
 			}
 		},
 		"node_modules/ecmarkdown": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.0.0.tgz",
-			"integrity": "sha512-hJxPALjSOpSMMcFjSzwzJBk8EWOu20mYlTfV7BnVTh9er0FEaT2eSx16y36YxqQfdFxPUsa0CSH4fLf0qUclKw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.1.0.tgz",
+			"integrity": "sha512-xTrf1Qj6nCsHGSHaOrAPfALoEH2nPSs+wclpzXEsozVJbEYcTkims59rJiJQB6TxAW2J4oFfoaB2up1wbb9k4w==",
 			"dependencies": {
 				"escape-html": "^1.0.1"
 			}
@@ -4370,9 +4370,9 @@
 			}
 		},
 		"ecmarkdown": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.0.0.tgz",
-			"integrity": "sha512-hJxPALjSOpSMMcFjSzwzJBk8EWOu20mYlTfV7BnVTh9er0FEaT2eSx16y36YxqQfdFxPUsa0CSH4fLf0qUclKw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.1.0.tgz",
+			"integrity": "sha512-xTrf1Qj6nCsHGSHaOrAPfALoEH2nPSs+wclpzXEsozVJbEYcTkims59rJiJQB6TxAW2J4oFfoaB2up1wbb9k4w==",
 			"requires": {
 				"escape-html": "^1.0.1"
 			}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"command-line-args": "^5.2.0",
 		"command-line-usage": "^6.1.1",
 		"dedent-js": "^1.0.1",
-		"ecmarkdown": "^7.0.0",
+		"ecmarkdown": "^7.1.0",
 		"eslint-formatter-codeframe": "^7.32.1",
 		"fast-glob": "^3.2.7",
 		"grammarkdown": "^3.2.0",

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -49,6 +49,8 @@ export default class Algorithm extends Builder {
 
     // @ts-ignore
     node.ecmarkdownTree = emdTree;
+    // @ts-ignore
+    node.originalHtml = innerHTML;
 
     if (spec.opts.lintSpec && spec.locate(node) != null && !node.hasAttribute('example')) {
       const clause = clauseStack[clauseStack.length - 1];

--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -316,9 +316,16 @@ export type Signature = {
   optionalParameters: Parameter[];
   return: null | Type;
 };
+export type AlgorithmType =
+  | 'abstract operation'
+  | 'host-defined abstract operation'
+  | 'implementation-defined abstract operation'
+  | 'syntax-directed operation'
+  | 'numeric method';
 export interface AlgorithmBiblioEntry extends BiblioEntryBase {
   type: 'op';
   aoid: string;
+  kind?: AlgorithmType;
   signature: null | Signature;
   effects: string[];
   /*@internal*/ _node?: Element;

--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -109,15 +109,13 @@ export default class Biblio {
     return this.lookup(ns, env => env._byAoid[aoid]);
   }
 
-  getSDONames(ns: string): Set<string> {
+  getOpNames(ns: string): Set<string> {
     const out = new Set<string>();
     let current = this._nsToEnvRec[ns];
     while (current) {
       const entries = current._byType['op'] || [];
       for (const entry of entries) {
-        if (entry.kind === 'syntax-directed operation') {
-          out.add(entry.aoid);
-        }
+        out.add(entry.aoid);
       }
       current = current._parent;
     }

--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -109,6 +109,21 @@ export default class Biblio {
     return this.lookup(ns, env => env._byAoid[aoid]);
   }
 
+  getSDONames(ns: string): Set<string> {
+    const out = new Set<string>();
+    let current = this._nsToEnvRec[ns];
+    while (current) {
+      const entries = current._byType['op'] || [];
+      for (const entry of entries) {
+        if (entry.kind === 'syntax-directed operation') {
+          out.add(entry.aoid);
+        }
+      }
+      current = current._parent;
+    }
+    return out;
+  }
+
   getDefinedWords(ns: string): Record<string, AlgorithmBiblioEntry | TermBiblioEntry> {
     const result = Object.create(null);
 

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -349,7 +349,9 @@ export default class Clause extends Builder {
       } else {
         const signature = clause.signature;
         let kind: AlgorithmType | undefined =
-          clause.type != null && aoidTypes.includes(clause.type) ? clause.type as AlgorithmType : undefined;
+          clause.type != null && aoidTypes.includes(clause.type)
+            ? (clause.type as AlgorithmType)
+            : undefined;
         // @ts-ignore
         if (kind === 'sdo') {
           kind = 'syntax-directed operation';

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -45,16 +45,11 @@ import {
 import { lint } from './lint/lint';
 import { CancellationToken } from 'prex';
 import type { JSDOM } from 'jsdom';
-import type {
-  OrderedListItemNode,
-  OrderedListNode,
-  parseAlgorithm,
-  UnorderedListItemNode,
-} from 'ecmarkdown';
+import type { OrderedListNode, parseAlgorithm } from 'ecmarkdown';
 import { getProductions, rhsMatches, getLocationInGrammarFile } from './lint/utils';
 import type { AugmentedGrammarEle } from './Grammar';
 import { offsetToLineAndColumn } from './utils';
-import { parse as parseExpr, walk as walkExpr, Expr } from './expr-parser';
+import { parse as parseExpr, walk as walkExpr, Expr, PathItem } from './expr-parser';
 
 const DRAFT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
   year: 'numeric',
@@ -484,8 +479,7 @@ export default class Spec {
 
     if (this.opts.lintSpec) {
       this.log('Checking types...');
-      this.checkCompletionUsage();
-      this.checkCalls();
+      this.typecheck();
     }
     this.log('Propagating effect annotations...');
     this.propagateEffects();
@@ -593,8 +587,8 @@ export default class Spec {
   }
 
   // checks that AOs which do/don't return completion records are invoked appropriately
-  private checkCompletionUsage() {
-    const isCall = (x: Xref) => x.isInvocation && x.clause != null && x.aoid != null;
+  // also checks that the appropriate number of arguments are passed
+  private typecheck() {
     const isUnused = (t: Type) =>
       t.kind === 'unused' ||
       (t.kind === 'completion' &&
@@ -605,146 +599,154 @@ export default class Spec {
     const onlyPerformed: Map<string, null | 'only performed' | 'top'> = new Map(
       AOs.filter(e => !isUnused(e.signature!.return!)).map(a => [a.aoid, null])
     );
-
     const alwaysAssertedToBeNormal: Map<string, null | 'always asserted normal' | 'top'> = new Map(
       AOs.filter(e => e.signature!.return!.kind === 'completion').map(a => [a.aoid, null])
     );
 
-    for (const xref of this._xrefs) {
-      if (!isCall(xref)) {
+    for (const node of this.doc.querySelectorAll('emu-alg')) {
+      if (node.hasAttribute('example') || !('ecmarkdownTree' in node)) {
         continue;
       }
-      const biblioEntry = this.biblio.byAoid(xref.aoid);
-      if (biblioEntry == null) {
-        this.warn({
-          type: 'node',
-          node: xref.node,
-          ruleId: 'xref-biblio',
-          message: `could not find biblio entry for xref ${JSON.stringify(xref.aoid)}`,
-        });
+      // @ts-ignore
+      const tree = node.ecmarkdownTree as ReturnType<typeof parseAlgorithm>;
+      if (tree == null) {
         continue;
       }
-      const signature = biblioEntry.signature;
-      if (signature == null) {
-        continue;
-      }
+      // @ts-ignore
+      const originalHtml: string = node.originalHtml;
 
-      const { return: returnType } = signature;
-      if (returnType == null) {
-        continue;
-      }
-
-      // this is really gross
-      // i am sorry
-      // the better approach is to make the xref-linkage logic happen on the level of the ecmarkdown tree
-      // so that we still have this information at that point
-      // rather than having to reconstruct it, approximately
-      // ... someday!
-      const warn = (message: string) => {
-        const path = [];
-        let pointer: HTMLElement | null = xref.node;
-        let alg: HTMLElement | null = null;
-        while (pointer != null) {
-          if (pointer.tagName === 'LI') {
-            // @ts-ignore
-            path.unshift([].indexOf.call(pointer.parentElement!.children, pointer));
-          }
-          if (pointer.tagName === 'EMU-ALG') {
-            alg = pointer;
-            break;
-          }
-          pointer = pointer.parentElement;
-        }
-        if (alg?.hasAttribute('example')) {
+      const expressionVisitor = (expr: Expr, path: PathItem[]) => {
+        if (expr.type !== 'call') {
           return;
         }
-        if (alg == null || !{}.hasOwnProperty.call(alg, 'ecmarkdownTree')) {
-          const ruleId = 'completion-invocation';
-          let pointer: Element | null = xref.node;
-          while (this.locate(pointer) == null) {
-            pointer = pointer.parentElement;
-            if (pointer == null) {
-              break;
-            }
-          }
-          if (pointer == null) {
-            this.warn({
-              type: 'global',
-              ruleId,
-              message: message + ` but I wasn't able to find a source location to give you, sorry!`,
-            });
-          } else {
-            this.warn({
-              type: 'node',
-              node: pointer,
-              ruleId,
-              message,
-            });
-          }
-        } else {
-          // @ts-ignore
-          const tree = alg.ecmarkdownTree as ReturnType<typeof parseAlgorithm>;
-          let stepPointer: OrderedListItemNode | UnorderedListItemNode = {
-            sublist: tree.contents,
-          } as OrderedListItemNode;
-          for (const step of path) {
-            stepPointer = stepPointer.sublist!.contents[step];
-          }
+
+        const { callee, arguments: args } = expr;
+        if (!(callee.parts.length === 1 && callee.parts[0].name === 'text')) {
+          return;
+        }
+        const calleeName = callee.parts[0].contents;
+
+        const warn = (message: string) => {
+          const { line, column } = offsetToLineAndColumn(
+            originalHtml,
+            callee.parts[0].location.start.offset
+          );
           this.warn({
             type: 'contents',
-            node: alg,
-            ruleId: 'invocation-return-type',
+            ruleId: 'typecheck',
             message,
-            nodeRelativeLine: stepPointer.location.start.line,
-            nodeRelativeColumn: stepPointer.location.start.column,
+            node,
+            nodeRelativeLine: line,
+            nodeRelativeColumn: column,
           });
-        }
-      };
+        };
 
-      const consumedAsCompletion = isConsumedAsCompletion(xref);
-      // checks elsewhere ensure that well-formed documents never have a union of completion and non-completion, so checking the first child suffices
-      // TODO: this is for 'a break completion or a throw completion', which is kind of a silly union; maybe address that in some other way?
-      const isCompletion =
-        returnType.kind === 'completion' ||
-        (returnType.kind === 'union' && returnType.types[0].kind === 'completion');
-      if (['Completion', 'ThrowCompletion', 'NormalCompletion'].includes(xref.aoid)) {
-        if (consumedAsCompletion) {
+        const biblioEntry = this.biblio.byAoid(calleeName);
+        if (biblioEntry == null) {
+          if (
+            ![
+              'thisTimeValue',
+              'thisStringValue',
+              'thisBigIntValue',
+              'thisNumberValue',
+              'thisSymbolValue',
+              'thisBooleanValue',
+              'toUppercase',
+              'toLowercase',
+              'ℝ',
+              '𝔽',
+              'ℤ',
+            ].includes(calleeName)
+          ) {
+            // TODO make the spec not do this
+            warn(`could not find definition for ${calleeName}`);
+          }
+          return;
+        } else if (biblioEntry.signature == null) {
+          return;
+        }
+        const min = biblioEntry.signature.parameters.length;
+        const max = min + biblioEntry.signature.optionalParameters.length;
+        if (args.length < min || args.length > max) {
+          const count = `${min}${min === max ? '' : `-${max}`}`;
+          // prettier-ignore
+          const message = `${calleeName} takes ${count} argument${count === '1' ? '' : 's'}, but this invocation passes ${args.length}`;
+          warn(message);
+        }
+
+        const { return: returnType } = biblioEntry.signature;
+        if (returnType == null) {
+          return;
+        }
+
+        const consumedAsCompletion = isConsumedAsCompletion(expr, path);
+
+        // checks elsewhere ensure that well-formed documents never have a union of completion and non-completion, so checking the first child suffices
+        // TODO: this is for 'a break completion or a throw completion', which is kind of a silly union; maybe address that in some other way?
+        const isCompletion =
+          returnType.kind === 'completion' ||
+          (returnType.kind === 'union' && returnType.types[0].kind === 'completion');
+        if (['Completion', 'ThrowCompletion', 'NormalCompletion'].includes(calleeName)) {
+          if (consumedAsCompletion) {
+            warn(
+              `${calleeName} clearly creates a Completion Record; it does not need to be marked as such, and it would not be useful to immediately unwrap its result`
+            );
+          }
+        } else if (isCompletion && !consumedAsCompletion) {
+          warn(`${calleeName} returns a Completion Record, but is not consumed as if it does`);
+        } else if (!isCompletion && consumedAsCompletion) {
+          warn(`${calleeName} does not return a Completion Record, but is consumed as if it does`);
+        }
+        if (returnType.kind === 'unused' && !isCalledAsPerform(expr, path, false)) {
           warn(
-            `${xref.aoid} clearly creates a Completion Record; it does not need to be marked as such, and it would not be useful to immediately unwrap its result`
+            `${calleeName} does not return a meaningful value and should only be invoked as \`Perform ${calleeName}(...).\``
           );
         }
-      } else if (isCompletion && !consumedAsCompletion) {
-        warn(`${xref.aoid} returns a Completion Record, but is not consumed as if it does`);
-      } else if (!isCompletion && consumedAsCompletion) {
-        warn(`${xref.aoid} does not return a Completion Record, but is consumed as if it does`);
-      }
-      if (returnType.kind === 'unused' && !isCalledAsPerform(xref, false)) {
-        warn(
-          `${xref.aoid} does not return a meaningful value and should only be invoked as \`Perform ${xref.aoid}(...).\``
-        );
-      }
 
-      if (onlyPerformed.has(xref.aoid) && onlyPerformed.get(xref.aoid) !== 'top') {
-        const old = onlyPerformed.get(xref.aoid);
-        const performed = isCalledAsPerform(xref, true);
-        if (!performed) {
-          onlyPerformed.set(xref.aoid, 'top');
-        } else if (old === null) {
-          onlyPerformed.set(xref.aoid, 'only performed');
+        if (onlyPerformed.has(calleeName) && onlyPerformed.get(calleeName) !== 'top') {
+          const old = onlyPerformed.get(calleeName);
+          const performed = isCalledAsPerform(expr, path, true);
+          if (!performed) {
+            onlyPerformed.set(calleeName, 'top');
+          } else if (old === null) {
+            onlyPerformed.set(calleeName, 'only performed');
+          }
         }
-      }
-      if (
-        alwaysAssertedToBeNormal.has(xref.aoid) &&
-        alwaysAssertedToBeNormal.get(xref.aoid) !== 'top'
-      ) {
-        const old = alwaysAssertedToBeNormal.get(xref.aoid);
-        const asserted = isAssertedToBeNormal(xref);
-        if (!asserted) {
-          alwaysAssertedToBeNormal.set(xref.aoid, 'top');
-        } else if (old === null) {
-          alwaysAssertedToBeNormal.set(xref.aoid, 'always asserted normal');
+        if (
+          alwaysAssertedToBeNormal.has(calleeName) &&
+          alwaysAssertedToBeNormal.get(calleeName) !== 'top'
+        ) {
+          const old = alwaysAssertedToBeNormal.get(calleeName);
+          const asserted = isAssertedToBeNormal(expr, path);
+          if (!asserted) {
+            alwaysAssertedToBeNormal.set(calleeName, 'top');
+          } else if (old === null) {
+            alwaysAssertedToBeNormal.set(calleeName, 'always asserted normal');
+          }
         }
-      }
+      };
+      const walkLines = (list: OrderedListNode) => {
+        for (const line of list.contents) {
+          const item = parseExpr(line.contents);
+          if (item.type === 'failure') {
+            const { line, column } = offsetToLineAndColumn(originalHtml, item.offset);
+            this.warn({
+              type: 'contents',
+              ruleId: 'expression-parsing',
+              message: item.message,
+              node,
+              nodeRelativeLine: line,
+              nodeRelativeColumn: column,
+            });
+          } else {
+            walkExpr(expressionVisitor, item);
+          }
+          if (line.sublist?.name === 'ol') {
+            walkLines(line.sublist);
+          }
+        }
+      };
+      walkLines(tree.contents);
     }
 
     for (const [aoid, state] of onlyPerformed) {
@@ -795,108 +797,6 @@ export default class Spec {
           message,
         });
       }
-    }
-  }
-
-  private checkCalls() {
-    for (const node of this.doc.querySelectorAll('emu-alg')) {
-      if (node.hasAttribute('example') || !('ecmarkdownTree' in node)) {
-        continue;
-      }
-      // @ts-ignore
-      const tree = node.ecmarkdownTree as ReturnType<typeof parseAlgorithm>;
-      if (tree == null) {
-        continue;
-      }
-      // @ts-ignore
-      const originalHtml: string = node.originalHtml;
-
-      const expressionVisitor = (expr: Expr) => {
-        if (expr.type !== 'call') {
-          return;
-        }
-
-        const { callee, arguments: args } = expr;
-        if (!(callee.parts.length === 1 && callee.parts[0].name === 'text')) {
-          return;
-        }
-        const calleeName = callee.parts[0].contents;
-        if (
-          [
-            'thisTimeValue',
-            'thisStringValue',
-            'thisBigIntValue',
-            'thisNumberValue',
-            'thisSymbolValue',
-            'thisBooleanValue',
-            'toUppercase',
-            'toLowercase',
-            'ℝ',
-            '𝔽',
-            'ℤ',
-          ].includes(calleeName)
-        ) {
-          // TODO make the spec not do this
-          return;
-        }
-        const biblioEntry = this.biblio.byAoid(calleeName);
-        if (biblioEntry == null) {
-          const { line, column } = offsetToLineAndColumn(
-            originalHtml,
-            callee.parts[0].location.start.offset
-          );
-          this.warn({
-            type: 'contents',
-            ruleId: 'typecheck',
-            message: `could not find definition for ${calleeName}`,
-            node,
-            nodeRelativeLine: line,
-            nodeRelativeColumn: column,
-          });
-        } else if (biblioEntry.signature != null) {
-          const min = biblioEntry.signature.parameters.length;
-          const max = min + biblioEntry.signature.optionalParameters.length;
-          if (args.length < min || args.length > max) {
-            const { line, column } = offsetToLineAndColumn(
-              originalHtml,
-              callee.parts[0].location.start.offset
-            );
-            const count = `${min}${min === max ? '' : `-${max}`}`;
-            // prettier-ignore
-            const message = `${calleeName} takes ${count} argument${count === '1' ? '' : 's'}, but this invocation passes ${args.length}`;
-            this.warn({
-              type: 'contents',
-              ruleId: 'typecheck',
-              message,
-              node,
-              nodeRelativeLine: line,
-              nodeRelativeColumn: column,
-            });
-          }
-        }
-      };
-      const walkLines = (list: OrderedListNode) => {
-        for (const line of list.contents) {
-          const item = parseExpr(line.contents);
-          if (item.type === 'failure') {
-            const { line, column } = offsetToLineAndColumn(originalHtml, item.offset);
-            this.warn({
-              type: 'contents',
-              ruleId: 'expression-parsing',
-              message: item.message,
-              node,
-              nodeRelativeLine: line,
-              nodeRelativeColumn: column,
-            });
-          } else {
-            walkExpr(expressionVisitor, item);
-          }
-          if (line.sublist?.name === 'ol') {
-            walkLines(line.sublist);
-          }
-        }
-      };
-      walkLines(tree.contents);
     }
   }
 
@@ -2173,56 +2073,75 @@ function pathFromRelativeLink(link: HTMLAnchorElement | HTMLLinkElement) {
   return link.href.startsWith('about:blank') ? link.href.substring(11) : link.href;
 }
 
-function isFirstChild(node: Node) {
-  const p = node.parentElement!;
-  return (
-    p.childNodes[0] === node || (p.childNodes[0].textContent === '' && p.childNodes[1] === node)
-  );
+function parentSkippingBlankSpace(expr: Expr, path: PathItem[]): PathItem | null {
+  for (let pointer: Expr = expr, i = path.length - 1; i >= 0; pointer = path[i].parent, --i) {
+    const { parent } = path[i];
+    if (
+      parent.type === 'seq' &&
+      parent.items.every(
+        i =>
+          (i.type === 'prose' &&
+            i.parts.every(
+              p => p.name === 'tag' || (p.name === 'text' && /^\s*$/.test(p.contents))
+            )) ||
+          i === pointer
+      )
+    ) {
+      // if parent is just whitespace/tags around the call, walk up the tree further
+      continue;
+    }
+    return path[i];
+  }
+  return null;
 }
 
-// TODO factor some of this stuff out
-function isCalledAsPerform(xref: Xref, allowQuestion: boolean) {
-  let node = xref.node;
-  if (node.parentElement?.tagName === 'EMU-META' && isFirstChild(node)) {
-    node = node.parentElement;
+function previousText(expr: Expr, path: PathItem[]): string | null {
+  const part = parentSkippingBlankSpace(expr, path);
+  if (part == null) {
+    return null;
   }
-  const previousSibling = node.previousSibling;
-  if (previousSibling?.nodeType !== 3 /* TEXT_NODE */) {
-    return false;
+  const { parent, index } = part;
+  if (parent.type === 'seq' && index > 0) {
+    const prev = parent.items[(index as number) - 1];
+    if (prev.type === 'prose' && prev.parts.length > 0) {
+      const prevProse = prev.parts[prev.parts.length - 1];
+      if (prevProse.name === 'text') {
+        return prevProse.contents;
+      }
+    }
   }
-  return (allowQuestion ? /\bperform ([?!]\s)?$/i : /\bperform $/i).test(
-    previousSibling.textContent!
-  );
+  return null;
 }
 
-function isAssertedToBeNormal(xref: Xref) {
-  let node = xref.node;
-  if (node.parentElement?.tagName === 'EMU-META' && isFirstChild(node)) {
-    node = node.parentElement;
-  }
-  const previousSibling = node.previousSibling;
-  if (previousSibling?.nodeType !== 3 /* TEXT_NODE */) {
-    return false;
-  }
-  return /\s!\s$/.test(previousSibling.textContent!);
+function isCalledAsPerform(expr: Expr, path: PathItem[], allowQuestion: boolean) {
+  const prev = previousText(expr, path);
+  return prev != null && (allowQuestion ? /\bperform ([?!]\s)?$/i : /\bperform $/i).test(prev);
 }
 
-function isConsumedAsCompletion(xref: Xref) {
-  let node = xref.node;
-  if (node.parentElement?.tagName === 'EMU-META' && isFirstChild(node)) {
-    node = node.parentElement;
-  }
-  const previousSibling = node.previousSibling;
-  if (previousSibling?.nodeType !== 3 /* TEXT_NODE */) {
+function isAssertedToBeNormal(expr: Expr, path: PathItem[]) {
+  const prev = previousText(expr, path);
+  return prev != null && /\s!\s$/.test(prev);
+}
+
+function isConsumedAsCompletion(expr: Expr, path: PathItem[]) {
+  const part = parentSkippingBlankSpace(expr, path);
+  if (part == null) {
     return false;
   }
-  if (/[!?]\s$/.test(previousSibling.textContent!)) {
-    return true;
-  }
-  if (previousSibling.textContent! === '(') {
-    // check for Completion(
-    const previousPrevious = previousSibling.previousSibling;
-    if (previousPrevious?.textContent === 'Completion') {
+  const { parent, index } = part;
+  if (parent.type === 'seq' && index > 0) {
+    // if the previous text ends in `! ` or `? `, this is a completion
+    const prev = parent.items[(index as number) - 1]; // typescript isn't quite smart enough to infer this, alas
+    if (prev.type === 'prose' && prev.parts.length > 0) {
+      const prevProse = prev.parts[prev.parts.length - 1];
+      if (prevProse.name === 'text' && /[!?]\s$/.test(prevProse.contents)) {
+        return true;
+      }
+    }
+  } else if (parent.type === 'call' && index === 0 && parent.arguments.length === 1) {
+    // if this is `Completion(Expr())`, this is a completion
+    const { parts } = parent.callee;
+    if (parts.length === 1 && parts[0].name === 'text' && parts[0].contents === 'Completion') {
       return true;
     }
   }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -657,9 +657,6 @@ export default class Spec {
               'thisBooleanValue',
               'toUppercase',
               'toLowercase',
-              'ℝ',
-              '𝔽',
-              'ℤ',
             ].includes(calleeName)
           ) {
             // TODO make the spec not do this

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -620,7 +620,6 @@ export default class Spec {
       const originalHtml: string = node.originalHtml;
 
       const expressionVisitor = (expr: Expr, path: PathItem[]) => {
-        // console.log(require('util').inspect(expr, { depth: Infinity }));
         if (expr.type !== 'call' && expr.type !== 'sdo-call') {
           return;
         }
@@ -758,7 +757,6 @@ export default class Spec {
               nodeRelativeColumn: column,
             });
           } else {
-            // console.log(require('util').inspect(item, { depth: Infinity}));
             walkExpr(expressionVisitor, item);
           }
           if (line.sublist?.name === 'ol') {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -604,7 +604,7 @@ export default class Spec {
     );
 
     // TODO strictly speaking this needs to be done in the namespace of the current algorithm
-    const sdoNames = this.biblio.getSDONames(this.namespace);
+    const opNames = this.biblio.getOpNames(this.namespace);
 
     // TODO move declarations out of loop
     for (const node of this.doc.querySelectorAll('emu-alg')) {
@@ -667,7 +667,15 @@ export default class Spec {
             warn(`could not find definition for ${calleeName}`);
           }
           return;
-        } else if (biblioEntry.signature == null) {
+        }
+
+        if (biblioEntry.kind === 'syntax-directed operation' && expr.type === 'call') {
+          warn(`${calleeName} is a syntax-directed operation and should not be invoked like a regular call`);
+        } else if (biblioEntry.kind != null && biblioEntry.kind !== 'syntax-directed operation' && expr.type === 'sdo-call') {
+          warn(`${calleeName} is not a syntax-directed operation but here is being invoked as one`);
+        }
+
+        if (biblioEntry.signature == null) {
           return;
         }
         const min = biblioEntry.signature.parameters.length;
@@ -732,7 +740,7 @@ export default class Spec {
       };
       const walkLines = (list: OrderedListNode) => {
         for (const line of list.contents) {
-          const item = parseExpr(line.contents, sdoNames);
+          const item = parseExpr(line.contents, opNames);
           if (item.type === 'failure') {
             const { line, column } = offsetToLineAndColumn(originalHtml, item.offset);
             this.warn({

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -670,8 +670,14 @@ export default class Spec {
         }
 
         if (biblioEntry.kind === 'syntax-directed operation' && expr.type === 'call') {
-          warn(`${calleeName} is a syntax-directed operation and should not be invoked like a regular call`);
-        } else if (biblioEntry.kind != null && biblioEntry.kind !== 'syntax-directed operation' && expr.type === 'sdo-call') {
+          warn(
+            `${calleeName} is a syntax-directed operation and should not be invoked like a regular call`
+          );
+        } else if (
+          biblioEntry.kind != null &&
+          biblioEntry.kind !== 'syntax-directed operation' &&
+          expr.type === 'sdo-call'
+        ) {
           warn(`${calleeName} is not a syntax-directed operation but here is being invoked as one`);
         }
 
@@ -2154,7 +2160,7 @@ function isConsumedAsCompletion(expr: Expr, path: PathItem[]) {
   const { parent, index } = part;
   if (parent.type === 'seq') {
     // if the previous text ends in `! ` or `? `, this is a completion
-    let text = textFromPreviousPart(parent, index as number);
+    const text = textFromPreviousPart(parent, index as number);
     if (text != null && /[!?]\s$/.test(text)) {
       return true;
     }

--- a/src/expr-parser.ts
+++ b/src/expr-parser.ts
@@ -1,0 +1,474 @@
+import type { parseFragment } from 'ecmarkdown';
+import { formatEnglishList } from './header-parser';
+
+// TODO export FragmentNode
+type Unarray<T> = T extends Array<infer U> ? U : T;
+type FragmentNode = Unarray<ReturnType<typeof parseFragment>>;
+
+const tokMatcher =
+  /(?<olist>&laquo;|«)|(?<clist>&raquo;|»)|(?<orec>\{)|(?<crec>\})|(?<oparen>\()|(?<cparen>\))/u;
+const tokOrCommaMatcher = new RegExp(tokMatcher.source + '|(?<comma>,)', 'u'); // gross
+
+type ProsePart =
+  | FragmentNode
+  | { name: 'text'; contents: string; location: { start: { offset: number } } };
+type Prose = {
+  type: 'prose';
+  parts: ProsePart[]; // nonempty
+};
+type List = {
+  type: 'list';
+  elements: Seq[];
+};
+type Record = {
+  type: 'record';
+  members: { name: string; value: Seq }[];
+};
+type RecordSpec = {
+  type: 'record-spec';
+  members: { name: string }[];
+};
+type Call = {
+  type: 'call';
+  callee: Prose;
+  arguments: Seq[];
+};
+type Paren = {
+  type: 'paren';
+  items: NonSeq[];
+};
+type Seq = {
+  type: 'seq';
+  items: NonSeq[];
+};
+type NonSeq = Prose | List | Record | RecordSpec | Call | Paren;
+export type Expr = NonSeq | Seq;
+type Failure = { type: 'failure'; message: string; offset: number };
+
+class ParseFailure extends Error {
+  declare offset: number;
+  constructor(message: string, offset: number) {
+    super(message);
+    this.offset = offset;
+  }
+}
+
+function formatClose(close: ('clist' | 'crec' | 'cparen' | 'comma' | 'eof')[]) {
+  const mapped = close.map(c => {
+    switch (c) {
+      case 'clist':
+        return 'list close';
+      case 'crec':
+        return 'record close';
+      case 'cparen':
+        return 'close parenthesis';
+      case 'eof':
+        return 'end of line';
+      default:
+        return c;
+    }
+  });
+  return formatEnglishList(mapped, 'or');
+}
+
+function isEmpty(s: Seq) {
+  return s.items.every(
+    i => i.type === 'prose' && i.parts.every(p => p.name === 'text' && /^\s*$/.test(p.contents))
+  );
+}
+
+function emptyThingHasNewline(s: Seq) {
+  // only call this function on things which pass isEmpty
+  return s.items.some(i =>
+    (i as Prose).parts.some(p => (p as { name: 'text'; contents: string }).contents.includes('\n'))
+  );
+}
+
+type TokenType = 'eof' | 'olist' | 'clist' | 'orec' | 'crec' | 'oparen' | 'cparen' | 'comma';
+type Token = Prose | { type: TokenType; offset: number };
+class ExprParser {
+  declare src: FragmentNode[];
+  srcIndex = 0;
+  textTokOffset: number | null = null; // offset into current text node; only meaningful if srcOffset points to a text node
+  next: Token[] = [];
+  constructor(src: FragmentNode[]) {
+    this.src = src;
+  }
+
+  private peek(matcher: RegExp): Token {
+    if (this.next.length === 0) {
+      this.advance(matcher);
+    }
+    return this.next[0];
+  }
+
+  // this method is complicated because the underlying data is a sequence of ecmarkdown fragments, not a string
+  private advance(matcher: RegExp) {
+    const currentProse: ProsePart[] = [];
+    while (this.srcIndex < this.src.length) {
+      const tok: ProsePart =
+        this.textTokOffset == null
+          ? this.src[this.srcIndex]
+          : {
+              name: 'text',
+              contents: (this.src[this.srcIndex].contents as string).slice(this.textTokOffset),
+              location: {
+                start: {
+                  offset: this.src[this.srcIndex].location.start.offset + this.textTokOffset,
+                },
+              },
+            };
+      const match = tok.name === 'text' ? tok.contents.match(matcher) : null;
+      if (tok.name !== 'text' || match == null) {
+        if (!(tok.name === 'text' && tok.contents.length === 0)) {
+          currentProse.push(tok);
+        }
+        ++this.srcIndex;
+        this.textTokOffset = null;
+        continue;
+      }
+      const { groups } = match;
+      const before = tok.contents.slice(0, match.index);
+      if (before.length > 0) {
+        currentProse.push({ name: 'text', contents: before, location: tok.location });
+      }
+      const matchKind = Object.keys(groups!).find(x => groups![x] != null)!;
+      if (currentProse.length > 0) {
+        this.next.push({ type: 'prose', parts: currentProse });
+      }
+      this.textTokOffset = (this.textTokOffset ?? 0) + match.index! + match[0].length;
+      this.next.push({
+        type: matchKind as TokenType,
+        offset: tok.location.start.offset + match.index!,
+      });
+      return;
+    }
+    if (currentProse.length > 0) {
+      this.next.push({ type: 'prose', parts: currentProse });
+    }
+    this.next.push({
+      type: 'eof',
+      offset: this.src.length === 0 ? 0 : this.src[this.src.length - 1].location.end.offset,
+    });
+  }
+
+  // guarantees the next token is an element of close
+  parseSeq(close: ('clist' | 'crec' | 'cparen' | 'comma' | 'eof')[]): Seq {
+    const items: NonSeq[] = [];
+    const matcher = close.includes('comma') ? tokOrCommaMatcher : tokMatcher;
+    while (true) {
+      const next = this.peek(matcher);
+      switch (next.type) {
+        case 'comma': {
+          if (!close.includes('comma')) {
+            throw new Error('unreachable: comma while not scanning for commas');
+          }
+          if (items.length === 0) {
+            throw new ParseFailure(
+              `unexpected comma (expected some content for element/argument)`,
+              next.offset
+            );
+          }
+          return { type: 'seq', items };
+        }
+        case 'eof': {
+          if (items.length === 0 || !close.includes('eof')) {
+            throw new ParseFailure(`unexpected eof (expected ${formatClose(close)})`, next.offset);
+          }
+          return { type: 'seq', items };
+        }
+        case 'prose': {
+          this.next.shift();
+          items.push(next);
+          break;
+        }
+        case 'olist': {
+          this.next.shift();
+          const elements: Seq[] = [];
+          if (this.peek(tokOrCommaMatcher).type !== 'clist') {
+            while (true) {
+              elements.push(this.parseSeq(['clist', 'comma']));
+              if (this.peek(tokOrCommaMatcher).type === 'clist') {
+                break;
+              }
+              this.next.shift();
+            }
+          }
+          if (elements.length > 0 && isEmpty(elements[elements.length - 1])) {
+            if (elements.length === 1 || emptyThingHasNewline(elements[elements.length - 1])) {
+              // allow trailing commas when followed by whitespace
+              elements.pop();
+            } else {
+              throw new ParseFailure(
+                `unexpected list close (expected some content for element)`,
+                (this.peek(tokOrCommaMatcher) as { offset: number }).offset
+              );
+            }
+          }
+          items.push({ type: 'list', elements });
+          this.next.shift(); // eat the clist
+          break;
+        }
+        case 'clist': {
+          if (!close.includes('clist')) {
+            throw new ParseFailure(
+              'unexpected list close without corresponding list open',
+              next.offset
+            );
+          }
+          return { type: 'seq', items };
+        }
+        case 'oparen': {
+          const lastPart = items[items.length - 1];
+          if (lastPart != null && lastPart.type === 'prose') {
+            const callee: ProsePart[] = [];
+            for (let i = lastPart.parts.length - 1; i >= 0; --i) {
+              const ppart = lastPart.parts[i];
+              if (ppart.name === 'text') {
+                const spaceIndex = ppart.contents.lastIndexOf(' ');
+                if (spaceIndex !== -1) {
+                  if (spaceIndex < ppart.contents.length - 1) {
+                    const calleePart = ppart.contents.slice(spaceIndex + 1);
+                    if (!/\p{Letter}/u.test(calleePart)) {
+                      // e.g. -(x + 1)
+                      break;
+                    }
+                    lastPart.parts[i] = {
+                      name: 'text',
+                      contents: ppart.contents.slice(0, spaceIndex + 1),
+                      location: ppart.location,
+                    };
+                    callee.unshift({
+                      name: 'text',
+                      contents: calleePart,
+                      location: {
+                        start: { offset: ppart.location.start.offset + spaceIndex + 1 },
+                      },
+                    });
+                  }
+                  break;
+                }
+              } else if (ppart.name === 'tag') {
+                break;
+              }
+              callee.unshift(ppart);
+              lastPart.parts.pop();
+            }
+            if (callee.length > 0) {
+              this.next.shift();
+              const args: Seq[] = [];
+              if (this.peek(tokOrCommaMatcher).type !== 'cparen') {
+                while (true) {
+                  args.push(this.parseSeq(['cparen', 'comma']));
+                  if (this.peek(tokOrCommaMatcher).type === 'cparen') {
+                    break;
+                  }
+                  this.next.shift();
+                }
+              }
+              if (args.length > 0 && isEmpty(args[args.length - 1])) {
+                if (args.length === 1 || emptyThingHasNewline(args[args.length - 1])) {
+                  // allow trailing commas when followed by a newline
+                  args.pop();
+                } else {
+                  throw new ParseFailure(
+                    `unexpected close parenthesis (expected some content for argument)`,
+                    (this.peek(tokOrCommaMatcher) as { offset: number }).offset
+                  );
+                }
+              }
+              items.push({
+                type: 'call',
+                callee: { type: 'prose', parts: callee },
+                arguments: args,
+              });
+              this.next.shift(); // eat the cparen
+              break;
+            }
+          }
+          this.next.shift();
+          items.push({ type: 'paren', items: this.parseSeq(['cparen']).items });
+          this.next.shift(); // eat the cparen
+          break;
+        }
+        case 'cparen': {
+          if (!close.includes('cparen')) {
+            throw new ParseFailure(
+              'unexpected close parenthesis without corresponding open parenthesis',
+              next.offset
+            );
+          }
+          return { type: 'seq', items };
+        }
+        case 'orec': {
+          this.next.shift();
+          let type: 'record' | 'record-spec' | null = null;
+          const members: ({ name: string; value: Seq } | { name: string })[] = [];
+          while (true) {
+            const nextTok = this.peek(tokOrCommaMatcher);
+            if (nextTok.type !== 'prose') {
+              throw new ParseFailure('expected to find record field name', nextTok.offset);
+            }
+            if (nextTok.parts[0].name !== 'text') {
+              throw new ParseFailure(
+                'expected to find record field name',
+                nextTok.parts[0].location.start.offset
+              );
+            }
+            const { contents } = nextTok.parts[0];
+            const nameMatch = contents.match(/^\s*\[\[(?<name>\w+)\]\]\s*(?<colon>:?)/);
+            if (nameMatch == null) {
+              if (members.length > 0 && /^\s*$/.test(contents) && contents.includes('\n')) {
+                // allow trailing commas when followed by a newline
+                this.next.shift(); // eat the whitespace
+                if (this.peek(tokOrCommaMatcher).type === 'crec') {
+                  this.next.shift();
+                  break;
+                }
+              }
+              throw new ParseFailure(
+                'expected to find record field',
+                nextTok.parts[0].location.start.offset + contents.match(/^\s*/)![0].length
+              );
+            }
+            const { name, colon } = nameMatch.groups!;
+            if (members.find(x => x.name === name)) {
+              throw new ParseFailure(
+                `duplicate record field name ${name}`,
+                nextTok.parts[0].location.start.offset + contents.match(/^\s*\[\[/)![0].length
+              );
+            }
+            const shortenedText = nextTok.parts[0].contents.slice(nameMatch[0].length);
+            const offset = nextTok.parts[0].location.start.offset + nameMatch[0].length;
+            if (shortenedText.length === 0 && nextTok.parts.length === 1) {
+              this.next.shift();
+            } else if (shortenedText.length === 0) {
+              this.next[0] = {
+                type: 'prose',
+                parts: nextTok.parts.slice(1),
+              };
+            } else {
+              const shortened: ProsePart = {
+                name: 'text',
+                contents: shortenedText,
+                location: {
+                  start: { offset },
+                },
+              };
+              this.next[0] = {
+                type: 'prose',
+                parts: [shortened, ...nextTok.parts.slice(1)],
+              };
+            }
+            if (colon) {
+              if (type == null) {
+                type = 'record';
+              } else if (type === 'record-spec') {
+                throw new ParseFailure(
+                  'record field has value but preceding field does not',
+                  offset - 1
+                );
+              }
+              const value = this.parseSeq(['crec', 'comma']);
+              if (value.items.length === 0) {
+                throw new ParseFailure('expected record field to have value', offset);
+              }
+              members.push({ name, value });
+            } else {
+              if (type == null) {
+                type = 'record-spec';
+              } else if (type === 'record') {
+                throw new ParseFailure('expected record field to have value', offset - 1);
+              }
+              members.push({ name });
+              if (!['crec', 'comma'].includes(this.peek(tokOrCommaMatcher).type)) {
+                throw new ParseFailure(`expected ${formatClose(['crec', 'comma'])}`, offset);
+              }
+            }
+            if (this.peek(tokOrCommaMatcher).type === 'crec') {
+              break;
+            }
+            this.next.shift(); // eat the comma
+          }
+          // @ts-ignore typing this correctly is annoying
+          items.push({ type, members });
+          this.next.shift(); // eat the crec
+          break;
+        }
+        case 'crec': {
+          if (!close.includes('crec')) {
+            throw new ParseFailure(
+              'unexpected end of record without corresponding start of record',
+              next.offset
+            );
+          }
+          return { type: 'seq', items };
+        }
+        default: {
+          // @ts-ignore
+          throw new Error(`unreachable: unknown token type ${next.type}`);
+        }
+      }
+    }
+  }
+}
+
+export function parse(src: FragmentNode[]): Seq | Failure {
+  const parser = new ExprParser(src);
+  try {
+    return parser.parseSeq(['eof']);
+  } catch (e) {
+    if (e instanceof ParseFailure) {
+      return { type: 'failure', message: e.message, offset: e.offset };
+    }
+    throw e;
+  }
+}
+
+type Index = number | 'callee' | null;
+export function walk(
+  f: (expr: Expr, index: Index, parent: Expr | null) => void,
+  current: Expr,
+  index: Index = null,
+  parent: Expr | null = null
+) {
+  f(current, index, parent);
+  switch (current.type) {
+    case 'prose': {
+      break;
+    }
+    case 'list': {
+      for (let i = 0; i < current.elements.length; ++i) {
+        walk(f, current.elements[i], i, current);
+      }
+      break;
+    }
+    case 'record': {
+      for (let i = 0; i < current.members.length; ++i) {
+        walk(f, current.members[i].value, i, current);
+      }
+      break;
+    }
+    case 'record-spec': {
+      break;
+    }
+    case 'call': {
+      walk(f, current.callee, 'callee', current);
+      for (let i = 0; i < current.arguments.length; ++i) {
+        walk(f, current.arguments[i], i, current);
+      }
+      break;
+    }
+    case 'paren':
+    case 'seq': {
+      for (let i = 0; i < current.items.length; ++i) {
+        walk(f, current.items[i], i, current);
+      }
+      break;
+    }
+    default: {
+      // @ts-ignore
+      throw new Error(`unreachable: unknown expression node type ${current.type}`);
+    }
+  }
+}

--- a/src/expr-parser.ts
+++ b/src/expr-parser.ts
@@ -115,13 +115,13 @@ function formatClose(close: CloseTokenType[]) {
 function addProse(items: NonSeq[], token: Token) {
   // sometimes we determine after seeing a token that it should not have been treated as a token
   // in that case we want to join it with the preceding prose, if any
-  let prev = items[items.length - 1];
+  const prev = items[items.length - 1];
   if (token.type === 'prose') {
     if (prev == null || prev.type !== 'prose') {
       items.push(token);
     } else {
-      let lastPartOfPrev = prev.parts[prev.parts.length - 1];
-      let firstPartOfThis = token.parts[0];
+      const lastPartOfPrev = prev.parts[prev.parts.length - 1];
+      const firstPartOfThis = token.parts[0];
       if (lastPartOfPrev?.name === 'text' && firstPartOfThis?.name === 'text') {
         items[items.length - 1] = {
           type: 'prose',
@@ -500,12 +500,12 @@ class ExprParser {
         }
         case 'x_of': {
           this.next.shift();
-          let callee = next.source.split(' ')[0];
+          const callee = next.source.split(' ')[0];
           if (!this.opNames.has(callee)) {
             addProse(items, next);
             break;
           }
-          let parseNode = this.parseSeq([
+          const parseNode = this.parseSeq([
             'eof',
             'period',
             'comma',
@@ -514,7 +514,7 @@ class ExprParser {
             'crec',
             'with_args',
           ]);
-          let args: Seq[] = [];
+          const args: Seq[] = [];
           if (this.peek().type === 'with_args') {
             this.next.shift();
             while (true) {

--- a/src/expr-parser.ts
+++ b/src/expr-parser.ts
@@ -548,7 +548,6 @@ class ExprParser {
             parseNode,
             arguments: args,
           });
-          // console.log(require('util').inspect(items[items.length - 1], { depth: Infinity }));
           break;
         }
         default: {
@@ -581,7 +580,6 @@ export function walk(
   current: Expr,
   path: PathItem[] = []
 ) {
-  // console.log('path', path, current.type);
   f(current, path);
   switch (current.type) {
     case 'prose': {

--- a/src/expr-parser.ts
+++ b/src/expr-parser.ts
@@ -173,13 +173,13 @@ function emptyThingHasNewline(s: Seq) {
 
 class ExprParser {
   declare src: FragmentNode[];
-  declare sdoNames: Set<String>;
+  declare opNames: Set<String>;
   srcIndex = 0;
   textTokOffset: number | null = null; // offset into current text node; only meaningful if srcOffset points to a text node
   next: Token[] = [];
-  constructor(src: FragmentNode[], sdoNames: Set<String>) {
+  constructor(src: FragmentNode[], opNames: Set<String>) {
     this.src = src;
-    this.sdoNames = sdoNames;
+    this.opNames = opNames;
   }
 
   private peek(): Token {
@@ -501,7 +501,7 @@ class ExprParser {
         case 'x_of': {
           this.next.shift();
           let callee = next.source.split(' ')[0];
-          if (!this.sdoNames.has(callee)) {
+          if (!this.opNames.has(callee)) {
             addProse(items, next);
             break;
           }
@@ -560,8 +560,8 @@ class ExprParser {
   }
 }
 
-export function parse(src: FragmentNode[], sdoNames: Set<String>): Seq | Failure {
-  const parser = new ExprParser(src, sdoNames);
+export function parse(src: FragmentNode[], opNames: Set<String>): Seq | Failure {
+  const parser = new ExprParser(src, opNames);
   try {
     return parser.parseSeq(['eof']);
   } catch (e) {

--- a/src/header-parser.ts
+++ b/src/header-parser.ts
@@ -645,7 +645,7 @@ export function formatPreamble(
   return paras;
 }
 
-function formatEnglishList(list: Array<string>) {
+export function formatEnglishList(list: Array<string>, conjuction = 'and') {
   if (list.length === 0) {
     throw new Error('formatEnglishList should not be called with an empty list');
   }
@@ -653,9 +653,9 @@ function formatEnglishList(list: Array<string>) {
     return list[0];
   }
   if (list.length === 2) {
-    return `${list[0]} and ${list[1]}`;
+    return `${list[0]} ${conjuction} ${list[1]}`;
   }
-  return `${list.slice(0, -1).join(', ')}, and ${list[list.length - 1]}`;
+  return `${list.slice(0, -1).join(', ')}, ${conjuction} ${list[list.length - 1]}`;
 }
 
 function eat(text: string, regex: RegExp) {

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -85,6 +85,8 @@ export async function lint(
     if ('tree' in pair) {
       // @ts-ignore we are intentionally adding a property here
       pair.element.ecmarkdownTree = pair.tree;
+      // @ts-ignore we are intentionally adding a property here
+      pair.element.originalHtml = pair.element.innerHTML;
     }
   }
 }

--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -125,7 +125,7 @@ export default function (report: Reporter, node: Element, algorithmSource: strin
 
       const hasSubsteps = node.sublist !== null;
 
-      // Special case: lines without substeps can end in `pre` tags.
+      // Special case: only lines without substeps can end in `pre` tags.
       if (last.name === 'opaqueTag' && /^\s*<pre>/.test(last.contents)) {
         if (hasSubsteps) {
           report({

--- a/test/expr-parser.js
+++ b/test/expr-parser.js
@@ -1,0 +1,259 @@
+'use strict';
+
+let { assertLint, positioned, lintLocationMarker: M, assertLintFree } = require('./utils.js');
+
+describe('expression parsing', () => {
+  describe('valid', () => {
+    it('lists', async () => {
+      await assertLintFree(`
+        <emu-alg>
+          1. Let _x_ be «».
+          1. Set _x_ to « ».
+          1. Set _x_ to «0».
+          1. Set _x_ to «0, 1».
+          1. Set _x_ to « 0,1 ».
+        </emu-alg>
+      `);
+    });
+
+    it('calls', async () => {
+      await assertLintFree(`
+        <emu-alg>
+          1. Let _x_ be _foo_().
+          1. Set _x_ to _foo_( ).
+          1. Set _x_ to _foo_.[[Bar]]().
+          1. Set _x_ to _foo_(0).
+          1. Set _x_ to _foo_( 0 ).
+          1. Set _x_ to _foo_(0, 1).
+        </emu-alg>
+      `);
+    });
+
+    it('records', async () => {
+      await assertLintFree(`
+        <emu-alg>
+          1. Let _x_ be { [[x]]: 0 }.
+          1. Set _x_ to {[[x]]:0}.
+        </emu-alg>
+      `);
+    });
+
+    it('record-spec', async () => {
+      await assertLintFree(`
+        <emu-alg>
+          1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
+            1. Something.
+        </emu-alg>
+      `);
+    });
+
+    it('trailing comma in multi-line list', async () => {
+      await assertLintFree(`
+        <emu-alg>
+        1. Let _x_ be «
+            0,
+            1,
+          ».
+        </emu-alg>
+      `);
+    });
+
+    it('trailing comma in multi-line call', async () => {
+      await assertLintFree(`
+        <emu-alg>
+        1. Let _x_ be _foo_(
+            0,
+            1,
+          ).
+        </emu-alg>
+      `);
+    });
+
+    it('trailing comma in multi-line record', async () => {
+      await assertLintFree(`
+        <emu-alg>
+        1. Let _x_ be the Record {
+            [[X]]: 0,
+            [[Y]]: 1,
+          }.
+        </emu-alg>
+      `);
+    });
+  });
+
+  describe('errors', () => {
+    it('open paren without close', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let (.${M}
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'unexpected eof (expected close parenthesis)',
+        }
+      );
+    });
+
+    it('close paren without open', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let ${M}).
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'unexpected close parenthesis without corresponding open parenthesis',
+        }
+      );
+    });
+
+    it('mismatched open/close tokens', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be «_foo_(_a_${M}»).
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'unexpected list close without corresponding list open',
+        }
+      );
+    });
+
+    it('elision in list', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be «${M},».
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'unexpected comma (expected some content for element/argument)',
+        }
+      );
+
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be «_x_, ${M}».
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'unexpected list close (expected some content for element)',
+        }
+      );
+    });
+
+    it('elision in call', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be _foo_(${M},)».
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'unexpected comma (expected some content for element/argument)',
+        }
+      );
+
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be _foo_(_a_, ${M}).
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'unexpected close parenthesis (expected some content for argument)',
+        }
+      );
+    });
+
+    it('record without names', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be the Record { ${M}}.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'expected to find record field',
+        }
+      );
+    });
+
+    it('record with malformed names', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be the Record { ${M}[x]: 0 }.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'expected to find record field',
+        }
+      );
+    });
+
+    it('record with duplicate names', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be the Record { [[A]]: 0, [[${M}A]]: 0 }.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'duplicate record field name A',
+        }
+      );
+    });
+
+    it('record where only some keys have values', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be the Record { [[A]], [[B]]${M}: 0 }.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'record field has value but preceding field does not',
+        }
+      );
+
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be the Record { [[A]]: 0, [[B]]${M} }.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'expression-parsing',
+          nodeType: 'emu-alg',
+          message: 'expected record field to have value',
+        }
+      );
+    });
+  });
+});

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -250,7 +250,7 @@ describe('linting algorithms', () => {
             1. Substep.
           1. Let _constructorText_ be the source text
           <pre><code class="javascript">constructor() {}</code></pre>
-          1. Set _constructor_ to ParseText(_constructorText_, _methodDefinition_).
+          1. Set _constructor_ to _parse_(_constructorText_, _methodDefinition_).
           1. <mark>A highlighted line.</mark>
           1. <ins>Amend the spec with this.</ins>
           1. <del>Remove this from the spec.</del>

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -810,7 +810,7 @@ describe('signature agreement', async () => {
     await assertLint(
       positioned`
         <emu-alg>
-          1. Return ${M}SDOTakesOneOrTwoArgs().
+          1. Return ${M}SDOTakesOneOrTwoArgs of _foo_.
         </emu-alg>
       `,
       {
@@ -839,6 +839,80 @@ describe('signature agreement', async () => {
           1. Perform SDOTakesOneOrTwoArgs of _foo_ with arguments 0 and 1.
           1. Perform <emu-meta suppress-effects="user-code">SDOTakesNoArgs of _foo_</emu-meta>.
         </emu-alg>
+      `,
+      {
+        extraBiblios: [biblio],
+      }
+    );
+  });
+});
+
+describe('invocation kind', async () => {
+  let biblio;
+  before(async () => {
+    biblio = await getBiblio(`
+      <emu-clause id="example" type="abstract operation">
+        <h1>AO ()</h1>
+        <dl class="header"></dl>
+      </emu-clause>
+
+      <emu-clause id="example-sdo" type="syntax-directed operation">
+        <h1>SDO ()</h1>
+        <dl class="header"></dl>
+      </emu-clause>
+    `);
+  });
+
+  it('SDO invoked as AO', async () => {
+    await assertLint(
+      positioned`
+        <emu-alg>
+          1. Return ${M}SDO().
+        </emu-alg>
+      `,
+      {
+        ruleId: 'typecheck',
+        nodeType: 'emu-alg',
+        message: 'SDO is a syntax-directed operation and should not be invoked like a regular call',
+      },
+      {
+        extraBiblios: [biblio],
+      }
+    );
+  });
+
+  it('AO invoked as SDO', async () => {
+    await assertLint(
+      positioned`
+        <emu-alg>
+          1. Return ${M}AO of _foo_.
+        </emu-alg>
+      `,
+      {
+        ruleId: 'typecheck',
+        nodeType: 'emu-alg',
+        message: 'AO is not a syntax-directed operation but here is being invoked as one',
+      },
+      {
+        extraBiblios: [biblio],
+      }
+    );
+  });
+
+  it('negative', async () => {
+    await assertLintFree(
+      `
+        <emu-clause id="example" type="abstract operation">
+        <h1>
+          Example ()
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg example>
+          1. Perform AO().
+          1. Perform SDO of _foo_.
+        </emu-alg>
+        </emu-clause>
       `,
       {
         extraBiblios: [biblio],

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -54,12 +54,12 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         <emu-alg>
-${M}      1. Return ExampleAlg().
+          1. Return ${M}ExampleAlg().
         </emu-alg>
         </emu-clause>
         `,
         {
-          ruleId: 'invocation-return-type',
+          ruleId: 'typecheck',
           nodeType: 'emu-alg',
           message: 'ExampleAlg returns a Completion Record, but is not consumed as if it does',
         },
@@ -93,6 +93,7 @@ ${M}      1. Return ExampleAlg().
           </dl>
           <emu-alg>
             1. Let _a_ be Completion(ExampleAlg()).
+            1. Let _a_ be Completion(<emu-meta suppress-effects="user-code">ExampleAlg()</emu-meta>).
             1. Set _a_ to ! ExampleAlg().
             1. Return ? ExampleAlg().
           </emu-alg>
@@ -138,12 +139,12 @@ ${M}      1. Return ExampleAlg().
         <dl class="header">
         </dl>
         <emu-alg>
-${M}      1. Return ? ExampleAlg().
+          1. Return ? ${M}ExampleAlg().
         </emu-alg>
         </emu-clause>
         `,
         {
-          ruleId: 'invocation-return-type',
+          ruleId: 'typecheck',
           nodeType: 'emu-alg',
           message: 'ExampleAlg does not return a Completion Record, but is consumed as if it does',
         }
@@ -344,12 +345,12 @@ ${M}      1. Return ? ExampleAlg().
           <dl class="header">
           </dl>
           <emu-alg>
-${M}          1. Let _x_ be ExampleAlg().
+            1. Let _x_ be ${M}ExampleAlg().
           </emu-alg>
           </emu-clause>
         `,
         {
-          ruleId: 'invocation-return-type',
+          ruleId: 'typecheck',
           nodeType: 'emu-alg',
           message:
             'ExampleAlg does not return a meaningful value and should only be invoked as `Perform ExampleAlg(...).`',

--- a/test/utils.js
+++ b/test/utils.js
@@ -119,8 +119,8 @@ async function assertErrorFree(html, opts) {
   assert.deepStrictEqual(warnings, []);
 }
 
-async function assertLint(a, b) {
-  await assertError(a, b, { lintSpec: true });
+async function assertLint(a, b, opts = {}) {
+  await assertError(a, b, { lintSpec: true, ...opts });
 }
 
 async function assertLintFree(html, opts = {}) {


### PR DESCRIPTION
This adds a barebones parser for algorithm steps, recognizing calls, SDO invocations, records, and lists. It is invoked downstream of the biblio being built, which means it can differentiate `List of _bar_` (which is not an SDO invocation) from `SDO of _bar_` (which is).

The parser is much less sophisticated than the ones in ecmaspeak-py or esmeta. On the other hand, it's also much less specialized to the current spec text, so hopefully will not require updates as often.

The new parser is used to
- ensure parentheses are balanced and so on
- check that everything being called is defined (with a hardcoded list of exceptions, see below)
- check that AOs and SDOs are invoked with the appropriate number of arguments
- check that record field names are not duplicated within a record
- fix the [super gross](https://github.com/tc39/ecmarkup/blob/e83854e4c9597a1e1fec96f258645481325713ce/src/Spec.ts#L630-L635) post-render walking we were previously doing to check that AOs returning completion records were invoked appropriately, which also lets us get more precise location information for those errors

I've checked this on 262 and 402 (which pass without error) as well as proposal-temporal (which has a few genuine bugs this catches).

It also incidentally adds AO kinds ("syntax-directed operation", "host-defined abstract operation", etc) to the biblio. This is not a breaking change because the new type allows the kind to be `undefined`.

---
Unfortunately I've had to hardcode the names of certain operations which are invoked without being defined as operations, namely
 - thisTimeValue
 - thisStringValue
 - thisBigIntValue
 - thisNumberValue
 - thisSymbolValue
 - thisBooleanValue
 - toUppercase
 - toLowercase
 - ℝ
 - 𝔽
 - ℤ

The `thisXValue` ones are a [weird thing we do](https://tc39.es/ecma262/multipage/numbers-and-dates.html#thistimevalue) where we define an AO without giving it its own clause, represented by source text like

```
The abstract operation <dfn id="thistimevalue" aoid="thisTimeValue" oldids="sec-thistimevalue">thisTimeValue</dfn> takes argument _value_. It performs the following steps when called:
```

We should get rid of these. (Also note that `aoid` on `dfn` doesn't do anything.)

`toUppercase` and `toLowercase` are invoking Unicode algorithms (see e.g. step 5 of [Canonicalize](https://tc39.es/ecma262/multipage/text-processing.html#sec-runtime-semantics-canonicalize-ch)). Not sure what to do about those - maybe those names should be written as `` `code` ``?

`ℝ` and friends just need to be defined with `emu-eqn` and then they can be removed from the hardcoded list; I'll make that change once https://github.com/tc39/ecma262/pull/2810 lands.

---
Depends on https://github.com/tc39/ecmarkdown/pull/92.
