### PR TITLE
fix emu-import bug

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1931,7 +1931,7 @@ function getBoilerplate(file: string) {
 }
 
 async function loadImports(spec: Spec, rootElement: HTMLElement, rootPath: string) {
-  const imports = rootElement.querySelectorAll('EMU-IMPORT');
+  const imports = rootElement.querySelectorAll('emu-import');
   for (let i = 0; i < imports.length; i++) {
     const node = imports[i];
     const imp = await Import.build(spec, node as EmuImportElement, rootPath);


### PR DESCRIPTION
Today I was trying to update https://github.com/tc39/proposal-record-tuple from `ecmarkup@9.1.0` to the latest but from version `10.0.1` and onwards the generated spec was almost entirely empty as all the `<emu-import>` tags were being ignored.

Stepping through with a debugger I get to the `querySelectorAll("EMU-IMPORT")` and see that it returns an empty NodeList. Changing it to lowercase fixes the issue, I'm presuming there is some recent non-locked down sub dependency of jsdom that has recently changed, otherwise I don't know how this is working for others.

<img width="1440" alt="screenshot-1" src="https://user-images.githubusercontent.com/4369552/178818991-766286e6-da96-4c4e-8f5a-2a2ed6fe5f23.png">

<img width="1440" alt="screenshot-2" src="https://user-images.githubusercontent.com/4369552/178819012-c3075eca-9fdd-4b8c-9950-468cff95b014.png">



