### PR TITLE
rephrase algorithm lint rules in terms of parsed lines

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -9,6 +9,7 @@ import type {
 import type { Context } from './Context';
 import type { AlgorithmBiblioEntry, ExportedBiblio, StepBiblioEntry, Type } from './Biblio';
 import type { BuilderInterface } from './Builder';
+import type { AlgorithmElementWithTree } from './Algorithm';
 
 import * as path from 'path';
 import * as fs from 'fs';
@@ -45,7 +46,7 @@ import {
 import { lint } from './lint/lint';
 import { CancellationToken } from 'prex';
 import type { JSDOM } from 'jsdom';
-import type { OrderedListNode, parseAlgorithm } from 'ecmarkdown';
+import type { OrderedListNode } from 'ecmarkdown';
 import { getProductions, rhsMatches, getLocationInGrammarFile } from './lint/utils';
 import type { AugmentedGrammarEle } from './Grammar';
 import { offsetToLineAndColumn } from './utils';
@@ -611,13 +612,11 @@ export default class Spec {
       if (node.hasAttribute('example') || !('ecmarkdownTree' in node)) {
         continue;
       }
-      // @ts-ignore
-      const tree = node.ecmarkdownTree as ReturnType<typeof parseAlgorithm>;
+      const tree = (node as AlgorithmElementWithTree).ecmarkdownTree;
       if (tree == null) {
         continue;
       }
-      // @ts-ignore
-      const originalHtml: string = node.originalHtml;
+      const originalHtml = (node as AlgorithmElementWithTree).originalHtml;
 
       const expressionVisitor = (expr: Expr, path: PathItem[]) => {
         if (expr.type !== 'call' && expr.type !== 'sdo-call') {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -2098,7 +2098,7 @@ function parentSkippingBlankSpace(expr: Expr, path: PathItem[]): PathItem | null
       parent.type === 'seq' &&
       parent.items.every(
         i =>
-          (i.type === 'prose' &&
+          (i.type === 'fragment' &&
             i.parts.every(
               p => p.name === 'tag' || (p.name === 'text' && /^\s*$/.test(p.contents))
             )) ||
@@ -2127,7 +2127,7 @@ function previousText(expr: Expr, path: PathItem[]): string | null {
 
 function textFromPreviousPart(seq: Seq, index: number): string | null {
   const prev = seq.items[index - 1];
-  if (prev?.type === 'prose' && prev.parts.length > 0) {
+  if (prev?.type === 'fragment' && prev.parts.length > 0) {
     let prevIndex = prev.parts.length - 1;
     while (prevIndex > 0 && prev.parts[prevIndex].name === 'tag') {
       --prevIndex;

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -12,8 +12,14 @@ import lintAlgorithmStepLabels from './rules/algorithm-step-labels';
 import lintForEachElement from './rules/for-each-element';
 import lintStepAttributes from './rules/step-attributes';
 import { checkVariableUsage } from './rules/variable-use-def';
+import { parse, Seq } from '../expr-parser';
 
-type LineRule = (report: Reporter, step: OrderedListItemNode, algorithmSource: string) => void;
+type LineRule = (
+  report: Reporter,
+  stepSeq: Seq | null,
+  step: OrderedListItemNode,
+  algorithmSource: string
+) => void;
 const stepRules: LineRule[] = [
   lintAlgorithmLineStyle,
   lintAlgorithmStepNumbering,
@@ -63,7 +69,10 @@ export function collectAlgorithmDiagnostics(
       warnEmdFailure(report, element, e);
     }
     function walk(visit: LineRule, step: OrderedListItemNode) {
-      visit(reporter, step, algorithmSource); // TODO reconsider algorithmSource
+      // we don't know the names of ops at this point
+      // TODO maybe run later in the process? but not worth worrying about for now
+      const parsed = parse(step.contents, new Set());
+      visit(reporter, parsed.type === 'seq' ? parsed : null, step, algorithmSource); // TODO reconsider algorithmSource
       if (step.sublist?.name === 'ol') {
         for (const substep of step.sublist.contents) {
           walk(visit, substep);

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -1,6 +1,6 @@
 import type { default as Spec, Warning } from '../Spec';
 
-import type { Node as EcmarkdownNode } from 'ecmarkdown';
+import type { AlgorithmNode } from 'ecmarkdown';
 
 type CollectNodesReturnType =
   | {
@@ -9,7 +9,7 @@ type CollectNodesReturnType =
       mainGrammar: { element: Element; source: string }[];
       sdos: { grammar: Element; alg: Element }[];
       earlyErrors: { grammar: Element; lists: HTMLUListElement[] }[];
-      algorithms: { element: Element; tree?: EcmarkdownNode }[];
+      algorithms: { element: Element; tree?: AlgorithmNode }[];
     }
   | {
       success: false;
@@ -25,7 +25,7 @@ export function collectNodes(
   const mainGrammar: { element: Element; source: string }[] = [];
   const sdos: { grammar: Element; alg: Element }[] = [];
   const earlyErrors: { grammar: Element; lists: HTMLUListElement[] }[] = [];
-  const algorithms: { element: Element; tree?: EcmarkdownNode }[] = [];
+  const algorithms: { element: Element; tree?: AlgorithmNode }[] = [];
 
   let failed = false;
 

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -7,6 +7,7 @@ import { collectAlgorithmDiagnostics } from './collect-algorithm-diagnostics';
 import { collectHeaderDiagnostics } from './collect-header-diagnostics';
 import { collectTagDiagnostics } from './collect-tag-diagnostics';
 import type { AugmentedGrammarEle } from '../Grammar';
+import type { AlgorithmElementWithTree } from '../Algorithm';
 
 /*
 Currently this checks
@@ -83,10 +84,9 @@ export async function lint(
 
   for (const pair of algorithms) {
     if ('tree' in pair) {
-      // @ts-ignore we are intentionally adding a property here
-      pair.element.ecmarkdownTree = pair.tree;
-      // @ts-ignore we are intentionally adding a property here
-      pair.element.originalHtml = pair.element.innerHTML;
+      const element = pair.element as AlgorithmElementWithTree;
+      element.ecmarkdownTree = pair.tree ?? null;
+      element.originalHtml = pair.element.innerHTML;
     }
   }
 }

--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -1,6 +1,7 @@
 import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
 import type { Seq } from '../../expr-parser';
+import { offsetToLineAndColumn } from '../../utils';
 
 const ruleId = 'algorithm-line-style';
 
@@ -31,90 +32,25 @@ export default function (
   node: OrderedListItemNode,
   algorithmSource: string
 ) {
-  let firstIndex = 0;
-  let lastIndex = node.contents.length - 1;
-
-  // Special case: ignore <ins>, <del>, or <mark> tags that surround a whole
-  // line, and lint the enclosed line as if there were no tag.
-  let first = node.contents[firstIndex];
-  let last = node.contents[lastIndex];
-  while (
-    first.name === 'tag' &&
-    last.name === 'tag' &&
-    ((first.contents === '<mark>' && last.contents === '</mark>') ||
-      (first.contents === '<ins>' && last.contents === '</ins>') ||
-      (first.contents === '<del>' && last.contents === '</del>'))
-  ) {
-    ++firstIndex;
-    --lastIndex;
-    first = node.contents[firstIndex];
-    last = node.contents[lastIndex];
-  }
-
-  while (firstIndex <= lastIndex && node.contents[firstIndex].name === 'tag') {
-    ++firstIndex;
-  }
-  if (firstIndex > lastIndex) {
-    report({
-      ruleId,
-      line: node.location.start.line,
-      column: node.location.start.column,
-      message: 'expected line to contain non-tag elements',
-    });
+  if (stepSeq == null || stepSeq.items.length === 0) {
     return;
   }
-  first = node.contents[firstIndex];
-  last = node.contents[lastIndex];
+  function locate(offset: number) {
+    return offsetToLineAndColumn(algorithmSource, offset);
+  }
 
-  // Special case: if the step has a figure, it should end in `:`
-  if (last.name === 'tag' && last.contents === '</figure>') {
-    let count = 1;
-    --lastIndex;
-    if (lastIndex < 0) {
+  let last = stepSeq.items[stepSeq.items.length - 1];
+
+  // If the step has a figure, it should end in `:`
+  if (last.type === 'figure') {
+    last = stepSeq.items[stepSeq.items.length - 2];
+    if (
+      !(last.type === 'fragment' && last.frag.name === 'text' && /:\n +$/.test(last.frag.contents))
+    ) {
       report({
         ruleId,
-        line: node.contents[0].location.start.line,
-        column: node.contents[0].location.start.column,
-        message: 'could not find matching <figure> tag',
-      });
-      return;
-    }
-    while (count > 0) {
-      last = node.contents[lastIndex];
-      if (last.name === 'tag') {
-        if (last.contents === '<figure>') {
-          --count;
-        } else if (last.contents === '</figure>') {
-          ++count;
-        }
-      }
-      --lastIndex;
-      if (lastIndex < 0) {
-        report({
-          ruleId,
-          line: node.contents[0].location.start.line,
-          column: node.contents[0].location.start.column,
-          message: 'could not find matching <figure> tag',
-        });
-        return;
-      }
-    }
-    last = node.contents[lastIndex];
-    if (last.name !== 'text') {
-      report({
-        ruleId,
-        line: last.location.start.line,
-        column: last.location.start.column,
-        message: `expected line to end with text (found ${last.name})`,
-      });
-      return;
-    }
-    if (!/:\n +$/.test(last.contents)) {
-      report({
-        ruleId,
-        line: last.location.end.line,
-        column: last.location.end.column,
         message: 'expected line with figure to end with ":"',
+        ...locate(last.end),
       });
     }
     return;
@@ -122,43 +58,20 @@ export default function (
 
   const hasSubsteps = node.sublist !== null;
 
-  // Special case: only lines without substeps can end in `pre` tags.
-  if (last.name === 'opaqueTag' && /^\s*<pre>/.test(last.contents)) {
-    if (hasSubsteps) {
-      report({
-        ruleId,
-        line: node.contents[0].location.start.line,
-        column: node.contents[0].location.start.column,
-        message: `lines ending in <pre> tags must not have substeps`,
-      });
-    }
-    return;
-  }
-
-  if (last.name !== 'text') {
-    report({
-      ruleId,
-      line: last.location.start.line,
-      column: last.location.start.column,
-      message: `expected line to end with text (found ${last.name})`,
-    });
-    return;
-  }
-
-  const initialText = first.name === 'text' ? first.contents : '';
+  const first = stepSeq.items[0];
+  const initialText =
+    first.type === 'fragment' && first.frag.name === 'text' ? first.frag.contents : '';
+  const finalText = last.type === 'fragment' && last.frag.name === 'text' ? last.frag.contents : '';
 
   if (/^(?:If |Else if)/.test(initialText)) {
     if (hasSubsteps) {
       if (node.sublist!.name === 'ol') {
-        const end = last.contents.match(/[,;] then$/);
+        const end = finalText.match(/[,;] then$/);
         if (!end) {
           report({
             ruleId,
-            line: last.location.end.line,
-            column: last.location.end.column,
-            message: `expected "If" with substeps to end with ", then" (found ${JSON.stringify(
-              last.contents
-            )})`,
+            message: `expected "If" with substeps to end with ", then"`,
+            ...locate(last.end),
           });
         } else if (
           end[0][0] === ';' &&
@@ -166,45 +79,34 @@ export default function (
         ) {
           report({
             ruleId,
-            line: last.location.end.line,
-            column: last.location.end.column - 6,
             message: `expected "If" with substeps to end with ", then" rather than "; then" when there are no other commas`,
+            ...locate(last.end - 6),
           });
         }
       } else {
-        if (!/:$/.test(last.contents)) {
+        if (!/:$/.test(finalText)) {
           report({
             ruleId,
-            line: last.location.end.line,
-            column: last.location.end.column,
-            message: `expected "If" with list to end with ":" (found ${JSON.stringify(
-              last.contents
-            )})`,
+            message: `expected "If" with list to end with ":"`,
+            ...locate(last.end),
           });
         }
       }
     } else {
-      const lineSource = algorithmSource.slice(
-        first.location.start.offset,
-        last.location.end.offset
-      );
+      const lineSource = algorithmSource.slice(first.start, last.end);
       const ifThenMatch = lineSource.match(/^If[^,\n]+, then /);
       if (ifThenMatch != null) {
         report({
           ruleId,
-          line: first.location.start.line,
-          column: first.location.start.column + ifThenMatch[0].length - 5,
           message: `single-line "If" steps should not have a "then"`,
+          ...locate(first.start + ifThenMatch[0].length - 5),
         });
       }
-      if (!/(?:\.|\.\)|:)$/.test(last.contents)) {
+      if (!/(?:\.|\.\)|:)$/.test(finalText)) {
         report({
           ruleId,
-          line: last.location.end.line,
-          column: last.location.end.column,
-          message: `expected "If" without substeps to end with "." or ":" (found ${JSON.stringify(
-            last.contents
-          )})`,
+          message: `expected "If" without substeps to end with "." or ":"`,
+          ...locate(last.end),
         });
       }
     }
@@ -212,38 +114,31 @@ export default function (
     if (/^Else, if/.test(initialText)) {
       report({
         ruleId,
-        line: first.location.start.line,
-        column: first.location.start.column + 4, // "Else".length === 4
         message: `prefer "Else if" over "Else, if"`,
+        ...locate(first.start + 4),
       });
     }
     if (hasSubsteps) {
-      if (node.contents.length === 1 && first.contents === 'Else,') {
+      if (stepSeq.items.length === 1 && initialText === 'Else,') {
         return;
       }
-      if (!/,$/.test(last.contents)) {
+      if (!/,$/.test(finalText)) {
         report({
           ruleId,
-          line: last.location.end.line,
-          column: last.location.end.column,
-          message: `expected "Else" with substeps to end with "," (found ${JSON.stringify(
-            last.contents
-          )})`,
+          message: `expected "Else" with substeps to end with ","`,
+          ...locate(last.end),
         });
       }
     } else {
-      if (!/(?:\.|\.\)|:)$/.test(last.contents)) {
+      if (!/(?:\.|\.\)|:)$/.test(finalText)) {
         report({
           ruleId,
-          line: last.location.end.line,
-          column: last.location.end.column,
-          message: `expected "Else" without substeps to end with "." or ":" (found ${JSON.stringify(
-            last.contents
-          )})`,
+          message: `expected "Else" without substeps to end with "." or ":"`,
+          ...locate(last.end),
         });
       }
     }
-  } else if (/^Repeat/.test(initialText)) {
+  } else if (/^Repeat\b/.test(initialText)) {
     if (!hasSubsteps) {
       report({
         ruleId,
@@ -252,48 +147,38 @@ export default function (
         message: 'expected "Repeat" to have substeps',
       });
     }
-    if (node.contents.length === 1 && first.contents === 'Repeat,') {
+    if (stepSeq.items.length === 1 && initialText === 'Repeat,') {
       return;
     }
     if (!/^Repeat, (?:while|until) /.test(initialText)) {
       report({
         ruleId,
-        line: node.contents[0].location.start.line,
-        column: node.contents[0].location.start.column,
-        message: `expected "Repeat" to start with "Repeat, while " or "Repeat, until " (found ${JSON.stringify(
-          initialText
-        )})`,
+        message: `expected "Repeat" to start with "Repeat, while " or "Repeat, until "`,
+        ...locate(first.start),
       });
     }
-    if (!/,$/.test(last.contents)) {
+    if (!/,$/.test(finalText)) {
       report({
         ruleId,
-        line: last.location.end.line,
-        column: last.location.end.column,
         message: 'expected "Repeat" to end with ","',
+        ...locate(last.end),
       });
     }
   } else if (/^For each/.test(initialText)) {
     if (hasSubsteps) {
-      if (!/, do$/.test(last.contents)) {
+      if (!/, do$/.test(finalText)) {
         report({
           ruleId,
-          line: last.location.end.line,
-          column: last.location.end.column,
-          message: `expected "For each" with substeps to end with ", do" (found ${JSON.stringify(
-            last.contents
-          )})`,
+          message: `expected "For each" with substeps to end with ", do"`,
+          ...locate(last.end),
         });
       }
     } else {
-      if (!/(?:\.|\.\))$/.test(last.contents)) {
+      if (!/(?:\.|\.\))$/.test(finalText)) {
         report({
           ruleId,
-          line: last.location.end.line,
-          column: last.location.end.column,
-          message: `expected "For each" without substeps to end with "." (found ${JSON.stringify(
-            last.contents
-          )})`,
+          message: `expected "For each" without substeps to end with "."`,
+          ...locate(last.end),
         });
       }
     }
@@ -303,46 +188,44 @@ export default function (
       const kind = initialText.match(/^(NOTE|Assert)/)![1];
       report({
         ruleId,
-        line: first.location.start.line,
-        column: first.location.start.column + kind.length + 2,
         message: `the clause after "${kind}:" should begin with a capital letter`,
+        ...locate(first.start + kind.length + 2),
       });
     }
     if (/^NOTE:/i.test(initialText) && !/^NOTE:/.test(initialText)) {
       report({
         ruleId,
-        line: first.location.start.line,
-        column: first.location.start.column,
         message: `"NOTE:" should be fully capitalized`,
+        ...locate(first.start),
       });
     }
     if (/^Assert:/i.test(initialText) && !/^Assert:/.test(initialText)) {
       report({
         ruleId,
-        line: first.location.start.line,
-        column: first.location.start.column,
         message: `"Assert:" should be capitalized`,
+        ...locate(first.start),
       });
     }
     if (hasSubsteps) {
-      if (!/:$/.test(last.contents)) {
+      if (!/:$/.test(finalText)) {
         report({
           ruleId,
-          line: last.location.end.line,
-          column: last.location.end.column,
-          message: `expected freeform line with substeps to end with ":" (found ${JSON.stringify(
-            last.contents
-          )})`,
+          message: `expected freeform line with substeps to end with ":"`,
+          ...locate(last.end),
         });
       }
-    } else if (!/(?:\.|\.\))$/.test(last.contents)) {
+    } else if (!/(?:\.|\.\))$/.test(finalText)) {
+      if (last.type === 'paren' && last.items.length > 0) {
+        const lastItem = last.items[last.items.length - 1];
+        if (lastItem.type === 'fragment' && lastItem.frag.name === 'text') {
+          return;
+        }
+      }
       report({
         ruleId,
-        line: last.location.end.line,
-        column: last.location.end.column,
-        message: `expected freeform line to end with "." (found ${JSON.stringify(last.contents)})`,
+        message: `expected freeform line to end with "."`,
+        ...locate(last.end),
       });
     }
   }
-  return;
 }

--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -1,4 +1,4 @@
-import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
 
 const ruleId = 'algorithm-line-style';
@@ -24,332 +24,319 @@ Checks that every algorithm step has one of these forms:
 - `Other.`
 - `Other:` + substeps
 */
-export default function (report: Reporter, node: Element, algorithmSource: string): Observer {
-  if (node.hasAttribute('example')) {
-    return {};
+export default function (report: Reporter, node: OrderedListItemNode, algorithmSource: string) {
+  let firstIndex = 0;
+  let lastIndex = node.contents.length - 1;
+
+  // Special case: ignore <ins>, <del>, or <mark> tags that surround a whole
+  // line, and lint the enclosed line as if there were no tag.
+  let first = node.contents[firstIndex];
+  let last = node.contents[lastIndex];
+  while (
+    first.name === 'tag' &&
+    last.name === 'tag' &&
+    ((first.contents === '<mark>' && last.contents === '</mark>') ||
+      (first.contents === '<ins>' && last.contents === '</ins>') ||
+      (first.contents === '<del>' && last.contents === '</del>'))
+  ) {
+    ++firstIndex;
+    --lastIndex;
+    first = node.contents[firstIndex];
+    last = node.contents[lastIndex];
   }
-  return {
-    enter(node: EcmarkdownNode) {
-      if (node.name !== 'ordered-list-item') {
-        return;
-      }
 
-      let firstIndex = 0;
-      let lastIndex = node.contents.length - 1;
+  while (firstIndex <= lastIndex && node.contents[firstIndex].name === 'tag') {
+    ++firstIndex;
+  }
+  if (firstIndex > lastIndex) {
+    report({
+      ruleId,
+      line: node.location.start.line,
+      column: node.location.start.column,
+      message: 'expected line to contain non-tag elements',
+    });
+    return;
+  }
+  first = node.contents[firstIndex];
+  last = node.contents[lastIndex];
 
-      // Special case: ignore <ins>, <del>, or <mark> tags that surround a whole
-      // line, and lint the enclosed line as if there were no tag.
-      let first = node.contents[firstIndex];
-      let last = node.contents[lastIndex];
-      while (
-        first.name === 'tag' &&
-        last.name === 'tag' &&
-        ((first.contents === '<mark>' && last.contents === '</mark>') ||
-          (first.contents === '<ins>' && last.contents === '</ins>') ||
-          (first.contents === '<del>' && last.contents === '</del>'))
-      ) {
-        ++firstIndex;
-        --lastIndex;
-        first = node.contents[firstIndex];
-        last = node.contents[lastIndex];
+  // Special case: if the step has a figure, it should end in `:`
+  if (last.name === 'tag' && last.contents === '</figure>') {
+    let count = 1;
+    --lastIndex;
+    if (lastIndex < 0) {
+      report({
+        ruleId,
+        line: node.contents[0].location.start.line,
+        column: node.contents[0].location.start.column,
+        message: 'could not find matching <figure> tag',
+      });
+      return;
+    }
+    while (count > 0) {
+      last = node.contents[lastIndex];
+      if (last.name === 'tag') {
+        if (last.contents === '<figure>') {
+          --count;
+        } else if (last.contents === '</figure>') {
+          ++count;
+        }
       }
-
-      while (firstIndex <= lastIndex && node.contents[firstIndex].name === 'tag') {
-        ++firstIndex;
-      }
-      if (firstIndex > lastIndex) {
+      --lastIndex;
+      if (lastIndex < 0) {
         report({
           ruleId,
-          line: node.location.start.line,
-          column: node.location.start.column,
-          message: 'expected line to contain non-tag elements',
+          line: node.contents[0].location.start.line,
+          column: node.contents[0].location.start.column,
+          message: 'could not find matching <figure> tag',
         });
         return;
       }
-      first = node.contents[firstIndex];
-      last = node.contents[lastIndex];
+    }
+    last = node.contents[lastIndex];
+    if (last.name !== 'text') {
+      report({
+        ruleId,
+        line: last.location.start.line,
+        column: last.location.start.column,
+        message: `expected line to end with text (found ${last.name})`,
+      });
+      return;
+    }
+    if (!/:\n +$/.test(last.contents)) {
+      report({
+        ruleId,
+        line: last.location.end.line,
+        column: last.location.end.column,
+        message: 'expected line with figure to end with ":"',
+      });
+    }
+    return;
+  }
 
-      // Special case: if the step has a figure, it should end in `:`
-      if (last.name === 'tag' && last.contents === '</figure>') {
-        let count = 1;
-        --lastIndex;
-        if (lastIndex < 0) {
-          report({
-            ruleId,
-            line: node.contents[0].location.start.line,
-            column: node.contents[0].location.start.column,
-            message: 'could not find matching <figure> tag',
-          });
-          return;
-        }
-        while (count > 0) {
-          last = node.contents[lastIndex];
-          if (last.name === 'tag') {
-            if (last.contents === '<figure>') {
-              --count;
-            } else if (last.contents === '</figure>') {
-              ++count;
-            }
-          }
-          --lastIndex;
-          if (lastIndex < 0) {
-            report({
-              ruleId,
-              line: node.contents[0].location.start.line,
-              column: node.contents[0].location.start.column,
-              message: 'could not find matching <figure> tag',
-            });
-            return;
-          }
-        }
-        last = node.contents[lastIndex];
-        if (last.name !== 'text') {
-          report({
-            ruleId,
-            line: last.location.start.line,
-            column: last.location.start.column,
-            message: `expected line to end with text (found ${last.name})`,
-          });
-          return;
-        }
-        if (!/:\n +$/.test(last.contents)) {
+  const hasSubsteps = node.sublist !== null;
+
+  // Special case: only lines without substeps can end in `pre` tags.
+  if (last.name === 'opaqueTag' && /^\s*<pre>/.test(last.contents)) {
+    if (hasSubsteps) {
+      report({
+        ruleId,
+        line: node.contents[0].location.start.line,
+        column: node.contents[0].location.start.column,
+        message: `lines ending in <pre> tags must not have substeps`,
+      });
+    }
+    return;
+  }
+
+  if (last.name !== 'text') {
+    report({
+      ruleId,
+      line: last.location.start.line,
+      column: last.location.start.column,
+      message: `expected line to end with text (found ${last.name})`,
+    });
+    return;
+  }
+
+  const initialText = first.name === 'text' ? first.contents : '';
+
+  if (/^(?:If |Else if)/.test(initialText)) {
+    if (hasSubsteps) {
+      if (node.sublist!.name === 'ol') {
+        const end = last.contents.match(/[,;] then$/);
+        if (!end) {
           report({
             ruleId,
             line: last.location.end.line,
             column: last.location.end.column,
-            message: 'expected line with figure to end with ":"',
-          });
-        }
-        return;
-      }
-
-      const hasSubsteps = node.sublist !== null;
-
-      // Special case: only lines without substeps can end in `pre` tags.
-      if (last.name === 'opaqueTag' && /^\s*<pre>/.test(last.contents)) {
-        if (hasSubsteps) {
-          report({
-            ruleId,
-            line: node.contents[0].location.start.line,
-            column: node.contents[0].location.start.column,
-            message: `lines ending in <pre> tags must not have substeps`,
-          });
-        }
-        return;
-      }
-
-      if (last.name !== 'text') {
-        report({
-          ruleId,
-          line: last.location.start.line,
-          column: last.location.start.column,
-          message: `expected line to end with text (found ${last.name})`,
-        });
-        return;
-      }
-
-      const initialText = first.name === 'text' ? first.contents : '';
-
-      if (/^(?:If |Else if)/.test(initialText)) {
-        if (hasSubsteps) {
-          if (node.sublist!.name === 'ol') {
-            const end = last.contents.match(/[,;] then$/);
-            if (!end) {
-              report({
-                ruleId,
-                line: last.location.end.line,
-                column: last.location.end.column,
-                message: `expected "If" with substeps to end with ", then" (found ${JSON.stringify(
-                  last.contents
-                )})`,
-              });
-            } else if (
-              end[0][0] === ';' &&
-              !node.contents.some(c => c.name === 'text' && /,/.test(c.contents))
-            ) {
-              report({
-                ruleId,
-                line: last.location.end.line,
-                column: last.location.end.column - 6,
-                message: `expected "If" with substeps to end with ", then" rather than "; then" when there are no other commas`,
-              });
-            }
-          } else {
-            if (!/:$/.test(last.contents)) {
-              report({
-                ruleId,
-                line: last.location.end.line,
-                column: last.location.end.column,
-                message: `expected "If" with list to end with ":" (found ${JSON.stringify(
-                  last.contents
-                )})`,
-              });
-            }
-          }
-        } else {
-          const lineSource = algorithmSource.slice(
-            first.location.start.offset,
-            last.location.end.offset
-          );
-          const ifThenMatch = lineSource.match(/^If[^,\n]+, then /);
-          if (ifThenMatch != null) {
-            report({
-              ruleId,
-              line: first.location.start.line,
-              column: first.location.start.column + ifThenMatch[0].length - 5,
-              message: `single-line "If" steps should not have a "then"`,
-            });
-          }
-          if (!/(?:\.|\.\)|:)$/.test(last.contents)) {
-            report({
-              ruleId,
-              line: last.location.end.line,
-              column: last.location.end.column,
-              message: `expected "If" without substeps to end with "." or ":" (found ${JSON.stringify(
-                last.contents
-              )})`,
-            });
-          }
-        }
-      } else if (/^Else/.test(initialText)) {
-        if (/^Else, if/.test(initialText)) {
-          report({
-            ruleId,
-            line: first.location.start.line,
-            column: first.location.start.column + 4, // "Else".length === 4
-            message: `prefer "Else if" over "Else, if"`,
-          });
-        }
-        if (hasSubsteps) {
-          if (node.contents.length === 1 && first.contents === 'Else,') {
-            return;
-          }
-          if (!/,$/.test(last.contents)) {
-            report({
-              ruleId,
-              line: last.location.end.line,
-              column: last.location.end.column,
-              message: `expected "Else" with substeps to end with "," (found ${JSON.stringify(
-                last.contents
-              )})`,
-            });
-          }
-        } else {
-          if (!/(?:\.|\.\)|:)$/.test(last.contents)) {
-            report({
-              ruleId,
-              line: last.location.end.line,
-              column: last.location.end.column,
-              message: `expected "Else" without substeps to end with "." or ":" (found ${JSON.stringify(
-                last.contents
-              )})`,
-            });
-          }
-        }
-      } else if (/^Repeat/.test(initialText)) {
-        if (!hasSubsteps) {
-          report({
-            ruleId,
-            line: node.contents[0].location.start.line,
-            column: node.contents[0].location.start.column,
-            message: 'expected "Repeat" to have substeps',
-          });
-        }
-        if (node.contents.length === 1 && first.contents === 'Repeat,') {
-          return;
-        }
-        if (!/^Repeat, (?:while|until) /.test(initialText)) {
-          report({
-            ruleId,
-            line: node.contents[0].location.start.line,
-            column: node.contents[0].location.start.column,
-            message: `expected "Repeat" to start with "Repeat, while " or "Repeat, until " (found ${JSON.stringify(
-              initialText
+            message: `expected "If" with substeps to end with ", then" (found ${JSON.stringify(
+              last.contents
             )})`,
           });
-        }
-        if (!/,$/.test(last.contents)) {
+        } else if (
+          end[0][0] === ';' &&
+          !node.contents.some(c => c.name === 'text' && /,/.test(c.contents))
+        ) {
           report({
             ruleId,
             line: last.location.end.line,
-            column: last.location.end.column,
-            message: 'expected "Repeat" to end with ","',
+            column: last.location.end.column - 6,
+            message: `expected "If" with substeps to end with ", then" rather than "; then" when there are no other commas`,
           });
-        }
-      } else if (/^For each/.test(initialText)) {
-        if (hasSubsteps) {
-          if (!/, do$/.test(last.contents)) {
-            report({
-              ruleId,
-              line: last.location.end.line,
-              column: last.location.end.column,
-              message: `expected "For each" with substeps to end with ", do" (found ${JSON.stringify(
-                last.contents
-              )})`,
-            });
-          }
-        } else {
-          if (!/(?:\.|\.\))$/.test(last.contents)) {
-            report({
-              ruleId,
-              line: last.location.end.line,
-              column: last.location.end.column,
-              message: `expected "For each" without substeps to end with "." (found ${JSON.stringify(
-                last.contents
-              )})`,
-            });
-          }
         }
       } else {
-        // these are not else-ifs because we still want to enforce the line-ending rules
-        if (/^(NOTE|Assert): [a-z]/.test(initialText)) {
-          const kind = initialText.match(/^(NOTE|Assert)/)![1];
-          report({
-            ruleId,
-            line: first.location.start.line,
-            column: first.location.start.column + kind.length + 2,
-            message: `the clause after "${kind}:" should begin with a capital letter`,
-          });
-        }
-        if (/^NOTE:/i.test(initialText) && !/^NOTE:/.test(initialText)) {
-          report({
-            ruleId,
-            line: first.location.start.line,
-            column: first.location.start.column,
-            message: `"NOTE:" should be fully capitalized`,
-          });
-        }
-        if (/^Assert:/i.test(initialText) && !/^Assert:/.test(initialText)) {
-          report({
-            ruleId,
-            line: first.location.start.line,
-            column: first.location.start.column,
-            message: `"Assert:" should be capitalized`,
-          });
-        }
-        if (hasSubsteps) {
-          if (!/:$/.test(last.contents)) {
-            report({
-              ruleId,
-              line: last.location.end.line,
-              column: last.location.end.column,
-              message: `expected freeform line with substeps to end with ":" (found ${JSON.stringify(
-                last.contents
-              )})`,
-            });
-          }
-        } else if (!/(?:\.|\.\))$/.test(last.contents)) {
+        if (!/:$/.test(last.contents)) {
           report({
             ruleId,
             line: last.location.end.line,
             column: last.location.end.column,
-            message: `expected freeform line to end with "." (found ${JSON.stringify(
+            message: `expected "If" with list to end with ":" (found ${JSON.stringify(
               last.contents
             )})`,
           });
         }
       }
+    } else {
+      const lineSource = algorithmSource.slice(
+        first.location.start.offset,
+        last.location.end.offset
+      );
+      const ifThenMatch = lineSource.match(/^If[^,\n]+, then /);
+      if (ifThenMatch != null) {
+        report({
+          ruleId,
+          line: first.location.start.line,
+          column: first.location.start.column + ifThenMatch[0].length - 5,
+          message: `single-line "If" steps should not have a "then"`,
+        });
+      }
+      if (!/(?:\.|\.\)|:)$/.test(last.contents)) {
+        report({
+          ruleId,
+          line: last.location.end.line,
+          column: last.location.end.column,
+          message: `expected "If" without substeps to end with "." or ":" (found ${JSON.stringify(
+            last.contents
+          )})`,
+        });
+      }
+    }
+  } else if (/^Else/.test(initialText)) {
+    if (/^Else, if/.test(initialText)) {
+      report({
+        ruleId,
+        line: first.location.start.line,
+        column: first.location.start.column + 4, // "Else".length === 4
+        message: `prefer "Else if" over "Else, if"`,
+      });
+    }
+    if (hasSubsteps) {
+      if (node.contents.length === 1 && first.contents === 'Else,') {
+        return;
+      }
+      if (!/,$/.test(last.contents)) {
+        report({
+          ruleId,
+          line: last.location.end.line,
+          column: last.location.end.column,
+          message: `expected "Else" with substeps to end with "," (found ${JSON.stringify(
+            last.contents
+          )})`,
+        });
+      }
+    } else {
+      if (!/(?:\.|\.\)|:)$/.test(last.contents)) {
+        report({
+          ruleId,
+          line: last.location.end.line,
+          column: last.location.end.column,
+          message: `expected "Else" without substeps to end with "." or ":" (found ${JSON.stringify(
+            last.contents
+          )})`,
+        });
+      }
+    }
+  } else if (/^Repeat/.test(initialText)) {
+    if (!hasSubsteps) {
+      report({
+        ruleId,
+        line: node.contents[0].location.start.line,
+        column: node.contents[0].location.start.column,
+        message: 'expected "Repeat" to have substeps',
+      });
+    }
+    if (node.contents.length === 1 && first.contents === 'Repeat,') {
       return;
-    },
-  };
+    }
+    if (!/^Repeat, (?:while|until) /.test(initialText)) {
+      report({
+        ruleId,
+        line: node.contents[0].location.start.line,
+        column: node.contents[0].location.start.column,
+        message: `expected "Repeat" to start with "Repeat, while " or "Repeat, until " (found ${JSON.stringify(
+          initialText
+        )})`,
+      });
+    }
+    if (!/,$/.test(last.contents)) {
+      report({
+        ruleId,
+        line: last.location.end.line,
+        column: last.location.end.column,
+        message: 'expected "Repeat" to end with ","',
+      });
+    }
+  } else if (/^For each/.test(initialText)) {
+    if (hasSubsteps) {
+      if (!/, do$/.test(last.contents)) {
+        report({
+          ruleId,
+          line: last.location.end.line,
+          column: last.location.end.column,
+          message: `expected "For each" with substeps to end with ", do" (found ${JSON.stringify(
+            last.contents
+          )})`,
+        });
+      }
+    } else {
+      if (!/(?:\.|\.\))$/.test(last.contents)) {
+        report({
+          ruleId,
+          line: last.location.end.line,
+          column: last.location.end.column,
+          message: `expected "For each" without substeps to end with "." (found ${JSON.stringify(
+            last.contents
+          )})`,
+        });
+      }
+    }
+  } else {
+    // these are not else-ifs because we still want to enforce the line-ending rules
+    if (/^(NOTE|Assert): [a-z]/.test(initialText)) {
+      const kind = initialText.match(/^(NOTE|Assert)/)![1];
+      report({
+        ruleId,
+        line: first.location.start.line,
+        column: first.location.start.column + kind.length + 2,
+        message: `the clause after "${kind}:" should begin with a capital letter`,
+      });
+    }
+    if (/^NOTE:/i.test(initialText) && !/^NOTE:/.test(initialText)) {
+      report({
+        ruleId,
+        line: first.location.start.line,
+        column: first.location.start.column,
+        message: `"NOTE:" should be fully capitalized`,
+      });
+    }
+    if (/^Assert:/i.test(initialText) && !/^Assert:/.test(initialText)) {
+      report({
+        ruleId,
+        line: first.location.start.line,
+        column: first.location.start.column,
+        message: `"Assert:" should be capitalized`,
+      });
+    }
+    if (hasSubsteps) {
+      if (!/:$/.test(last.contents)) {
+        report({
+          ruleId,
+          line: last.location.end.line,
+          column: last.location.end.column,
+          message: `expected freeform line with substeps to end with ":" (found ${JSON.stringify(
+            last.contents
+          )})`,
+        });
+      }
+    } else if (!/(?:\.|\.\))$/.test(last.contents)) {
+      report({
+        ruleId,
+        line: last.location.end.line,
+        column: last.location.end.column,
+        message: `expected freeform line to end with "." (found ${JSON.stringify(last.contents)})`,
+      });
+    }
+  }
+  return;
 }

--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -1,5 +1,6 @@
 import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
+import type { Seq } from '../../expr-parser';
 
 const ruleId = 'algorithm-line-style';
 
@@ -24,7 +25,12 @@ Checks that every algorithm step has one of these forms:
 - `Other.`
 - `Other:` + substeps
 */
-export default function (report: Reporter, node: OrderedListItemNode, algorithmSource: string) {
+export default function (
+  report: Reporter,
+  stepSeq: Seq | null,
+  node: OrderedListItemNode,
+  algorithmSource: string
+) {
   let firstIndex = 0;
   let lastIndex = node.contents.length - 1;
 

--- a/src/lint/rules/algorithm-step-labels.ts
+++ b/src/lint/rules/algorithm-step-labels.ts
@@ -1,12 +1,18 @@
 import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
+import type { Seq } from '../../expr-parser';
 
 const ruleId = 'algorithm-step-labels';
 
 /*
 Checks that step labels all start with `step-`.
 */
-export default function (report: Reporter, node: OrderedListItemNode, algorithmSource: string) {
+export default function (
+  report: Reporter,
+  stepSeq: Seq | null,
+  node: OrderedListItemNode,
+  algorithmSource: string
+) {
   const idAttr = node.attrs.find(({ key }) => key === 'id');
   if (idAttr != null && !/^step-/.test(idAttr.value)) {
     const itemSource = algorithmSource.slice(

--- a/src/lint/rules/algorithm-step-labels.ts
+++ b/src/lint/rules/algorithm-step-labels.ts
@@ -1,4 +1,4 @@
-import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
 
 const ruleId = 'algorithm-step-labels';
@@ -6,26 +6,19 @@ const ruleId = 'algorithm-step-labels';
 /*
 Checks that step labels all start with `step-`.
 */
-export default function (report: Reporter, node: Element, algorithmSource: string): Observer {
-  return {
-    enter(node: EcmarkdownNode) {
-      if (node.name !== 'ordered-list-item') {
-        return;
-      }
-      const idAttr = node.attrs.find(({ key }) => key === 'id');
-      if (idAttr != null && !/^step-/.test(idAttr.value)) {
-        const itemSource = algorithmSource.slice(
-          idAttr.location.start.offset,
-          idAttr.location.end.offset
-        );
-        const offset = itemSource.match(/^id *= *"/)![0].length;
-        report({
-          ruleId,
-          line: idAttr.location.start.line,
-          column: idAttr.location.start.column + offset,
-          message: `step labels should start with "step-"`,
-        });
-      }
-    },
-  };
+export default function (report: Reporter, node: OrderedListItemNode, algorithmSource: string) {
+  const idAttr = node.attrs.find(({ key }) => key === 'id');
+  if (idAttr != null && !/^step-/.test(idAttr.value)) {
+    const itemSource = algorithmSource.slice(
+      idAttr.location.start.offset,
+      idAttr.location.end.offset
+    );
+    const offset = itemSource.match(/^id *= *"/)![0].length;
+    report({
+      ruleId,
+      line: idAttr.location.start.line,
+      column: idAttr.location.start.column + offset,
+      message: `step labels should start with "step-"`,
+    });
+  }
 }

--- a/src/lint/rules/algorithm-step-numbering.ts
+++ b/src/lint/rules/algorithm-step-numbering.ts
@@ -1,12 +1,18 @@
 import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
+import type { Seq } from '../../expr-parser';
 
 const ruleId = 'algorithm-step-numbering';
 
 /*
 Checks that step numbers are all `1`.
 */
-export default function (report: Reporter, node: OrderedListItemNode, algorithmSource: string) {
+export default function (
+  report: Reporter,
+  stepSeq: Seq | null,
+  node: OrderedListItemNode,
+  algorithmSource: string
+) {
   const itemSource = algorithmSource.slice(node.location.start.offset, node.location.end.offset);
   const match = itemSource.match(/^(\s*)(\d+\.) /)!;
   if (match[2] !== '1.') {

--- a/src/lint/rules/algorithm-step-numbering.ts
+++ b/src/lint/rules/algorithm-step-numbering.ts
@@ -1,4 +1,4 @@
-import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
 
 const ruleId = 'algorithm-step-numbering';
@@ -6,24 +6,15 @@ const ruleId = 'algorithm-step-numbering';
 /*
 Checks that step numbers are all `1`.
 */
-export default function (report: Reporter, node: Element, algorithmSource: string): Observer {
-  return {
-    enter(node: EcmarkdownNode) {
-      if (node.name === 'ordered-list-item') {
-        const itemSource = algorithmSource.slice(
-          node.location.start.offset,
-          node.location.end.offset
-        );
-        const match = itemSource.match(/^(\s*)(\d+\.) /)!;
-        if (match[2] !== '1.') {
-          report({
-            ruleId,
-            line: node.location.start.line,
-            column: node.location.start.column + match[1].length,
-            message: `expected step number to be "1." (found ${JSON.stringify(match[2])})`,
-          });
-        }
-      }
-    },
-  };
+export default function (report: Reporter, node: OrderedListItemNode, algorithmSource: string) {
+  const itemSource = algorithmSource.slice(node.location.start.offset, node.location.end.offset);
+  const match = itemSource.match(/^(\s*)(\d+\.) /)!;
+  if (match[2] !== '1.') {
+    report({
+      ruleId,
+      line: node.location.start.line,
+      column: node.location.start.column + match[1].length,
+      message: `expected step number to be "1." (found ${JSON.stringify(match[2])})`,
+    });
+  }
 }

--- a/src/lint/rules/for-each-element.ts
+++ b/src/lint/rules/for-each-element.ts
@@ -1,4 +1,4 @@
-import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
 
 const ruleId = 'for-each-element';
@@ -6,21 +6,17 @@ const ruleId = 'for-each-element';
 /*
 Checks that "For each" loops name a type or say "element" before the variable.
 */
-export default function (report: Reporter): Observer {
-  return {
-    enter(node: EcmarkdownNode) {
-      if (node.name !== 'ordered-list-item' || node.contents.length < 2) {
-        return;
-      }
-      const [first, second] = node.contents;
-      if (first.name === 'text' && first.contents === 'For each ' && second.name === 'underscore') {
-        report({
-          ruleId,
-          line: second.location.start.line,
-          column: second.location.start.column,
-          message: 'expected "for each" to have a type name or "element" before the loop variable',
-        });
-      }
-    },
-  };
+export default function (report: Reporter, node: OrderedListItemNode) {
+  if (node.contents.length < 2) {
+    return;
+  }
+  const [first, second] = node.contents;
+  if (first.name === 'text' && first.contents === 'For each ' && second.name === 'underscore') {
+    report({
+      ruleId,
+      line: second.location.start.line,
+      column: second.location.start.column,
+      message: 'expected "for each" to have a type name or "element" before the loop variable',
+    });
+  }
 }

--- a/src/lint/rules/for-each-element.ts
+++ b/src/lint/rules/for-each-element.ts
@@ -7,15 +7,21 @@ const ruleId = 'for-each-element';
 Checks that "For each" loops name a type or say "element" before the variable.
 */
 export default function (report: Reporter, stepSeq: Seq | null) {
-  if (stepSeq?.items[0]?.type !== 'fragment' || stepSeq.items[0].parts.length < 2) {
+  if (stepSeq == null || stepSeq.items.length < 2) {
     return;
   }
-  const [first, second] = stepSeq.items[0].parts;
-  if (first.name === 'text' && first.contents === 'For each ' && second.name === 'underscore') {
+  const [first, second] = stepSeq.items;
+  if (
+    first.type === 'fragment' &&
+    first.frag.name === 'text' &&
+    first.frag.contents === 'For each ' &&
+    second.type === 'fragment' &&
+    second.frag.name === 'underscore'
+  ) {
     report({
       ruleId,
-      line: second.location.start.line,
-      column: second.location.start.column,
+      line: second.frag.location.start.line,
+      column: second.frag.location.start.column,
       message: 'expected "for each" to have a type name or "element" before the loop variable',
     });
   }

--- a/src/lint/rules/for-each-element.ts
+++ b/src/lint/rules/for-each-element.ts
@@ -7,7 +7,7 @@ const ruleId = 'for-each-element';
 Checks that "For each" loops name a type or say "element" before the variable.
 */
 export default function (report: Reporter, stepSeq: Seq | null) {
-  if (stepSeq?.items[0]?.type !== 'prose' || stepSeq.items[0].parts.length < 2) {
+  if (stepSeq?.items[0]?.type !== 'fragment' || stepSeq.items[0].parts.length < 2) {
     return;
   }
   const [first, second] = stepSeq.items[0].parts;

--- a/src/lint/rules/for-each-element.ts
+++ b/src/lint/rules/for-each-element.ts
@@ -1,16 +1,16 @@
-import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
+import type { Seq } from '../../expr-parser';
 
 const ruleId = 'for-each-element';
 
 /*
 Checks that "For each" loops name a type or say "element" before the variable.
 */
-export default function (report: Reporter, node: OrderedListItemNode) {
-  if (node.contents.length < 2) {
+export default function (report: Reporter, stepSeq: Seq | null) {
+  if (stepSeq?.items[0]?.type !== 'prose' || stepSeq.items[0].parts.length < 2) {
     return;
   }
-  const [first, second] = node.contents;
+  const [first, second] = stepSeq.items[0].parts;
   if (first.name === 'text' && first.contents === 'For each ' && second.name === 'underscore') {
     report({
       ruleId,

--- a/src/lint/rules/step-attributes.ts
+++ b/src/lint/rules/step-attributes.ts
@@ -1,5 +1,6 @@
 import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
+import type { Seq } from '../../expr-parser';
 
 const ruleId = 'unknown-step-attribute';
 
@@ -8,7 +9,7 @@ const KNOWN_ATTRIBUTES = ['id', 'fence-effects', 'declared'];
 /*
 Checks for unknown attributes on steps.
 */
-export default function (report: Reporter, node: OrderedListItemNode) {
+export default function (report: Reporter, stepSeq: Seq | null, node: OrderedListItemNode) {
   for (const attr of node.attrs) {
     if (!KNOWN_ATTRIBUTES.includes(attr.key)) {
       report({

--- a/src/lint/rules/step-attributes.ts
+++ b/src/lint/rules/step-attributes.ts
@@ -1,4 +1,4 @@
-import type { Node as EcmarkdownNode, Observer } from 'ecmarkdown';
+import type { OrderedListItemNode } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
 
 const ruleId = 'unknown-step-attribute';
@@ -8,22 +8,15 @@ const KNOWN_ATTRIBUTES = ['id', 'fence-effects', 'declared'];
 /*
 Checks for unknown attributes on steps.
 */
-export default function (report: Reporter): Observer {
-  return {
-    enter(node: EcmarkdownNode) {
-      if (node.name !== 'ordered-list-item') {
-        return;
-      }
-      for (const attr of node.attrs) {
-        if (!KNOWN_ATTRIBUTES.includes(attr.key)) {
-          report({
-            ruleId,
-            message: `unknown step attribute ${JSON.stringify(attr.key)}`,
-            line: attr.location.start.line,
-            column: attr.location.start.column,
-          });
-        }
-      }
-    },
-  };
+export default function (report: Reporter, node: OrderedListItemNode) {
+  for (const attr of node.attrs) {
+    if (!KNOWN_ATTRIBUTES.includes(attr.key)) {
+      report({
+        ruleId,
+        message: `unknown step attribute ${JSON.stringify(attr.key)}`,
+        line: attr.location.start.line,
+        column: attr.location.start.column,
+      });
+    }
+  }
 }

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -16,7 +16,7 @@ describe('linting algorithms', () => {
         {
           ruleId,
           nodeType,
-          message: 'expected freeform line to end with "." (found "testing")',
+          message: 'expected freeform line to end with "."',
         }
       );
     });
@@ -29,7 +29,7 @@ describe('linting algorithms', () => {
         {
           ruleId,
           nodeType,
-          message: 'expected freeform line to end with "." (found "testing")',
+          message: 'expected freeform line to end with "."',
         }
       );
     });
@@ -38,7 +38,7 @@ describe('linting algorithms', () => {
       await assertLint(positioned`<emu-alg>1. testing${M}</emu-alg>`, {
         ruleId,
         nodeType,
-        message: 'expected freeform line to end with "." (found "testing")',
+        message: 'expected freeform line to end with "."',
       });
     });
 
@@ -66,7 +66,7 @@ describe('linting algorithms', () => {
         {
           ruleId,
           nodeType,
-          message: 'expected "If" without substeps to end with "." or ":" (found ", then")',
+          message: 'expected "If" without substeps to end with "." or ":"',
         }
       );
     });
@@ -95,7 +95,7 @@ describe('linting algorithms', () => {
         {
           ruleId,
           nodeType,
-          message: 'expected "If" with substeps to end with ", then" (found ",")',
+          message: 'expected "If" with substeps to end with ", then"',
         }
       );
 
@@ -159,7 +159,7 @@ describe('linting algorithms', () => {
         {
           ruleId,
           nodeType,
-          message: 'expected freeform line to end with "." (found "NOTE: Foo")',
+          message: 'expected freeform line to end with "."',
         }
       );
     });
@@ -194,23 +194,7 @@ describe('linting algorithms', () => {
         {
           ruleId,
           nodeType,
-          message: 'expected freeform line to end with "." (found "Assert: Foo")',
-        }
-      );
-    });
-
-    it('pre', async () => {
-      await assertLint(
-        positioned`<emu-alg>
-            1. ${M}Let _constructorText_ be the source text
-            <pre><code class="javascript">constructor() {}</code></pre>
-              1. Foo.
-            1. Use _constructorText_.
-        </emu-alg>`,
-        {
-          ruleId,
-          nodeType,
-          message: 'lines ending in <pre> tags must not have substeps',
+          message: 'expected freeform line to end with "."',
         }
       );
     });
@@ -219,7 +203,7 @@ describe('linting algorithms', () => {
       await assertLint(positioned`<emu-alg>1. <mark>testing${M}</mark></emu-alg>`, {
         ruleId,
         nodeType,
-        message: 'expected freeform line to end with "." (found "testing")',
+        message: 'expected freeform line to end with "."',
       });
     });
 
@@ -254,10 +238,10 @@ describe('linting algorithms', () => {
           1. Assert: The following algorithm returns *true*:
             1. Return *true*.
           1. Other.
+          1. Other. (But with an aside.)
           1. Other:
             1. Substep.
-          1. Let _constructorText_ be the source text
-          <pre><code class="javascript">constructor() {}</code></pre>
+          1. Let _constructorText_ be some text.
           1. Let _parse_ be a method.
           1. Let _constructor_ be a variable.
           1. Set _constructor_ to _parse_(_constructorText_).

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -199,12 +199,36 @@ describe('linting algorithms', () => {
       );
     });
 
-    it('rules still apply to ignored whole-line tags', async () => {
+    it('rules still apply when tags surround the line', async () => {
       await assertLint(positioned`<emu-alg>1. <mark>testing${M}</mark></emu-alg>`, {
         ruleId,
         nodeType,
         message: 'expected freeform line to end with "."',
       });
+    });
+
+    it('rules are aware of internal use of ins/del', async () => {
+      await assertLint(
+        positioned`<emu-alg>
+        1. <ins>If some condition, then</ins>
+          1. <ins>Do a thing.</ins>
+        1. <del>If</del><ins>Else if</ins> some other condition,${M}
+          1. Do a different thing.
+        </emu-alg>`,
+        {
+          ruleId,
+          nodeType,
+          message: 'expected "If" with substeps to end with ", then"',
+        }
+      );
+      await assertLintFree(`
+        <emu-alg>
+          1. <ins>If some condition, then</ins>
+            1. <ins>Do a thing.</ins>
+          1. <del>If</del><ins>Else if</ins> some other condition, then
+            1. Do a different thing.
+        </emu-alg>
+      `);
     });
 
     it('negative', async () => {

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -4,7 +4,7 @@ let { assertLint, assertLintFree, lintLocationMarker: M, positioned } = require(
 
 const nodeType = 'emu-alg';
 
-describe.only('linting algorithms', () => {
+describe('linting algorithms', () => {
   describe('line style', () => {
     const ruleId = 'algorithm-line-style';
 

--- a/test/lint-algorithms.js
+++ b/test/lint-algorithms.js
@@ -4,7 +4,7 @@ let { assertLint, assertLintFree, lintLocationMarker: M, positioned } = require(
 
 const nodeType = 'emu-alg';
 
-describe('linting algorithms', () => {
+describe.only('linting algorithms', () => {
   describe('line style', () => {
     const ruleId = 'algorithm-line-style';
 


### PR DESCRIPTION
The algorithm lint rules were written before the addition of the expression parser in #464.

The expression parser is smarter than the bare ecmarkdown parser, particularly around the handling of `<ins>`/`<del>` (specifically, it silently inlines the contents of `<ins>` and discards the contents of `<del>` [as of #494] so that you're linting against the intended spec text). By rewriting the algorithm lint rules in terms of the expression parser, we get correct handling of `<ins>`/`<del>` for free. That also lets us rip out some gross and incomplete logic for handling `<ins>`/`<del>` from `algorithm-line-style.ts`.

The expression parser wasn't surfacing location information, and had an annoying intermediate node type, so it needed to be tweaked too.