### PR TITLE
link non-wordchars AOs

### DIFF
--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -145,11 +145,11 @@ function isCommonAbstractOp(op: string) {
 function lookAheadBeyond(key: string, entry: BiblioEntry) {
   if (isCommonAbstractOp(key)) {
     // must be followed by parentheses
-    return '\\b(?=\\()';
+    return '(?=\\()';
   }
   if (entry.type !== 'term' || /^\w/.test(key)) {
-    // must not be followed by `.word` or `%%` or `]]`
-    return '\\b(?!\\.\\w|%%|\\]\\])';
+    // must not be followed by a letter, `.word`, `%%`, `]]`
+    return '(?!\\w|\\.\\w|%%|\\]\\])';
   }
   return '';
 }

--- a/test/baselines/generated-reference/autolinking.html
+++ b/test/baselines/generated-reference/autolinking.html
@@ -30,7 +30,7 @@
   <p>Also, no autolinks in <a href="#">anchors: Lowercase</a>.</p>
   <p>Similarly, no autolinks for <sub>[Await]</sub>.</p>
   <p><emu-xref href="#variants" id="_ref_5"><a href="#variants">Variants</a></emu-xref> like <emu-xref href="#variants" id="_ref_6"><a href="#variants">vOne</a></emu-xref> and <emu-xref href="#variants" id="_ref_7"><a href="#variants">vTwo</a></emu-xref> should autolink, including when capitalized as in <emu-xref href="#variants" id="_ref_8"><a href="#variants">VOne</a></emu-xref>.</p>
-  <emu-alg><ol><li>Non-word-chars AOs still link when invoked, like 𝔽(<var>x</var>).</li></ol></emu-alg>
+  <emu-alg><ol><li>Non-word-chars AOs still link when invoked, like <emu-xref aoid="𝔽" id="_ref_9"><a href="#𝔽">𝔽</a></emu-xref>(<var>x</var>).</li></ol></emu-alg>
 </emu-clause>
 <p><emu-xref href="#sec-array-constructor"><a href="https://tc39.es/ecma262/#sec-array-constructor">%Array%</a></emu-xref> and %ArrayPrototype% outside of clauses is ok.</p>
 </div></body>

--- a/test/baselines/generated-reference/autolinking.html
+++ b/test/baselines/generated-reference/autolinking.html
@@ -17,6 +17,7 @@
   <p><dfn>extra      spaces</dfn></p>
   <p><dfn>Await</dfn></p>
   <p><dfn id="variants" variants="vOne, vTwo">Variants</dfn></p>
+  <p><emu-eqn id="𝔽" aoid="𝔽" class="inline">𝔽(<var>x</var>)</emu-eqn></p>
 </emu-clause>
 <emu-clause id="sec-bar">
   <h1><span class="secnum">2</span> Autolinking 2</h1>
@@ -29,6 +30,7 @@
   <p>Also, no autolinks in <a href="#">anchors: Lowercase</a>.</p>
   <p>Similarly, no autolinks for <sub>[Await]</sub>.</p>
   <p><emu-xref href="#variants" id="_ref_5"><a href="#variants">Variants</a></emu-xref> like <emu-xref href="#variants" id="_ref_6"><a href="#variants">vOne</a></emu-xref> and <emu-xref href="#variants" id="_ref_7"><a href="#variants">vTwo</a></emu-xref> should autolink, including when capitalized as in <emu-xref href="#variants" id="_ref_8"><a href="#variants">VOne</a></emu-xref>.</p>
+  <emu-alg><ol><li>Non-word-chars AOs still link when invoked, like 𝔽(<var>x</var>).</li></ol></emu-alg>
 </emu-clause>
 <p><emu-xref href="#sec-array-constructor"><a href="https://tc39.es/ecma262/#sec-array-constructor">%Array%</a></emu-xref> and %ArrayPrototype% outside of clauses is ok.</p>
 </div></body>

--- a/test/baselines/sources/autolinking.html
+++ b/test/baselines/sources/autolinking.html
@@ -14,6 +14,7 @@ assets: none
   <p><dfn>extra      spaces</dfn></p>
   <p><dfn>Await</dfn></p>
   <p><dfn id="variants" variants="vOne, vTwo">Variants</dfn></p>
+  <p><emu-eqn id="𝔽" aoid="𝔽">𝔽(_x_)</emu-eqn></p>
 </emu-clause>
 <emu-clause id="sec-bar">
   <h1>Autolinking 2</h1>
@@ -26,5 +27,8 @@ assets: none
   <p>Also, no autolinks in <a href="#">anchors: Lowercase</a>.</p>
   <p>Similarly, no autolinks for <sub>[Await]</sub>.</p>
   <p>Variants like vOne and vTwo should autolink, including when capitalized as in VOne.</p>
+  <emu-alg>
+    1. Non-word-chars AOs still link when invoked, like 𝔽(_x_).
+  </emu-alg>
 </emu-clause>
 <p>%Array% and %ArrayPrototype% outside of clauses is ok.</p>


### PR DESCRIPTION
This makes https://github.com/tc39/ecma262/pull/2810 work.

I've confirmed this has no effect on 262 currently.