### PR TITLE
expr-parser: handle negated calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"html-escape": "^1.0.2",
 				"js-yaml": "^3.13.1",
 				"jsdom": "^19.0.0",
-				"nwsapi": "^2.2.0",
+				"nwsapi": "2.2.0",
 				"parse5": "^6.0.1",
 				"prex": "^0.4.7",
 				"promise-debounce": "^1.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ecmarkup",
-	"version": "14.1.0",
+	"version": "14.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ecmarkup",
-			"version": "14.1.0",
+			"version": "14.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "14.1.0",
+	"version": "14.1.1",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/expr-parser.ts
+++ b/src/expr-parser.ts
@@ -349,6 +349,28 @@ class ExprParser {
               lastPart.parts.pop();
             }
             if (callee.length > 0) {
+              if (callee[0].name === 'text') {
+                // check for -F(), which is negation of F() not an AO named -F
+                const initialNonLetter = callee[0].contents.match(/^\P{Letter}+/u);
+                if (initialNonLetter != null) {
+                  const extra = initialNonLetter[0].length;
+                  const extraLoc = callee[0].location.start.offset;
+                  // we know by construction that there is at least one letter, so this is guaranteed to be nonempty
+                  callee[0].contents = callee[0].contents.substring(extra);
+                  callee[0].location.start.offset += extra;
+                  addProse(items, {
+                    type: 'prose',
+                    parts: [
+                      {
+                        name: 'text',
+                        contents: callee[0].contents.substring(0, extra),
+                        location: { start: { offset: extraLoc } },
+                      },
+                    ],
+                  });
+                }
+              }
+
               this.next.shift();
               const args: Seq[] = [];
               if (this.peek().type !== 'cparen') {

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -920,3 +920,77 @@ describe('invocation kind', async () => {
     );
   });
 });
+
+describe('negation', async () => {
+  let biblio;
+  before(async () => {
+    biblio = await getBiblio(`
+      <emu-clause id="example" type="abstract operation">
+        <h1>F ()</h1>
+        <dl class="header"></dl>
+      </emu-clause>
+    `);
+  });
+
+  it('AO with a dash in it', async () => {
+    await assertLint(
+      positioned`
+        <emu-alg>
+          1. Return ${M}x-F().
+        </emu-alg>
+      `,
+      {
+        ruleId: 'typecheck',
+        nodeType: 'emu-alg',
+        message: 'could not find definition for x-F',
+      },
+      {
+        extraBiblios: [biblio],
+      }
+    );
+  });
+
+  it('AO with a dash in it, negated', async () => {
+    await assertLint(
+      positioned`
+        <emu-alg>
+          1. Return -${M}x-F().
+        </emu-alg>
+      `,
+      {
+        ruleId: 'typecheck',
+        nodeType: 'emu-alg',
+        message: 'could not find definition for x-F',
+      },
+      {
+        extraBiblios: [biblio],
+      }
+    );
+  });
+
+  it('negative: binary minus', async () => {
+    await assertLintFree(
+      `
+        <emu-alg>
+          1. Return x - F().
+        </emu-alg>
+      `,
+      {
+        extraBiblios: [biblio],
+      }
+    );
+  });
+
+  it('negative: unary negation', async () => {
+    await assertLintFree(
+      `
+        <emu-alg>
+          1. Return -F().
+        </emu-alg>
+      `,
+      {
+        extraBiblios: [biblio],
+      }
+    );
+  });
+});


### PR DESCRIPTION
`-ℝ(_y_)` should parse as a negation of `ℝ(_y_)`, not as an invocation of an AO named `-ℝ`.