### PR TITLE
Dynamically add content to make <sup>s copy-paste safe

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -119,6 +119,10 @@ body.oldtoc {
   margin: 0 auto;
 }
 
+span[aria-hidden='true'] {
+  font-size: 0;
+}
+
 a {
   text-decoration: none;
   color: #206ca7;
@@ -282,10 +286,6 @@ emu-alg ol.nested-once ol ol ol ol,
 /* depth 7+ */
 emu-alg ol.nested-lots ol {
   list-style-type: lower-roman;
-}
-
-emu-alg [aria-hidden='true'] {
-  font-size: 0;
 }
 
 emu-eqn {

--- a/js/superscripts.js
+++ b/js/superscripts.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Update superscripts to not suffer misinterpretation when copied and pasted as plain text.
+// For example, `10<sup>3</sup>` becomes `103`, but `10³` is preserved.
+
+const arithmeticReplacements = new Map([
+  ['0', '⁰'],
+  ['1', '¹'],
+  ['2', '²'],
+  ['3', '³'],
+  ['4', '⁴'],
+  ['5', '⁵'],
+  ['6', '⁶'],
+  ['7', '⁷'],
+  ['8', '⁸'],
+  ['9', '⁹'],
+  ['(', '⁽'],
+  [')', '⁾'],
+  ['=', '⁼'],
+  ['+', '⁺'],
+  ['-', '⁻'],
+  // Space is allowed as a special case.
+  [' ', ' '],
+]);
+
+function makeSuperscriptAccessible(sup) {
+  // Replace a text-only superscript with text when it is fully replaceable,
+  // but otherwise do not modify it (for cases such as `1<sup>st</sup>`).
+  if ([...sup.childNodes].every(node => node.nodeType === 3)) {
+    const replacementText = sup.textContent
+      .split('')
+      .map(ch => arithmeticReplacements.get(ch) || '')
+      .join('');
+    if (replacementText.length === sup.textContent.length) {
+      sup.replaceWith(replacementText);
+    }
+    return;
+  }
+  // Wrap a not-yet-handled superscript with hidden Knuth up-arrow notation
+  // if it appears to represent exponentiation.
+  if (!sup.classList.contains('text') && !sup.querySelector('*:not(var)')) {
+    let prefix = ' ↑ ';
+    let suffix = '';
+    if (sup.childNodes.length > 1 && !/^\(.*\)$/s.test(sup.textContent.trim())) {
+      prefix += '(';
+      suffix += ')';
+    }
+    sup.insertAdjacentHTML('beforebegin', `<span aria-hidden="true">${prefix}</span>`);
+    if (suffix) {
+      sup.insertAdjacentHTML('afterend', `<span aria-hidden="true">${suffix}</span>`);
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('sup').forEach(sup => {
+    makeSuperscriptAccessible(sup);
+  });
+});

--- a/js/superscripts.js
+++ b/js/superscripts.js
@@ -20,7 +20,7 @@ function makeExponentPlainTextSafe(sup) {
   const isText = [...sup.childNodes].every(node => node.nodeType === 3);
   const text = sup.textContent;
   if (isText) {
-    if (!/^[0-9. 𝔽ℝℤ()=*×/÷±+−-]+$/u.test(text)) {
+    if (!/^[0-9. 𝔽ℝℤ()=*×/÷±+\u2212-]+$/u.test(text)) {
       return;
     }
   } else {

--- a/js/superscripts.js
+++ b/js/superscripts.js
@@ -35,7 +35,8 @@ function makeExponentPlainTextSafe(sup) {
   // Add wrapping parentheses unless they are already present
   // or this is a simple (possibly signed) integer or single-variable exponent.
   const skipParens =
-    /^\(.*\)$/s.test(text.trim()) || /^[±+−-]?(?:[0-9]+|\p{ID_Start}\p{ID_Continue}*)$/u.test(text);
+    /^\(.*\)$/s.test(text.trim()) ||
+    /^[±+\u2212-]?(?:[0-9]+|\p{ID_Start}\p{ID_Continue}*)$/u.test(text);
   if (!skipParens) {
     prefix += '(';
     suffix += ')';

--- a/spec/index.html
+++ b/spec/index.html
@@ -362,7 +362,8 @@ markEffects: true
     &lt;p>The following is an alernative definition of step &lt;emu-xref href="#step-example-label">&lt;/emu-xref>.&lt;/p>
     &lt;emu-alg replaces-step="step-example-label">
       1. Set _length_ to _length_ + 1.
-      1. If _length_ = 10&lt;sup>9&lt;/sup>, then
+      1. Let _weight_ be GetWeight of _node_.
+      1. If _length_ = 10&lt;sup>9&lt;/sup> or _weight_ &gt; 2&lt;sup>_length_ + 1&lt;/sup>, then
         1. Throw a *RangeError* exception.
     &lt;/emu-alg>
   </code></pre>
@@ -380,7 +381,8 @@ markEffects: true
     <p>The following is an alernative definition of step <emu-xref href="#step-example-label"></emu-xref>.</p>
     <emu-alg replaces-step="step-example-label">
       1. Set _length_ to _length_ + 1.
-      1. If _length_ = 10<sup>9</sup>, then
+      1. Let _weight_ be GetWeight of _node_.
+      1. If _length_ = 10<sup>9</sup> or _weight_ > 2<sup>_length_ + 1</sup>, then
         1. Throw a *RangeError* exception.
     </emu-alg>
   </aside>

--- a/spec/index.html
+++ b/spec/index.html
@@ -66,7 +66,7 @@ markEffects: true
       <tr><td></td><td>`title`</td><td>Document title, for example "ECMAScript 2016" or "Async Functions".</td></tr>
       <tr><td></td><td>`status`</td><td>Document status. Can be "proposal", "draft", or "standard". Defaults to "proposal".</td></tr>
       <tr><td></td><td>`stage`</td><td><a href="https://tc39.es/process-document/">TC39 proposal stage</a>. If present and `status` is "proposal", `version` defaults to "Stage <var>stage</var> Draft".</td></tr>
-      <tr><td></td><td>`version`</td><td>Document version, for example "6&lt;sup>th&lt;/sup> Edition" or "Draft 1".</td></tr>
+      <tr><td></td><td>`version`</td><td>Document version, for example "6&lt;sup>th&lt;/sup> Edition" (which renders like "6<sup>th</sup> Edition") or "Draft 1".</td></tr>
       <tr><td></td><td>`date`</td><td>Timestamp of document rendering, used for various pieces of boilerplate. Defaults to the value of <a href="https://reproducible-builds.org/docs/source-date-epoch/">the `SOURCE_DATE_EPOCH` environment variable</a> (as a number of second since the POSIX epoch) if it exists, otherwise to the current date and time.</td></tr>
       <tr><td></td><td>`shortname`</td><td>Document shortname, for example "ECMA-262". If present and `status` is "draft", `version` defaults to "Draft <var>shortname</var>".</td></tr>
       <tr><td></td><td>`location`</td><td>URL of this document. Used in conjunction with the biblio file to support inbound references from other documents.</td></tr>
@@ -340,7 +340,7 @@ markEffects: true
   </aside>
 </emu-clause>
 
-<emu-clause id="emu-alg" aoid="EmuAlg">
+<emu-clause id="emu-alg">
   <h1>emu-alg</h1>
   <p>Algorithm steps. Should not contain any HTML. The node's textContent is parsed as an Ecmarkdown document. Additionally, calls to abstract operations inside algorithm steps are automatically linked to their definitions by first checking for any clauses or algorithms with the appropriate <b>aoid</b> in the current spec, and afterwards checking any linked <a href="#emu-biblio">bibliography files</a>.</p>
   <p>Algorithm steps can be annotated with additional metadata as summarized in <emu-xref href="#algorithm-step-annotation"></emu-xref>.</p>
@@ -350,33 +350,38 @@ markEffects: true
   <p><b>replaces-step:</b> If present, references a step to replace by its <emu-xref href="#labeled-steps"><b>id</b></emu-xref> (whose numbering the algorithm adopts).</p>
 
   <h2>Example</h2>
-  <emu-note>The <emu-xref href="#emu-alg" title></emu-xref> clause has an aoid of "EmuAlg".</emu-note>
   <pre><code class="language-html">
     &lt;emu-alg>
-      1. Let _clauseAbstractOp_ be the result of calling EmuAlg().
-      1. If *false* is *true*, then
-        1. [id="step-example-label"] Let _recurse_ be the result of calling EmuAlg(*true*).
-        1. Return the result of evaluating this |NonTerminalProduction|.
+      1. Let _length_ be 0.
+      1. Let _node_ be this |ListNode|.
+      1. Repeat, while _node_ is not *undefined*,
+        1. Set _node_ to NextNode of _node_.
+        1. [id="step-example-label"] Set _length_ to _length_ + 1.
+      1. Return _length_.
     &lt;/emu-alg>
     &lt;p>The following is an alernative definition of step &lt;emu-xref href="#step-example-label">&lt;/emu-xref>.&lt;/p>
     &lt;emu-alg replaces-step="step-example-label">
-      1. Replacement.
-        1. Substep.
+      1. Set _length_ to _length_ + 1.
+      1. If _length_ = 10&lt;sup>9&lt;/sup>, then
+        1. Throw a *RangeError* exception.
     &lt;/emu-alg>
   </code></pre>
 
   <h3>Result</h3>
   <aside class="result">
     <emu-alg>
-      1. Let _clauseAbstractOp_ be the result of calling EmuAlg().
-      1. If *false* is *true*, then
-        1. [id="step-example-label"] Let _recurse_ be the result of calling EmuAlg(*true*).
-        1. Return the result of evaluating this |NonTerminalProduction|.
+      1. Let _length_ be 0.
+      1. Let _node_ be this |ListNode|.
+      1. Repeat, while _node_ is not *undefined*,
+        1. [id="step-example-label"] Set _length_ to _length_ + 1.
+        1. Set _node_ to NextNode of _node_.
+      1. Return _length_.
     </emu-alg>
     <p>The following is an alernative definition of step <emu-xref href="#step-example-label"></emu-xref>.</p>
     <emu-alg replaces-step="step-example-label">
-      1. Replacement.
-        1. Substep.
+      1. Set _length_ to _length_ + 1.
+      1. If _length_ = 10<sup>9</sup>, then
+        1. Throw a *RangeError* exception.
     </emu-alg>
   </aside>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -373,8 +373,8 @@ markEffects: true
       1. Let _length_ be 0.
       1. Let _node_ be this |ListNode|.
       1. Repeat, while _node_ is not *undefined*,
-        1. [id="step-example-label"] Set _length_ to _length_ + 1.
         1. Set _node_ to NextNode of _node_.
+        1. [id="step-example-label"] Set _length_ to _length_ + 1.
       1. Return _length_.
     </emu-alg>
     <p>The following is an alernative definition of step <emu-xref href="#step-example-label"></emu-xref>.</p>

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -2135,7 +2135,7 @@ async function walk(walker: TreeWalker, context: Context) {
   context.tagStack.pop();
 }
 
-const jsDependencies = ['sdoMap.js', 'menu.js', 'listNumbers.js'];
+const jsDependencies = ['sdoMap.js', 'menu.js', 'listNumbers.js', 'superscripts.js'];
 async function concatJs(...extras: string[]) {
   let dependencies = await Promise.all(
     jsDependencies.map(dependency => utils.readFile(path.join(__dirname, '../js/' + dependency)))


### PR DESCRIPTION
Fixes #516

* Replace a simple numeric text `<sup>` with Unicode superscript characters.
* Wrap a `<sup>` having other text and/or `<var>` contents with hidden copyable text (a leading [`↑`](https://en.wikipedia.org/wiki/Knuth%27s_up-arrow_notation) and [iff necessary] parentheses).
* Leave other `<sup>`s alone (to not break e.g. `1<sup>st</sup>`).