### PR TITLE
lint for used-but-not-declared and declared-but-not-used variables in algorithms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -346,6 +346,16 @@ toc: false
       1. Return the result of evaluating this |NonTerminalProduction|.
   </emu-alg>
 
+  <h2>Declarations</h2>
+  <p>The linter checks that each used variable in an algorithm step is declared earlier. It recognizes most common forms of declaration automatically, but in case there is a declaration which is not automatically inferred, a variable can be marked as declared for the purposes of this analysis by adding a `[declared="v"]` attribute at the start of the step. Multiple variables can be listed by seperating them with commas.</p>
+
+  <h3>Element</h3>
+  <pre><code class="language-html">
+&lt;emu-alg>
+  1. [declared="x"] Suppose the existence of _x_.
+&lt;/emu-alg>
+  </code></pre>
+
   <h2>Replacement algorithms</h2>
   <p>Algorithms may be specified to replace a labeled step, in which case the algorithm will adopt the numbering of that step. For example:</p>
 

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -11,6 +11,7 @@ import lintAlgorithmStepNumbering from './rules/algorithm-step-numbering';
 import lintAlgorithmStepLabels from './rules/algorithm-step-labels';
 import lintForEachElement from './rules/for-each-element';
 import lintStepAttributes from './rules/step-attributes';
