### PR TITLE
tweak header name regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ecmarkup",
-	"version": "13.0.0",
+	"version": "13.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ecmarkup",
-			"version": "13.0.0",
+			"version": "13.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "13.0.0",
+	"version": "13.0.1",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/lint/collect-header-diagnostics.ts
+++ b/src/lint/collect-header-diagnostics.ts
@@ -44,19 +44,16 @@ export function collectHeaderDiagnostics(
       // [[GetOwnProperty]]
       /^\[\[[A-Z][A-Za-z0-9]*\]\]\s*$/,
 
-      // _NativeError_
-      /^_[A-Z][A-Za-z0-9]*_\s*$/,
+      // ForIn/OfHeadEvaluation
+      /^[A-Za-z][A-Za-z0-9/]*\s*$/,
 
       // CreateForInIterator
       // Object.fromEntries
-      // ForIn/OfHeadEvaluation
+      // _NativeError_ [ @@whatever ]
       // Array.prototype [ @@iterator ]
-      // Object.prototype.__defineGetter__
-      /^[A-Za-z][A-Za-z0-9/]*(\.[A-Za-z][A-Za-z0-9]*)*(\.__[a-z][A-Za-z0-9]*__| \[ @@[a-z][a-zA-Z]+ \])?\s*$/,
-
       // %ForInIteratorPrototype%.next
-      // %TypedArray%.prototype [ @@iterator ]
-      /^%[A-Z][A-Za-z0-9]*%(\.[A-Za-z][A-Za-z0-9]*)*( \[ @@[a-z][a-zA-Z]+ \])?\s*$/,
+      // Object.prototype.__defineGetter__
+      /^([%_]?)[A-Za-z][A-Za-z0-9/]*\1(\.[A-Za-z][A-Za-z0-9]*|\.__[a-z][A-Za-z0-9]*__| \[ @@[a-z][a-zA-Z]+ \])*\s*$/,
     ].some(r => r.test(name));
 
     if (!nameMatches) {

--- a/test/lint.js
+++ b/test/lint.js
@@ -364,6 +364,9 @@ describe('linting whole program', () => {
           <emu-clause id="i9">
             <h1>Object.prototype.__defineGetter__ ( )</h1>
           </emu-clause>
+          <emu-clause id="i10">
+            <h1>_NativeError_ [ @@baz ] ( )</h1>
+          </emu-clause>
       `);
     });
 


### PR DESCRIPTION
Fixes https://github.com/tc39/ecmarkup/issues/468.

Includes version bump commit, so please **rebase**, not squash.