### PR TITLE
CSS: Fix very long words being cut off (word-wrap: break-word)

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -1,5 +1,6 @@
 body {
   display: flex;
+  word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
   font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;


### PR DESCRIPTION
By default, CSS won't insert linebreaks in words that are too long to fit, resulting in text overflowing or being cut off.
For example: in [ECMAScript, B.2.1.1 - escape](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-escape-string), the end of this string is lost offscreen, if your screen isn't wide enough:
> ![image](https://user-images.githubusercontent.com/4053256/180849816-1f5dba1e-a7a5-468a-bb57-7a57a9c7b80f.png)


[`word-wrap`](https://drafts.csswg.org/css-text/#overflow-wrap-property) only takes effect when a word would otherwise overflow, and only when `white-space` allows text wrapping. So, it should be safe to apply to the entire document.