+import { checkVariableUsage } from './rules/variable-use-def';
 
 const algorithmRules = [
   lintAlgorithmLineStyle,
@@ -80,6 +81,7 @@ export function collectAlgorithmDiagnostics(
     }
     if (tree != null) {
       visit(tree, observer);
+      checkVariableUsage(algorithm.element, tree.contents, reporter);
     }
 
     algorithm.tree = tree;

--- a/src/lint/rules/step-attributes.ts
+++ b/src/lint/rules/step-attributes.ts
@@ -3,7 +3,7 @@ import type { Reporter } from '../algorithm-error-reporter-type';
 
 const ruleId = 'unknown-step-attribute';
 
-const KNOWN_ATTRIBUTES = ['id', 'fence-effects'];
+const KNOWN_ATTRIBUTES = ['id', 'fence-effects', 'declared'];
 
 /*
 Checks for unknown attributes on steps.

--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -29,7 +29,8 @@ export function checkVariableUsage(
   let preceding = previousOrParent(containingAlgorithm, parentClause);
   while (preceding != null) {
     if (preceding.tagName !== 'EMU-ALG' && preceding.querySelector('emu-alg') == null && preceding.textContent != null) {
-      for (let name of preceding.textContent.matchAll(/\b_([a-zA-Z0-9]+)_\b/g)) {
+      // `__` is for <del>_x_</del><ins>_y_</ins>, which has textContent `_x__y_`
+      for (let name of preceding.textContent.matchAll(/(?<=\b|_)_([a-zA-Z0-9]+)_(?=\b|_)/g)) {
         scope.declare(name[1], null);
       }
     }
@@ -282,7 +283,7 @@ function walkAlgorithm(steps: OrderedListNode | UnorderedListNode, scope: Scope,
             if (
               // "of"/"in" guard is to distinguish "an integer X such that" from "an integer X in Y such that" - latter should not declare Y
               (isSuchThat && cur.name === 'text' && !/(?: of | in )/.test(cur.contents)) ||
-              (isBe && cur.name === 'text' && /\blet $/i.test(cur.contents))
+              (isBe && cur.name === 'text' && /\blet (?:each of )?$/i.test(cur.contents))
             ) {
               for (let v of varsDeclaredHere) {
                 scope.declare(v.contents[0].contents, v);

--- a/test/expr-parser.js
+++ b/test/expr-parser.js
@@ -19,6 +19,7 @@ describe('expression parsing', () => {
     it('calls', async () => {
       await assertLintFree(`
         <emu-alg>
+          1. Let _foo_ be a variable.
           1. Let _x_ be _foo_().
           1. Set _x_ to _foo_( ).
           1. Set _x_ to _foo_.[[Bar]]().
@@ -41,8 +42,9 @@ describe('expression parsing', () => {
     it('record-spec', async () => {
       await assertLintFree(`
         <emu-alg>
+          1. Let _entries_ be a List.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
-            1. Something.
+            1. Use _p_.
         </emu-alg>
       `);
     });
@@ -54,6 +56,7 @@ describe('expression parsing', () => {
             0,
             1,
           ».
+        1. Use _x_.
         </emu-alg>
       `);
     });
@@ -61,10 +64,12 @@ describe('expression parsing', () => {
     it('trailing comma in multi-line call', async () => {
       await assertLintFree(`
         <emu-alg>
+        1. Let _foo_ be a function.
         1. Let _x_ be _foo_(
             0,
             1,
           ).
+        1. Use _x_.
         </emu-alg>
       `);
     });
@@ -76,6 +81,7 @@ describe('expression parsing', () => {
             [[X]]: 0,
             [[Y]]: 1,
           }.
+        1. Use _x_.
         </emu-alg>
       `);
     });
@@ -87,6 +93,7 @@ describe('expression parsing', () => {
         1. Let _x_ be a new Record { [[Foo]]: 0, <ins>[[Bar]]: 1</ins> }.
         1. Let _x_ be a new Record { [[Foo]]: 0, <ins>[[Bar]]: 1, [[Baz]]: 2</ins> }.
         1. Let _x_ be a new Record { [[Foo]]: 0, <ins>[[Bar]]: 1,</ins> [[Baz]]: 2 }.
+        1. Use _x_.
         </emu-alg>
       `);
     });
@@ -127,7 +134,9 @@ describe('expression parsing', () => {
       await assertLint(
         positioned`
           <emu-alg>
+            1. Let _foo_ and _a_ be variables.
             1. Let _x_ be «_foo_(_a_${M}»).
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -143,6 +152,7 @@ describe('expression parsing', () => {
         positioned`
           <emu-alg>
             1. Let _x_ be «${M},».
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -170,7 +180,9 @@ describe('expression parsing', () => {
       await assertLint(
         positioned`
           <emu-alg>
+            1. Let _foo_ be a function.
             1. Let _x_ be _foo_(${M},)».
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -183,7 +195,9 @@ describe('expression parsing', () => {
       await assertLint(
         positioned`
           <emu-alg>
+            1. Let _foo_ and _a_ be variables.
             1. Let _x_ be _foo_(_a_, ${M}).
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -199,6 +213,7 @@ describe('expression parsing', () => {
         positioned`
           <emu-alg>
             1. Let _x_ be the Record { ${M}}.
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -214,6 +229,7 @@ describe('expression parsing', () => {
         positioned`
           <emu-alg>
             1. Let _x_ be the Record { ${M}[x]: 0 }.
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -229,6 +245,7 @@ describe('expression parsing', () => {
         positioned`
           <emu-alg>
             1. Let _x_ be the Record { [[A]]: 0, [[${M}A]]: 0 }.
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -244,6 +261,7 @@ describe('expression parsing', () => {
         positioned`
           <emu-alg>
             1. Let _x_ be the Record { [[A]], [[B]]${M}: 0 }.
+            1. Use _x_.
           </emu-alg>
         `,
         {
@@ -257,6 +275,7 @@ describe('expression parsing', () => {
         positioned`
           <emu-alg>
             1. Let _x_ be the Record { [[A]]: 0, [[B]]${M} }.
+            1. Use _x_.
           </emu-alg>
         `,
         {

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -45,6 +45,7 @@ describe('linting algorithms', () => {
     it('repeat', async () => {
       await assertLint(
         positioned`<emu-alg>
+          1. Let _x_ be a variable.
           1. Repeat, while _x_ < 10${M}
             1. Foo.
         </emu-alg>`,
@@ -59,6 +60,7 @@ describe('linting algorithms', () => {
     it('inline if', async () => {
       await assertLint(
         positioned`<emu-alg>
+          1. Let _x_ be a variable.
           1. If _x_, then${M}
         </emu-alg>`,
         {
@@ -72,6 +74,7 @@ describe('linting algorithms', () => {
     it('inline if-then', async () => {
       await assertLint(
         positioned`<emu-alg>
+          1. Let _x_ be a variable.
           1. If _x_, ${M}then do something.
         </emu-alg>`,
         {
@@ -85,6 +88,7 @@ describe('linting algorithms', () => {
     it('multiline if', async () => {
       await assertLint(
         positioned`<emu-alg>
+          1. Let _x_ be a variable.
           1. If _x_,${M}
             1. Foo.
         </emu-alg>`,
@@ -97,6 +101,7 @@ describe('linting algorithms', () => {
 
       await assertLint(
         positioned`<emu-alg>
+          1. Let _x_ be a variable.
           1. If _x_${M}; then
             1. Foo.
           </emu-alg>`,
@@ -112,6 +117,7 @@ describe('linting algorithms', () => {
     it('else if', async () => {
       await assertLint(
         positioned`<emu-alg>
+          1. Let _x_ and _y_ be variables.
           1. If _x_, foo.
           1. Else${M}, if _y_, bar.
         </emu-alg>`,
@@ -199,6 +205,7 @@ describe('linting algorithms', () => {
             1. ${M}Let _constructorText_ be the source text
             <pre><code class="javascript">constructor() {}</code></pre>
               1. Foo.
+            1. Use _constructorText_.
         </emu-alg>`,
         {
           ruleId,
@@ -219,6 +226,7 @@ describe('linting algorithms', () => {
     it('negative', async () => {
       await assertLintFree(`
         <emu-alg>
+          1. Let _x_, _y_, and _z_ be variables.
           1. If foo, bar.
           1. Else if foo, bar.
           1. Else, bar.
@@ -250,7 +258,9 @@ describe('linting algorithms', () => {
             1. Substep.
           1. Let _constructorText_ be the source text
           <pre><code class="javascript">constructor() {}</code></pre>
-          1. Set _constructor_ to _parse_(_constructorText_, _methodDefinition_).
+          1. Let _parse_ be a method.
+          1. Let _constructor_ be a variable.
+          1. Set _constructor_ to _parse_(_constructorText_).
           1. <mark>A highlighted line.</mark>
           1. <ins>Amend the spec with this.</ins>
           1. <del>Remove this from the spec.</del>
@@ -413,6 +423,7 @@ describe('linting algorithms', () => {
       await assertLint(
         positioned`
         <emu-alg>
+          1. Let _y_ be a List.
           1. For each ${M}_x_ of _y_, do foo.
         </emu-alg>`,
         {
@@ -426,6 +437,8 @@ describe('linting algorithms', () => {
     it('negative', async () => {
       await assertLintFree(`
         <emu-alg>
+          1. Let _y_ be a List.
+          1. Let _S_ be a Set.
           1. For each String _x_ of _y_, do foo.
           1. For each element _x_ of _y_, do foo.
           1. For each integer _x_ such that _x_ &in; _S_, do foo.

--- a/test/lint-spelling.js
+++ b/test/lint-spelling.js
@@ -45,7 +45,10 @@ describe('spelling', () => {
   it('*0*', async () => {
     await assertLint(
       positioned`
-        <emu-alg>1. If _x_ is ${M}*0*<sub>𝔽</sub>, do foo.</emu-alg>
+        <emu-alg>
+          1. Let _x_ be a value.
+          1. If _x_ is ${M}*0*<sub>𝔽</sub>, do foo.
+        </emu-alg>
       `,
       {
         ruleId: 'spelling',

--- a/test/lint-variable-use-def.js
+++ b/test/lint-variable-use-def.js
@@ -115,6 +115,38 @@ describe('variables are declared and used appropriately', () => {
       );
     });
 
+    it('variables in a loop header other than the loop variable must be declared', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _c_ be a variable.
+            1. For each integer _a_ of ${M}_b_ such that _c_ relates to _a_ in some way, do
+              1. Something.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "b"',
+        }
+      );
+
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _b_ be a variable.
+            1. For each integer _a_ of _b_ such that ${M}_c_ relates to _a_ in some way, do
+              1. Something.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "c"',
+        }
+      );
+    });
+
     it('explicit "declared" annotations should not be redundant', async () => {
       await assertLint(
         positioned`

--- a/test/lint-variable-use-def.js
+++ b/test/lint-variable-use-def.js
@@ -278,6 +278,22 @@ describe('variables are declared and used appropriately', () => {
       );
     });
 
+    it('abstract closure parameters/captures are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-clause id="sec-object.fromentries">
+          <h1>Object.fromEntries ( <del>_del_</del><ins>_obj_</ins> )</h1>
+          <emu-alg>
+            1. Let _closure_ be a new Abstract Closure with parameters (_key_, _value_) that captures _obj_ and performs the following steps when called:
+              1. Do something with _obj_, _key_, and _value_.
+              1. Return *undefined*.
+            1. Return _closure_.
+          </emu-alg>
+        </emu-clause>
+        `
+      );
+    });
+
     it('multiple declarations are visible', async () => {
       await assertLintFree(
         `

--- a/test/lint-variable-use-def.js
+++ b/test/lint-variable-use-def.js
@@ -1,0 +1,355 @@
+'use strict';
+
+let {
+  assertLint,
+  assertLintFree,
+  positioned,
+  lintLocationMarker: M,
+  getBiblio,
+} = require('./utils.js');
+
+describe('variables are declared and used appropriately', () => {
+  describe('variables must be declared', () => {
+    it('variables must be declared', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be 0.
+            1. Something with _x_ and ${M}_y_.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "y"',
+        }
+      );
+    });
+
+    it('loop variables are not visible after the loop', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. For each integer _k_ less than 10, do
+              1. Something with _k_.
+            1. Something with ${M}_k_.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "k"',
+        }
+      );
+    });
+
+    it('abstract closure captures must be declared', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures ${M}_undeclared_ and performs the following steps when called:
+              1. Do something with _undeclared_.
+              1. Return *undefined*.
+            1. Return _closure_.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "undeclared"',
+        }
+      );
+    });
+
+    it('abstract closures must capture their values', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _v_ be 0.
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
+              1. Do something with ${M}_v_.
+              1. Return *undefined*.
+            1. Do something with _v_ so it does not seem unused.
+            1. Return _closure_.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "v"',
+        }
+      );
+    });
+
+    it('abstract closure captures must be used', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _outer_ be 0.
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures ${M}_outer_ and performs the following steps when called:
+              1. Return *undefined*.
+            1. Return _closure_.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'unused-capture',
+          nodeType: 'emu-alg',
+          message: 'closure captures "outer", but never uses it',
+        }
+      );
+    });
+
+    it('"there exists _x_ in _y_ such that" declares _x_ but not _y_"', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. If there exists an integer _x_ in ${M}_y_ such that _x_ < 10, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "y"',
+        }
+      );
+    });
+
+    it('explicit "declared" annotations should not be redundant', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _y_ be 0.
+            1. [declared="x,${M}y"] Return _x_ + _y_.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'unnecessary-declared-var',
+          nodeType: 'emu-alg',
+          message: '"y" is already declared and does not need an explict annotation',
+        }
+      );
+    });
+  });
+
+  describe('variables must be used', () => {
+    it('variables must be used', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. Let _x_ be 0.
+            1. Let ${M}_y_ be 1.
+            1. Return _x_.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'unused-declaration',
+          nodeType: 'emu-alg',
+          message: '"y" is declared here, but never referred to',
+        }
+      );
+    });
+  });
+
+  describe('valid declaration + use', () => {
+    it('declarations are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. Let _x_ be 0.
+            1. Return _x_.
+          </emu-alg>
+        `
+      );
+    });
+
+    it('declarations from a nested if/else are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. If condition, let _result_ be 0.
+            1. Else, let _result_ be 1.
+            1. Return _result_.
+          </emu-alg>
+        `
+      );
+
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. If condition, then
+              1. Let _result_ be 0.
+            1. Else,
+              1. Let _result_ be 1.
+            1. Return _result_.
+          </emu-alg>
+        `
+      );
+    });
+
+    it('declarations from built-in function parameters are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-clause id="sec-array.prototype.unshift">
+            <h1>Array.prototype.unshift ( ..._items_ )</h1>
+            <p>It performs the following steps when called:</p>
+            <emu-alg>
+              1. Let _argCount_ be the number of elements in _items_.
+              1. Do something with _argCount_.
+            </emu-alg>
+          </emu-clause>
+        `
+      );
+    });
+
+    it('declarations from free-form headers are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-clause id="sec-valid-chosen-reads">
+            <h1>Valid Chosen Reads</h1>
+            <p>A candidate execution _execution_ has valid chosen reads if the following algorithm returns *true*.</p>
+            <emu-alg>
+              1. If some condition of _execution_, return *true*.
+              1. Return *false*.
+            </emu-alg>
+          </emu-clause>
+        `
+      );
+    });
+
+    it('declarations from free-form headers are visible even when the algorithm is nested', async () => {
+      await assertLintFree(
+        `
+          <emu-clause id="sec-valid-chosen-reads">
+            <h1>Valid Chosen Reads</h1>
+            <p>A candidate execution _execution_ has valid chosen reads if the following algorithm returns *true*.</p>
+            <table>
+              <tr>
+              <td>
+              <emu-alg>
+                1. If some condition of _execution_, return *true*.
+                1. Return *false*.
+              </emu-alg>
+              </td>
+              <td>
+              <emu-alg>
+                1. If some condition of _execution_, return *true*.
+                1. Return *false*.
+              </emu-alg>
+              </td>
+              </tr>
+            </table>
+          </emu-clause>
+        `
+      );
+    });
+
+    it('the receiver for concrete methods is visible', async () => {
+      await assertLintFree(
+        `
+          <emu-clause id="sec-declarative-environment-records-hasbinding-n" type="concrete method">
+            <h1>HasBinding ( _N_ )</h1>
+            <dl class="header">
+              <dt>for</dt>
+              <dd>a Declarative Environment Record _envRec_</dd>
+            </dl>
+            <emu-alg>
+              1. If _envRec_ has a binding for the name that is the value of _N_, return *true*.
+              1. Return *false*.
+            </emu-alg>
+          </emu-clause>
+        `
+      );
+    });
+
+    it('abstract closure parameters/captures are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-clause id="sec-object.fromentries">
+          <h1>Object.fromEntries ( _obj_ )</h1>
+          <emu-alg>
+            1. Let _closure_ be a new Abstract Closure with parameters (_key_, _value_) that captures _obj_ and performs the following steps when called:
+              1. Do something with _obj_, _key_, and _value_.
+              1. Return *undefined*.
+            1. Return _closure_.
+          </emu-alg>
+        </emu-clause>
+        `
+      );
+    });
+
+    it('multiple declarations are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. Let _x_, _y_, and _z_ be some values.
+            1. Return _x_ + _y_ + _z_.
+          </emu-alg>
+        `
+      );
+    });
+
+    it('"such that" counts as a declaration"', async () => {
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. If there is an integer _x_ such that _x_ < 10, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        `
+      );
+
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. If there are integers _x_ and _y_ such that _x_ < _y_, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        `
+      );
+    });
+
+    it('"there exists" counts as a declaration"', async () => {
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. If there exists an integer _x_ between 0 and 10, return _x_.
+            1. Return -1.
+          </emu-alg>
+        `
+      );
+    });
+
+    it('declarations from explicit attributes are visible', async () => {
+      await assertLintFree(
+        `
+          <emu-clause id="sec-array.prototype.unshift">
+            <h1>Array.prototype.unshift ( ..._items_ )</h1>
+            <p>It performs the following steps when called:</p>
+            <emu-alg>
+              1. [declared="x,y"] Do something with _x_ and _y_.
+            </emu-alg>
+          </emu-clause>
+        `
+      );
+    });
+
+    it('loop variables are visible within the loop', async () => {
+      let biblio = await getBiblio(`
+        <emu-grammar type="definition">
+          CaseClause : \`a\`
+        </emu-grammar>
+      `);
+
+      await assertLintFree(
+        `
+          <emu-alg>
+            1. For each |CaseClause| _c_ of some list, do
+              1. Something with _c_.
+          </emu-alg>
+        `,
+        { extraBiblios: [biblio] }
+      );
+    });
+  });
+});

--- a/test/lint.js
+++ b/test/lint.js
@@ -482,6 +482,7 @@ describe('linting whole program', () => {
         positioned`
           <emu-alg>
             1. Let _s_ be |${M}Example|.
+            1. Return _s_.
           </emu-alg>
         `,
         {
@@ -503,6 +504,7 @@ describe('linting whole program', () => {
             <emu-grammar>Statement: \`;\`</emu-grammar>
             <emu-alg>
               1. Let _s_ be |${M}Statements|.
+              1. Return _s_.
             </emu-alg>
           </emu-clause>
         `,
@@ -554,6 +556,7 @@ describe('linting whole program', () => {
         </emu-grammar>
         <emu-alg>
           1. Let _s_ be |Example1|.
+          1. Return _s_.
         </emu-alg>
         <p>Discuss: |Example1|.</p>
         <p>Discuss: <emu-nt>Example1</emu-nt>.</p>

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -84,6 +84,7 @@ describe('typechecking completions', () => {
           <dl class="header">
           </dl>
           <emu-alg>
+            1. Let _foo_ be 0.
             1. Return ${M}ExampleAlg of _foo_.
           </emu-alg>
           </emu-clause>
@@ -133,6 +134,7 @@ describe('typechecking completions', () => {
             1. Let _a_ be Completion(<emu-meta suppress-effects="user-code">ExampleAlg()</emu-meta>).
             1. Set _a_ to ! ExampleAlg().
             1. Return ? ExampleAlg().
+            1. Let _foo_ be 0.
             1. Let _a_ be Completion(ExampleSDO of _foo_).
             1. Let _a_ be Completion(ExampleSDO of _foo_ with argument 0).
             1. If ? ExampleSDO of _foo_ is *true*, then
@@ -230,6 +232,7 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return ${M}? _foo_.
         </emu-alg>
         </emu-clause>
@@ -272,6 +275,7 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         <emu-alg>
+          1. Let _x_ be 0.
           1. ${M}Return Completion(_x_).
         </emu-alg>
         </emu-clause>
@@ -298,6 +302,8 @@ describe('typechecking completions', () => {
           <dl class="header">
           </dl>
           <emu-alg>
+            1. Let _foo_ be 0.
+            1. Let _x_ be 0.
             1. Return ? _foo_.
             1. Return Completion(_x_).
             1. Throw a new TypeError.
@@ -322,6 +328,7 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         ${M}<emu-alg>
+          1. Let _foo_ be 0.
           1. Return _foo_.
         </emu-alg>
         </emu-clause>
@@ -344,6 +351,7 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return ? _foo_.
         </emu-alg>
         </emu-clause>
@@ -357,6 +365,7 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return _foo_.
         </emu-alg>
         </emu-clause>
@@ -375,6 +384,7 @@ describe('typechecking completions', () => {
           <dl class="header">
           </dl>
           <emu-alg>
+            1. Let _foo_ be 0.
             1. Return _foo_.
           </emu-alg>
           </emu-clause>
@@ -387,6 +397,7 @@ describe('typechecking completions', () => {
           </dl>
           <emu-alg>
             1. Let _x_ be ${M}ExampleAlg().
+            1. Return _x_.
           </emu-alg>
           </emu-clause>
         `,
@@ -408,6 +419,7 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return _foo_.
         </emu-alg>
         </emu-clause>
@@ -481,7 +493,8 @@ describe('typechecking completions', () => {
         <dl class="header">
         </dl>
         <emu-alg>
-        1. Let _x_ be ExampleAlg().
+          1. Let _x_ be ExampleAlg().
+          1. Return _x_.
         </emu-alg>
         </emu-clause>
       `);
@@ -523,6 +536,7 @@ describe('typechecking completions', () => {
           <dl class="header">
           </dl>
           <emu-alg>
+            1. Let _foo_ be 0.
             1. Return ? _foo_.
           </emu-alg>
           </emu-clause>
@@ -534,7 +548,8 @@ describe('typechecking completions', () => {
           <dl class="header">
           </dl>
           <emu-alg>
-          1. Let _x_ be ! ExampleAlg().
+            1. Let _x_ be ! ExampleAlg().
+            1. Return _x_.
           </emu-alg>
           </emu-clause>
         `,
@@ -556,6 +571,7 @@ describe('typechecking completions', () => {
           <dl class="header">
           </dl>
           <emu-alg>
+            1. Let _foo_ be 0.
             1. Return ? _foo_.
           </emu-alg>
           </emu-clause>
@@ -567,7 +583,8 @@ describe('typechecking completions', () => {
           <dl class="header">
           </dl>
           <emu-alg>
-          1. Let _x_ be ? ExampleAlg().
+            1. Let _x_ be ? ExampleAlg().
+            1. Return _x_.
           </emu-alg>
           </emu-clause>
       `);
@@ -710,6 +727,7 @@ describe('signature agreement', async () => {
     await assertLint(
       positioned`
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return ${M}SDOTakesNoArgs of _foo_ with argument 1.
         </emu-alg>
       `,
@@ -726,6 +744,7 @@ describe('signature agreement', async () => {
     await assertLint(
       positioned`
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return <emu-meta suppress-effects="user-code">${M}SDOTakesNoArgs of _foo_ with argument 0</emu-meta>.
         </emu-alg>
       `,
@@ -742,6 +761,7 @@ describe('signature agreement', async () => {
     await assertLint(
       positioned`
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return ${M}SDOTakesOneOrTwoArgs of _foo_ with arguments 0, 1, and 2.
         </emu-alg>
       `,
@@ -794,6 +814,7 @@ describe('signature agreement', async () => {
     await assertLint(
       positioned`
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return ${M}SDOTakesOneArg of _foo_.
         </emu-alg>
       `,
@@ -810,6 +831,7 @@ describe('signature agreement', async () => {
     await assertLint(
       positioned`
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return ${M}SDOTakesOneOrTwoArgs of _foo_.
         </emu-alg>
       `,
@@ -828,6 +850,7 @@ describe('signature agreement', async () => {
     await assertLintFree(
       `
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Perform TakesNoArgs().
           1. Perform TakesOneArg(0).
           1. Perform TakesOneOrTwoArgs(0).
@@ -885,6 +908,7 @@ describe('invocation kind', async () => {
     await assertLint(
       positioned`
         <emu-alg>
+          1. Let _foo_ be 0.
           1. Return ${M}AO of _foo_.
         </emu-alg>
       `,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
         "stripInternal": true,
         "importsNotUsedAsValues": "error",
         "outDir": "lib",
-        "lib": ["es5", "es2019", "dom", "dom.iterable"],
+        "lib": ["es2020", "dom", "dom.iterable"],
         "typeRoots": [
             "node_modules/@types"
         ]


### PR DESCRIPTION
Based on https://github.com/tc39/ecmarkup/pull/482. Fixes https://github.com/tc39/ecmarkup/issues/129.

Given https://github.com/tc39/ecma262/pull/2896 and https://github.com/tc39/ecma262/commit/5f759fa947f6c8ea2bf29c7f5b3a345a8f7714db, this passes on ecma262 except for a few genuinely unused declarations, which I'll fix as part of merging this.

This is pretty conservative (e.g. it assumes any variable referred to in a previous paragraph in the clause is defined, to handle stuff like [this](https://tc39.es/ecma262/multipage/memory-model.html#sec-tear-free-aligned-reads)), but seems to work well. In particular it handles abstract closures correctly (variables must be captured from the outer scope, captures count as using variables from the outer scope).