### PR TITLE
expr-parser: flatten prose even more

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -628,7 +628,7 @@ export default class Spec {
       const originalHtml = (node as AlgorithmElementWithTree).originalHtml;
 
       const expressionVisitor = (expr: Expr, path: PathItem[]) => {
-        if (expr.type !== 'call' && expr.type !== 'sdo-call') {
+        if (expr.name !== 'call' && expr.name !== 'sdo-call') {
           return;
         }
 
@@ -751,7 +751,7 @@ export default class Spec {
       const walkLines = (list: OrderedListNode) => {
         for (const line of list.contents) {
           const item = parseExpr(line.contents, opNames);
-          if (item.type === 'failure') {
+          if (item.name === 'failure') {
             const { line, column } = offsetToLineAndColumn(originalHtml, item.offset);
             this.warn({
               type: 'contents',
@@ -2104,11 +2104,11 @@ function parentSkippingBlankSpace(expr: Expr, path: PathItem[]): PathItem | null
   for (let pointer: Expr = expr, i = path.length - 1; i >= 0; pointer = path[i].parent, --i) {
     const { parent } = path[i];
     if (
-      parent.type === 'seq' &&
+      parent.name === 'seq' &&
       parent.items.every(
         i =>
           i === pointer ||
-          (i.type === 'fragment' &&
+          (i.name === 'fragment' &&
             (i.frag.name === 'tag' || (i.frag.name === 'text' && /^\s*$/.test(i.frag.contents))))
       )
     ) {
@@ -2126,7 +2126,7 @@ function previousText(expr: Expr, path: PathItem[]): string | null {
     return null;
   }
   const { parent, index } = part;
-  if (parent.type === 'seq') {
+  if (parent.name === 'seq') {
     return textFromPreviousPart(parent, index);
   }
   return null;
@@ -2135,7 +2135,7 @@ function previousText(expr: Expr, path: PathItem[]): string | null {
 function textFromPreviousPart(seq: Seq, index: number): string | null {
   let prevIndex = index - 1;
   let prev;
-  while ((prev = seq.items[prevIndex])?.type === 'fragment') {
+  while ((prev = seq.items[prevIndex])?.name === 'fragment') {
     if (prev.frag.name === 'text') {
       return prev.frag.contents;
     } else if (prev.frag.name === 'tag') {
@@ -2163,13 +2163,13 @@ function isConsumedAsCompletion(expr: Expr, path: PathItem[]) {
     return false;
   }
   const { parent, index } = part;
-  if (parent.type === 'seq') {
+  if (parent.name === 'seq') {
     // if the previous text ends in `! ` or `? `, this is a completion
     const text = textFromPreviousPart(parent, index);
     if (text != null && /[!?]\s$/.test(text)) {
       return true;
     }
-  } else if (parent.type === 'call' && index === 0 && parent.arguments.length === 1) {
+  } else if (parent.name === 'call' && index === 0 && parent.arguments.length === 1) {
     // if this is `Completion(Expr())`, this is a completion
     const parts = parent.callee;
     if (parts.length === 1 && parts[0].name === 'text' && parts[0].contents === 'Completion') {

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -72,7 +72,7 @@ export function collectAlgorithmDiagnostics(
       // we don't know the names of ops at this point
       // TODO maybe run later in the process? but not worth worrying about for now
       const parsed = parse(step.contents, new Set());
-      visit(reporter, parsed.type === 'seq' ? parsed : null, step, algorithmSource); // TODO reconsider algorithmSource
+      visit(reporter, parsed.name === 'seq' ? parsed : null, step, algorithmSource); // TODO reconsider algorithmSource
       if (step.sublist?.name === 'ol') {
         for (const substep of step.sublist.contents) {
           walk(visit, substep);

--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -44,9 +44,7 @@ export default function (
   // If the step has a figure, it should end in `:`
   if (last.name === 'figure') {
     last = stepSeq.items[stepSeq.items.length - 2];
-    if (
-      !(last.name === 'fragment' && last.frag.name === 'text' && /:\n +$/.test(last.frag.contents))
-    ) {
+    if (!(last.name === 'text' && /:\n +$/.test(last.contents))) {
       report({
         ruleId,
         message: 'expected line with figure to end with ":"',
@@ -59,9 +57,8 @@ export default function (
   const hasSubsteps = node.sublist !== null;
 
   const first = stepSeq.items[0];
-  const initialText =
-    first.name === 'fragment' && first.frag.name === 'text' ? first.frag.contents : '';
-  const finalText = last.name === 'fragment' && last.frag.name === 'text' ? last.frag.contents : '';
+  const initialText = first.name === 'text' ? first.contents : '';
+  const finalText = last.name === 'text' ? last.contents : '';
 
   if (/^(?:If |Else if)/.test(initialText)) {
     if (hasSubsteps) {
@@ -220,7 +217,7 @@ export default function (
     } else if (!/(?:\.|\.\))$/.test(finalText)) {
       if (last.name === 'paren' && last.items.length > 0) {
         const lastItem = last.items[last.items.length - 1];
-        if (lastItem.name === 'fragment' && lastItem.frag.name === 'text') {
+        if (lastItem.name === 'text') {
           return;
         }
       }

--- a/src/lint/rules/algorithm-line-style.ts
+++ b/src/lint/rules/algorithm-line-style.ts
@@ -50,7 +50,7 @@ export default function (
       report({
         ruleId,
         message: 'expected line with figure to end with ":"',
-        ...locate(last.end),
+        ...locate(last.location.end.offset),
       });
     }
     return;

--- a/src/lint/rules/for-each-element.ts
+++ b/src/lint/rules/for-each-element.ts
@@ -12,10 +12,10 @@ export default function (report: Reporter, stepSeq: Seq | null) {
   }
   const [first, second] = stepSeq.items;
   if (
-    first.type === 'fragment' &&
+    first.name === 'fragment' &&
     first.frag.name === 'text' &&
     first.frag.contents === 'For each ' &&
-    second.type === 'fragment' &&
+    second.name === 'fragment' &&
     second.frag.name === 'underscore'
   ) {
     report({

--- a/src/lint/rules/for-each-element.ts
+++ b/src/lint/rules/for-each-element.ts
@@ -11,17 +11,11 @@ export default function (report: Reporter, stepSeq: Seq | null) {
     return;
   }
   const [first, second] = stepSeq.items;
-  if (
-    first.name === 'fragment' &&
-    first.frag.name === 'text' &&
-    first.frag.contents === 'For each ' &&
-    second.name === 'fragment' &&
-    second.frag.name === 'underscore'
-  ) {
+  if (first.name === 'text' && first.contents === 'For each ' && second.name === 'underscore') {
     report({
       ruleId,
-      line: second.frag.location.start.line,
-      column: second.frag.location.start.column,
+      line: second.location.start.line,
+      column: second.location.start.column,
       message: 'expected "for each" to have a type name or "element" before the loop variable',
     });
   }


### PR DESCRIPTION
This completes the change begun in https://github.com/tc39/ecmarkup/pull/498/commits/6bd7fae48845f56f0d1f558d7443720973bbb5ba, making the expr-parser node types a superset of the ecmarkdown node types (instead of having a wrapper node, `Fragment`). This makes some things worse (using 'name' instead of 'type' for the discriminant; using a complicated 'location' property instead of start/end keys), but overall it's worth it to drop the layer of indirection, I think.