### PR TITLE
Allow specifying custom clause numbers

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -171,6 +171,7 @@ toc: false
     <p><b>example:</b> If present, the clause is an example.</p>
     <p><b>legacy:</b> If present, the clause is Legacy.</p>
     <p><b>normative-optional:</b> If present, the clause is Normative Optional.</p>
+    <p><b>number:</b> Optional: An explicit clause number, overriding the default auto-incrementing number. Can be a nested number, as in `number="2.1"`.</p>
     <p><b>type:</b> Optional: Type of feature described by the clause.</p>
     <ul>
       <li>"abstract operation"</li>

--- a/src/clauseNums.ts
+++ b/src/clauseNums.ts
@@ -8,7 +8,7 @@ export interface ClauseNumberIterator {
 
 /*@internal*/
 export default function iterator(spec: Spec): ClauseNumberIterator {
-  const ids: (string | number)[] = [];
+  const ids: (string | number[])[] = [];
   let inAnnex = false;
   let currentLevel = 0;
 
@@ -46,12 +46,22 @@ export default function iterator(spec: Spec): ClauseNumberIterator {
 
       currentLevel = level;
 
-      return ids.join('.');
+      return ids.flat().join('.');
     },
   };
 
-  function nextAnnexNum(clauseStack: Clause[], node: HTMLElement): string | number {
+  function nextAnnexNum(clauseStack: Clause[], node: HTMLElement): string | number[] {
     const level = clauseStack.length;
+    if (level === 0 && node.hasAttribute('number')) {
+      spec.warn({
+        type: 'attr',
+        node,
+        attr: 'number',
+        ruleId: 'annex-clause-number',
+        message:
+          'top-level annexes do not support explicit numbers; if you need this, open a bug on ecmarkup',
+      });
+    }
     if (!inAnnex) {
       if (level > 0) {
         spec.warn({
@@ -67,7 +77,7 @@ export default function iterator(spec: Spec): ClauseNumberIterator {
     }
 
     if (level === 0) {
-      return String.fromCharCode((<string>ids[0]).charCodeAt(0) + 1);
+      return String.fromCharCode((ids[0] as string).charCodeAt(0) + 1);
     }
 
     return nextClauseNum(clauseStack, node);
@@ -75,18 +85,48 @@ export default function iterator(spec: Spec): ClauseNumberIterator {
 
   function nextClauseNum({ length: level }: { length: number }, node: HTMLElement) {
     if (node.hasAttribute('number')) {
-      const num = Number(node.getAttribute('number'));
-      if (Number.isSafeInteger(num) && num > 0) return num;
-
-      spec.warn({
-        type: 'node',
-        node,
-        ruleId: 'invalid-clause-number',
-        message: 'clause numbers must be positive integers',
-      });
+      const nums = node
+        .getAttribute('number')!
+        .split('.')
+        .map(n => Number(n));
+      if (nums.length === 0 || nums.some(num => !Number.isSafeInteger(num) || num <= 0)) {
+        spec.warn({
+          type: 'attr-value',
+          node,
+          attr: 'number',
+          ruleId: 'invalid-clause-number',
+          message: 'clause numbers must be positive integers or dotted lists of positive integers',
+        });
+      }
+      if (ids[level] !== undefined) {
+        if (nums.length !== ids[level].length) {
+          spec.warn({
+            type: 'attr-value',
+            node,
+            attr: 'number',
+            ruleId: 'invalid-clause-number',
+            message:
+              'multi-step explicit clause numbers should not be mixed with single-step clause numbers in the same parent clause',
+          });
+        } else if (
+          nums.some((n, i) => n < ids[level][i]) ||
+          nums.every((n, i) => n === ids[level][i])
+        ) {
+          spec.warn({
+            type: 'attr-value',
+            node,
+            attr: 'number',
+            ruleId: 'invalid-clause-number',
+            message: 'clause numbers should be strictly increasing',
+          });
+        }
+      }
+      return nums;
     }
 
-    if (ids[level] === undefined) return 1;
-    return <number>ids[level] + 1;
+    if (ids[level] === undefined) return [1];
+    const head = (ids[level] as number[]).slice(0, -1);
+    const tail = (ids[level] as number[])[ids[level].length - 1];
+    return [...head, tail + 1];
   }
 }

--- a/src/clauseNums.ts
+++ b/src/clauseNums.ts
@@ -70,10 +70,22 @@ export default function iterator(spec: Spec): ClauseNumberIterator {
       return String.fromCharCode((<string>ids[0]).charCodeAt(0) + 1);
     }
 
-    return nextClauseNum(clauseStack);
+    return nextClauseNum(clauseStack, node);
   }
 
-  function nextClauseNum({ length: level }: { length: number }) {
+  function nextClauseNum({ length: level }: { length: number }, node: HTMLElement) {
+    if (node.hasAttribute('number')) {
+      const num = Number(node.getAttribute('number'));
+      if (Number.isSafeInteger(num) && num > 0) return num;
+
+      spec.warn({
+        type: 'node',
+        node,
+        ruleId: 'invalid-clause-number',
+        message: 'clause numbers must be positive integers',
+      });
+    }
+
     if (ids[level] === undefined) return 1;
     return <number>ids[level] + 1;
   }

--- a/test/baselines/generated-reference/clauses.html
+++ b/test/baselines/generated-reference/clauses.html
@@ -6,7 +6,7 @@
 
   <li><span>Jump to search box</span><code>/</code></li>
 </ul></div><div id="spec-container">
-<div><h2>Table of Contents</h2><ol class="toc"><li><a href="#sec-intro" title="Intro">Intro</a><ol class="toc"><li><a href="#sec-intro2" title="Sub Intro">Sub Intro</a></li></ol></li><li><a href="#sec-clause" title="Clause Foo(a, b)"><span class="secnum">1</span> Clause Foo(<var>a</var>, <var>b</var>)</a><ol class="toc"><li><a href="#Foo" title="Sub Clause"><span class="secnum">1.1</span> Sub Clause</a></li></ol></li><li><a href="#sec-annex" title="Annex"><span class="secnum">A</span> Annex</a><ol class="toc"><li><a href="#sec-annex2" title="Sub-annex"><span class="secnum">A.1</span> Sub-annex</a></li></ol></li></ol></div><emu-intro id="sec-intro">
+<div><h2>Table of Contents</h2><ol class="toc"><li><a href="#sec-intro" title="Intro">Intro</a><ol class="toc"><li><a href="#sec-intro2" title="Sub Intro">Sub Intro</a></li></ol></li><li><a href="#sec-clause" title="Clause Foo(a, b)"><span class="secnum">1</span> Clause Foo(<var>a</var>, <var>b</var>)</a><ol class="toc"><li><a href="#Foo" title="Sub Clause"><span class="secnum">1.1</span> Sub Clause</a></li></ol></li><li><a href="#sec-number" title="Explicit number"><span class="secnum">7</span> Explicit number</a><ol class="toc"><li><a href="#sec-number1" title="Automatic number inside explicit number"><span class="secnum">7.1</span> Automatic number inside explicit number</a></li><li><a href="#sec-number2" title="Nested explicit number"><span class="secnum">7.4</span> Nested explicit number</a></li><li><a href="#sec-number3" title="Automatic number after explicit number"><span class="secnum">7.5</span> Automatic number after explicit number</a></li></ol></li><li><a href="#sec-annex" title="Annex"><span class="secnum">A</span> Annex</a><ol class="toc"><li><a href="#sec-annex2" title="Sub-annex"><span class="secnum">A.1</span> Sub-annex</a></li></ol></li></ol></div><emu-intro id="sec-intro">
   <h1>Intro</h1>
   <emu-intro id="sec-intro2">
     <h1>Sub Intro</h1>
@@ -20,6 +20,22 @@
   <emu-clause id="Foo" aoid="Foo">
     <h1><span class="secnum">1.1</span> Sub Clause</h1>
 
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="sec-number" number="7">
+  <h1><span class="secnum">7</span> Explicit number</h1>
+
+  <emu-clause id="sec-number1">
+    <h1><span class="secnum">7.1</span> Automatic number inside explicit number</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-number2" number="4">
+    <h1><span class="secnum">7.4</span> Nested explicit number</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-number3">
+    <h1><span class="secnum">7.5</span> Automatic number after explicit number</h1>
   </emu-clause>
 </emu-clause>
 

--- a/test/baselines/generated-reference/clauses.html
+++ b/test/baselines/generated-reference/clauses.html
@@ -6,7 +6,7 @@
 
   <li><span>Jump to search box</span><code>/</code></li>
 </ul></div><div id="spec-container">
-<div><h2>Table of Contents</h2><ol class="toc"><li><a href="#sec-intro" title="Intro">Intro</a><ol class="toc"><li><a href="#sec-intro2" title="Sub Intro">Sub Intro</a></li></ol></li><li><a href="#sec-clause" title="Clause Foo(a, b)"><span class="secnum">1</span> Clause Foo(<var>a</var>, <var>b</var>)</a><ol class="toc"><li><a href="#Foo" title="Sub Clause"><span class="secnum">1.1</span> Sub Clause</a></li></ol></li><li><a href="#sec-number" title="Explicit number"><span class="secnum">7</span> Explicit number</a><ol class="toc"><li><a href="#sec-number1" title="Automatic number inside explicit number"><span class="secnum">7.1</span> Automatic number inside explicit number</a></li><li><a href="#sec-number2" title="Nested explicit number"><span class="secnum">7.4</span> Nested explicit number</a></li><li><a href="#sec-number3" title="Automatic number after explicit number"><span class="secnum">7.5</span> Automatic number after explicit number</a></li></ol></li><li><a href="#sec-annex" title="Annex"><span class="secnum">A</span> Annex</a><ol class="toc"><li><a href="#sec-annex2" title="Sub-annex"><span class="secnum">A.1</span> Sub-annex</a></li></ol></li></ol></div><emu-intro id="sec-intro">
+<div><h2>Table of Contents</h2><ol class="toc"><li><a href="#sec-intro" title="Intro">Intro</a><ol class="toc"><li><a href="#sec-intro2" title="Sub Intro">Sub Intro</a></li></ol></li><li><a href="#sec-clause" title="Clause Foo(a, b)"><span class="secnum">1</span> Clause Foo(<var>a</var>, <var>b</var>)</a><ol class="toc"><li><a href="#Foo" title="Sub Clause"><span class="secnum">1.1</span> Sub Clause</a></li></ol></li><li><a href="#sec-number" title="Explicit number"><span class="secnum">7</span> Explicit number</a><ol class="toc"><li><a href="#sec-number1" title="Automatic number inside explicit number"><span class="secnum">7.1</span> Automatic number inside explicit number</a></li><li><a href="#sec-number2" title="Nested explicit number"><span class="secnum">7.4</span> Nested explicit number</a></li><li><a href="#sec-number3" title="Automatic number after explicit number"><span class="secnum">7.5</span> Automatic number after explicit number</a></li><li><a href="#sec-number-nested" title="Multi-step explicit numbers"><span class="secnum">7.6</span> Multi-step explicit numbers</a><ol class="toc"><li><a href="#sec-number-multi-step" title="Multi-step explicit numbers"><span class="secnum">7.6.1.1</span> Multi-step explicit numbers</a></li><li><a href="#sec-number-multi-step-1" title="Automatic number after explicit number"><span class="secnum">7.6.1.2</span> Automatic number after explicit number</a><ol class="toc"><li><a href="#sec-number-multi-step-inner" title="Nested clause after explicit multi-step number"><span class="secnum">7.6.1.2.1</span> Nested clause after explicit multi-step number</a></li></ol></li><li><a href="#sec-number-multi-step" title="Increasing multi-step explicit numbers"><span class="secnum">7.6.2.1</span> Increasing multi-step explicit numbers</a></li></ol></li></ol></li><li><a href="#sec-annex" title="Annex"><span class="secnum">A</span> Annex</a><ol class="toc"><li><a href="#sec-annex2" title="Sub-annex"><span class="secnum">A.1</span> Sub-annex</a></li></ol></li></ol></div><emu-intro id="sec-intro">
   <h1>Intro</h1>
   <emu-intro id="sec-intro2">
     <h1>Sub Intro</h1>
@@ -36,6 +36,24 @@
 
   <emu-clause id="sec-number3">
     <h1><span class="secnum">7.5</span> Automatic number after explicit number</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-number-nested">
+    <h1><span class="secnum">7.6</span> Multi-step explicit numbers</h1>
+    <emu-clause id="sec-number-multi-step" number="1.1">
+      <h1><span class="secnum">7.6.1.1</span> Multi-step explicit numbers</h1>
+    </emu-clause>
+
+    <emu-clause id="sec-number-multi-step-1">
+      <h1><span class="secnum">7.6.1.2</span> Automatic number after explicit number</h1>
+      <emu-clause id="sec-number-multi-step-inner">
+        <h1><span class="secnum">7.6.1.2.1</span> Nested clause after explicit multi-step number</h1>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-number-multi-step" number="2.1">
+      <h1><span class="secnum">7.6.2.1</span> Increasing multi-step explicit numbers</h1>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 

--- a/test/baselines/sources/clauses.html
+++ b/test/baselines/sources/clauses.html
@@ -34,6 +34,24 @@ assets: none
   <emu-clause id="sec-number3">
     <h1>Automatic number after explicit number</h1>
   </emu-clause>
+
+  <emu-clause id="sec-number-nested">
+    <h1>Multi-step explicit numbers</h1>
+    <emu-clause id="sec-number-multi-step" number="1.1">
+      <h1>Multi-step explicit numbers</h1>
+    </emu-clause>
+
+    <emu-clause id="sec-number-multi-step-1">
+      <h1>Automatic number after explicit number</h1>
+      <emu-clause id="sec-number-multi-step-inner">
+        <h1>Nested clause after explicit multi-step number</h1>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-number-multi-step" number="2.1">
+      <h1>Increasing multi-step explicit numbers</h1>
+    </emu-clause>
+  </emu-clause>
 </emu-clause>
 
 <emu-annex id="sec-annex">

--- a/test/baselines/sources/clauses.html
+++ b/test/baselines/sources/clauses.html
@@ -20,6 +20,22 @@ assets: none
   </emu-clause>
 </emu-clause>
 
+<emu-clause id="sec-number" number="7">
+  <h1>Explicit number</h1>
+
+  <emu-clause id="sec-number1">
+    <h1>Automatic number inside explicit number</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-number2" number="4">
+    <h1>Nested explicit number</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-number3">
+    <h1>Automatic number after explicit number</h1>
+  </emu-clause>
+</emu-clause>
+
 <emu-annex id="sec-annex">
   <h1>Annex</h1>
 

--- a/test/clauseIds.js
+++ b/test/clauseIds.js
@@ -11,8 +11,8 @@ describe('clause id generation', () => {
   });
 
   specify('generating clause ids', () => {
-    const CLAUSE = { nodeName: 'EMU-CLAUSE' };
-    const ANNEX = { nodeName: 'EMU-ANNEX' };
+    const CLAUSE = { nodeName: 'EMU-CLAUSE', hasAttribute: () => false };
+    const ANNEX = { nodeName: 'EMU-ANNEX', hasAttribute: () => false };
     assert.strictEqual(iter.next([], CLAUSE), '1');
     assert.strictEqual(iter.next([{}], CLAUSE), '1.1');
     assert.strictEqual(iter.next([{}], CLAUSE), '1.2');

--- a/test/errors.js
+++ b/test/errors.js
@@ -898,53 +898,106 @@ ${M}      </pre>
   it('invalid clause number', async () => {
     await assertError(
       positioned`
-        ${M}<emu-clause id="sec-c" number="-1">
+        <emu-clause id="sec-c" number="${M}-1">
           <h1>Clause</h1>
         </emu-clause>
       `,
       {
         ruleId: 'invalid-clause-number',
         nodeType: 'emu-clause',
-        message: 'clause numbers must be positive integers',
+        message: 'clause numbers must be positive integers or dotted lists of positive integers',
       }
     );
 
     await assertError(
       positioned`
-        ${M}<emu-clause id="sec-c" number="0">
+        <emu-clause id="sec-c" number="${M}0">
           <h1>Clause</h1>
         </emu-clause>
       `,
       {
         ruleId: 'invalid-clause-number',
         nodeType: 'emu-clause',
-        message: 'clause numbers must be positive integers',
+        message: 'clause numbers must be positive integers or dotted lists of positive integers',
       }
     );
 
     await assertError(
       positioned`
-        ${M}<emu-clause id="sec-c" number="3.14">
+        <emu-clause id="sec-c" number="${M}foo">
           <h1>Clause</h1>
         </emu-clause>
       `,
       {
         ruleId: 'invalid-clause-number',
         nodeType: 'emu-clause',
-        message: 'clause numbers must be positive integers',
+        message: 'clause numbers must be positive integers or dotted lists of positive integers',
       }
     );
 
     await assertError(
       positioned`
-        ${M}<emu-clause id="sec-c" number="foo">
+        <emu-clause id="sec-b">
           <h1>Clause</h1>
         </emu-clause>
-      `,
+
+        <emu-clause id="sec-c" number="${M}1">
+          <h1>Clause</h1>
+        </emu-clause>
+        `,
       {
         ruleId: 'invalid-clause-number',
         nodeType: 'emu-clause',
-        message: 'clause numbers must be positive integers',
+        message: 'clause numbers should be strictly increasing',
+      }
+    );
+
+    await assertError(
+      positioned`
+        <emu-clause id="sec-b" number="1.2.3">
+          <h1>Clause</h1>
+        </emu-clause>
+
+        <emu-clause id="sec-c" number="${M}1.1.4">
+          <h1>Clause</h1>
+        </emu-clause>
+        `,
+      {
+        ruleId: 'invalid-clause-number',
+        nodeType: 'emu-clause',
+        message: 'clause numbers should be strictly increasing',
+      }
+    );
+
+    await assertError(
+      positioned`
+        <emu-clause id="sec-b">
+          <h1>Clause</h1>
+        </emu-clause>
+
+        <emu-clause id="sec-c" number="${M}1.1">
+          <h1>Clause</h1>
+        </emu-clause>
+        `,
+      {
+        ruleId: 'invalid-clause-number',
+        nodeType: 'emu-clause',
+        message:
+          'multi-step explicit clause numbers should not be mixed with single-step clause numbers in the same parent clause',
+      }
+    );
+
+    await assertError(
+      positioned`
+        <emu-annex id="sec-c" ${M}number="1">
+          <h1>Clause</h1>
+        </emu-annex>
+      `,
+      {
+        ruleId: 'annex-clause-number',
+        nodeType: 'emu-annex',
+        message:
+          'top-level annexes do not support explicit numbers; if you need this, open a bug on ecmarkup',
       }
     );
   });

--- a/test/errors.js
+++ b/test/errors.js
@@ -895,6 +895,60 @@ ${M}      </pre>
     );
   });
 
+  it('invalid clause number', async () => {
+    await assertError(
+      positioned`
+        ${M}<emu-clause id="sec-c" number="-1">
+          <h1>Clause</h1>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'invalid-clause-number',
+        nodeType: 'emu-clause',
+        message: 'clause numbers must be positive integers',
+      }
+    );
+
+    await assertError(
+      positioned`
+        ${M}<emu-clause id="sec-c" number="0">
+          <h1>Clause</h1>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'invalid-clause-number',
+        nodeType: 'emu-clause',
+        message: 'clause numbers must be positive integers',
+      }
+    );
+
+    await assertError(
+      positioned`
+        ${M}<emu-clause id="sec-c" number="3.14">
+          <h1>Clause</h1>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'invalid-clause-number',
+        nodeType: 'emu-clause',
+        message: 'clause numbers must be positive integers',
+      }
+    );
+
+    await assertError(
+      positioned`
+        ${M}<emu-clause id="sec-c" number="foo">
+          <h1>Clause</h1>
+        </emu-clause>
+      `,
+      {
+        ruleId: 'invalid-clause-number',
+        nodeType: 'emu-clause',
+        message: 'clause numbers must be positive integers',
+      }
+    );
+  });
+
   it('biblio missing href', async () => {
     await assertError(
       positioned`


### PR DESCRIPTION
Some proposal authors prefer writing proposals using the same section numbers as ecma262, but it requires [hacks](https://github.com/tc39/proposal-symbol-predicates/blob/372c0528da010c15efcee449fce6045825d9ec80/spec.emu#L13-L44).

This PR allows specifying a custom `number="..."` attribute for `emu-clause` nodes.
- for nested clauses, you can only specify the last number segment: the first ones are always inherited from the parent clause
- after a custom number, automatic numbering continues from that number and not from where it left. This means that `<emu-clause /> <emu-clause number="8" /> <emu-clause />` gives `1, 8, 9` and not `1, 8, 2` or `1, 8, 3`.

cc @ljharb 