### PR TITLE
continue processing ecmarkdown after comments

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1955,9 +1955,7 @@ async function walk(walker: TreeWalker, context: Context) {
     previousInNoEmd = false;
   }
 
-  if (context.node.nodeType === 3) {
-    // walked to a text node
-
+  if (context.node.nodeType === 3 /* Node.TEXT_NODE */) {
     if (context.node.textContent!.trim().length === 0) return; // skip empty nodes; nothing to do!
 
     const clause = context.clauseStack[context.clauseStack.length - 1] || context.spec;
@@ -1966,13 +1964,19 @@ async function walk(walker: TreeWalker, context: Context) {
       // new nodes as a result of emd processing should be skipped
       context.inNoEmd = true;
       let node = context.node as Node | null;
-      while (node && !node.nextSibling) {
+      function nextRealSibling(node: Node | null) {
+        while (node?.nextSibling?.nodeType === 8 /* Node.COMMENT_NODE */) {
+          node = node.nextSibling;
+        }
+        return node?.nextSibling;
+      }
+      while (node && !nextRealSibling(node)) {
         node = node.parentNode;
       }
 
       if (node) {
         // inNoEmd will be set to false when we walk to this node
-        context.followingEmd = node.nextSibling;
+        context.followingEmd = nextRealSibling(node)!;
       }
       // else, there's no more nodes to process and inNoEmd does not need to be tracked
 

--- a/test/baselines/generated-reference/ecmarkdown.html
+++ b/test/baselines/generated-reference/ecmarkdown.html
@@ -8,7 +8,7 @@
 </ul></div><div id="spec-container">
 <emu-clause id="sec-foo">
   <h1><span class="secnum">1</span> ecmarkdown basics</h1>
-  <p>ecmarkdown like <var>v</var> works before <!-- a comment --> and after comments _v_.</p>
+  <p>ecmarkdown like <var>v</var> works before <!-- a comment --> and after comments <var>v</var>.</p>
 </emu-clause>
 
 </div></body>

--- a/test/baselines/generated-reference/ecmarkdown.html
+++ b/test/baselines/generated-reference/ecmarkdown.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<head><meta charset="utf-8"></head><body><div id="shortcuts-help">
+<ul>
+  <li><span>Toggle shortcuts help</span><code>?</code></li>
+  <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
+
+  <li><span>Jump to search box</span><code>/</code></li>
+</ul></div><div id="spec-container">
+<emu-clause id="sec-foo">
+  <h1><span class="secnum">1</span> ecmarkdown basics</h1>
+  <p>ecmarkdown like <var>v</var> works before <!-- a comment --> and after comments _v_.</p>
+</emu-clause>
+
+</div></body>

--- a/test/baselines/sources/ecmarkdown.html
+++ b/test/baselines/sources/ecmarkdown.html
@@ -1,0 +1,10 @@
+<pre class=metadata>
+toc: false
+copyright: false
+assets: none
+</pre>
+<emu-clause id="sec-foo">
+  <h1>ecmarkdown basics</h1>
+  <p>ecmarkdown like _v_ works before <!-- a comment --> and after comments _v_.</p>
+</emu-clause>
+


### PR DESCRIPTION
When processing text nodes with ecmarkdown, we [replace that single node with potentially multiple nodes output by ecmarkdown](https://github.com/tc39/ecmarkup/blob/33c04a6c2e9cd8492b53ed8c6ac86b46e16f96aa/src/utils.ts#L98).

We do this _while walking the tree_, which is sketchy. To prevent re-running ecmarkdown on text nodes we just created, we [keep track of the node which originally followed this text node](https://github.com/tc39/ecmarkup/blob/33c04a6c2e9cd8492b53ed8c6ac86b46e16f96aa/src/Spec.ts#L1975) and then [skip those](https://github.com/tc39/ecmarkup/blob/33c04a6c2e9cd8492b53ed8c6ac86b46e16f96aa/src/Spec.ts#L1965).

But the walker only sees text nodes and elements, so when the next node is a comment node, it just skipped the reset of the element. Fix is to keep track of the next _non-comment_ node.