### PR TITLE
remove special treatment of "the result of evaluating"

### DIFF
--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -25,21 +25,17 @@ export default class Algorithm extends Builder {
     context.inAlg = true;
     const { spec, node, clauseStack } = context;
 
-    // Mark all "the result of evaluation Foo" language as having the
-    // "user-code" effect. Do this before ecmarkdown, otherwise productions like
-    // |Foo| get turned into tags and the regexp gets complicated.
-    const innerHTML = node.innerHTML.replace(
-      /the result of evaluating ([a-zA-Z_|0-9]+)/g,
-      'the result of <emu-meta effects="user-code">evaluating $1</emu-meta>'
-    ); // TODO use original slice, forward this from linter
+    const innerHTML = node.innerHTML; // TODO use original slice, forward this from linter
 
-    let emdTree;
-    try {
-      emdTree = emd.parseAlgorithm(innerHTML);
-    } catch (e: any) {
-      if (!('ecmarkdownTree' in node)) {
-        // if it is present, we've already warned earlier
-        warnEmdFailure(spec.warn, node, e);
+    let emdTree: ReturnType<typeof emd.parseAlgorithm> | null = null;
+    if ('ecmarkdownTree' in node) {
+      // @ts-expect-error
+      emdTree = node.ecmarkdownTree;
+    } else {
+      try {
+        emdTree = emd.parseAlgorithm(innerHTML);
+      } catch (e) {
+        warnEmdFailure(spec.warn, node, e as SyntaxError);
       }
     }
     if (emdTree == null) {

--- a/test/baselines/generated-reference/effect-user-code.html
+++ b/test/baselines/generated-reference/effect-user-code.html
@@ -130,14 +130,14 @@
 
 <emu-clause id="sec-result-of-evaluating" type="abstract operation" aoid="ResultOfEvaluating">
   <h1><span class="secnum">21</span> ResultOfEvaluating ( )</h1>
-  <p>The abstract operation ResultOfEvaluating takes no arguments. The phrase "the result of evaluating Foo" is automatically considered as can call user code. It performs the following steps when called:</p>
-  <emu-alg><ol><li>Let <var>res</var> be the result of <span class="e-user-code">evaluating <emu-nt>Foo</emu-nt></span>.</li></ol></emu-alg>
+  <p>The abstract operation ResultOfEvaluating takes no arguments. The phrase "the result of evaluating Foo" is not automatically considered as can call user code. It performs the following steps when called:</p>
+  <emu-alg><ol><li>Let <var>res</var> be the result of evaluating <emu-nt>Foo</emu-nt>.</li></ol></emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-fenced-effects" type="abstract operation" aoid="FencedEffects">
   <h1><span class="secnum">22</span> FencedEffects ( )</h1>
   <p>The abstract operation FencedEffects takes no arguments. Effects don't propagate past fences in parent steps. A fence must be at the beginning of a step. It performs the following steps when called:</p>
-  <emu-alg><ol><li fence-effects="user-code">Fence.<ol><li><emu-xref aoid="UserCode" id="_ref_20"><a href="#sec-user-code" class="e-user-code">UserCode</a></emu-xref>().</li><li>Let <var>foo</var> be the result of <span class="e-user-code">evaluating <var>someUserCode</var></span>.</li></ol></li></ol></emu-alg>
+  <emu-alg><ol><li fence-effects="user-code">Fence.<ol><li><emu-xref aoid="UserCode" id="_ref_20"><a href="#sec-user-code" class="e-user-code">UserCode</a></emu-xref>().</li><li>Let <var>foo</var> be the result of evaluating <var>someUserCode</var>.</li></ol></li></ol></emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-call-fenced-effects" type="abstract operation" aoid="CallFencedEffects">

--- a/test/baselines/sources/effect-user-code.html
+++ b/test/baselines/sources/effect-user-code.html
@@ -230,7 +230,7 @@ markEffects: true
   <h1>ResultOfEvaluating()</h1>
   <dl class="header">
     <dt>description</dt>
-    <dd>The phrase "the result of evaluating Foo" is automatically considered as can call user code.</dd>
+    <dd>The phrase "the result of evaluating Foo" is not automatically considered as can call user code.</dd>
   </dl>
   <emu-alg>
     1. Let _res_ be the result of evaluating |Foo|.


### PR DESCRIPTION
Since we don't really use that as of https://github.com/tc39/ecma262/pull/2744, except for two occurrences in the [[Call]]/[[Construct]] semantics for built-in functions (which will need to be explicitly annotated - they can invoke user code transitively, so that is a true positive).

Also reverts https://github.com/tc39/ecmarkup/pull/393, since it was only necessitated by the html-transforming part of https://github.com/tc39/ecmarkup/pull/362, which this PR is removing.

Technically a breaking change.