### PR TITLE
Preserve line breaks and white space in algorithm steps

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -149,6 +149,10 @@ emu-val {
   font-weight: bold;
 }
 
+emu-alg {
+  white-space: pre-wrap;
+}
+
 /* depth 1 */
 emu-alg ol,
 /* depth 4 */


### PR DESCRIPTION
Temporal makes extensive use of line breaks in defining large Records, but they end up collapsed in rendered documentation (for example, ParseTemporalInstantString [source](https://github.com/tc39/proposal-temporal/blob/dcdc47f4505e24292c4eab6541a785fe631162ed/spec/abstractops.html#L1340-L1351) vs. [result](https://tc39.es/proposal-temporal/#sec-temporal-parsetemporalinstantstring)). As noted in https://github.com/tc39/proposal-temporal/pull/2290#pullrequestreview-1012509000 , that hinders readability.

This PR updates the CSS to preserve line breaks and whitespace while preserving wrapping of long lines.