### PR TITLE
relax restrictions on '...' in parameter lists

### DIFF
--- a/src/lint/collect-header-diagnostics.ts
+++ b/src/lint/collect-header-diagnostics.ts
@@ -80,10 +80,9 @@ export function collectHeaderDiagnostics(
         /^ \. \. \. $/,
 
         // String.raw ( _template_, ..._substitutions_ )
-        /^ (_[A-Za-z0-9]+_, )*\.\.\._[A-Za-z0-9]+_ $/,
-
         // Function ( _p1_, _p2_, &hellip; , _pn_, _body_ )
-        /^ (_[A-Za-z0-9]+_, )*… (, _[A-Za-z0-9]+_)+ $/,
+        // Function ( ..._parameterArgs_, _bodyArg_ )
+        /^ (_[A-Za-z0-9]+_, )*(\.\.\.|&hellip;|…)(_[A-Za-z0-9]+_| )(, _[A-Za-z0-9]+_)* $/,
 
         // Example ( _foo_ [ , _bar_ ] )
         // Example ( [ _foo_ ] )

--- a/test/lint.js
+++ b/test/lint.js
@@ -393,6 +393,9 @@ describe('linting whole program', () => {
           <emu-clause id="i7">
             <h1>Function ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
           </emu-clause>
+          <emu-clause id="i7-a">
+            <h1>Function ( ..._parameterArgs_, _bodyArg_ )</h1>
+          </emu-clause>
           <emu-clause id="i8">
             <h1>Example ( _a_, <del>_b_</del><ins>_c_</ins> )</h1>
           </emu-clause>


### PR DESCRIPTION
So that https://github.com/tc39/ecma262/pull/2902 passes the lint check.

The regex says "some parameters (possibly zero), followed by `..._x_` or `... `, followed by some more parameters (possibly zero)", with three different forms of "..." accepted (normalizing those is not this rule's job).