### PR TITLE
Fix formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ecmarkup",
-	"version": "16.1.0",
+	"version": "16.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ecmarkup",
-			"version": "16.1.0",
+			"version": "16.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "16.1.0",
+	"version": "16.1.1",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/src/formatter/ecmarkdown.ts
+++ b/src/formatter/ecmarkdown.ts
@@ -179,8 +179,12 @@ export async function printFragments(
         output.append(await printFormat(source, node, indent));
         break;
       }
+      case 'double-brackets': {
+        output.appendText(`[[${node.contents}]]`);
+        break;
+      }
       default: {
-        // @ts-ignore
+        // @ts-expect-error
         throw new Error(`Unknown node type ${node.name}`);
       }
     }

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -46,7 +46,7 @@ function productionBodies(body: ProductionBody) {
     case SyntaxKind.RightHandSide:
       return [body];
     default:
-      // @ts-ignore
+      // @ts-expect-error
       throw new Error('unknown production body type ' + body.constructor.name);
   }
 }

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -474,6 +474,7 @@ describe('algorithm formatting', () => {
       1. Another   step.
             1. A substep.
             1. [ x =  "a",y="b"  ] A step with attributes.
+            1. A step with _vars_, numbers like **10<sup>x</sup>**, records like {  [[A]]: 0  }, and fields like _o_.[[field]].
       </emu-alg>
       `,
       dedentKeepingTrailingNewline`
@@ -482,6 +483,7 @@ describe('algorithm formatting', () => {
         1. Another step.
           1. A substep.
           1. [x="a", y="b"] A step with attributes.
+          1. A step with _vars_, numbers like **10<sup>x</sup>**, records like { [[A]]: 0 }, and fields like _o_.[[field]].
       </emu-alg>
       `
     );


### PR DESCRIPTION
TS has this annoying problem where if you have a `switch` it thinks it is exhaustive you cannot also have a `default` which refers to properties of the thing you're switching over - it infers the type as the bottom type, `never`, which has no properties.

That would be fine if its type system were sound, since you could just omit the `default`, but since it's not, you probably still want the `default` to give a useful error.  Also it doesn't have a way to assert that a `switch` is exhaustive when it's not expected to return things from every branch, so you want to have the `default` anyway in case you're accidentally not exhaustive.

That means you'll get an error in the `default` case, which you have to ignore. If you just `ts-ignore` it, that means that it will still compile if you add a new kind to the thing you're switching over. So it's important to use `ts-expect-error` instead, so that you actually get a compile failure if the error does _not_ happen.

This PR fixes the two places we were failing to follow that rule, and fixes a bug masked by this failure. It also includes a version bump, so please **rebase**, not squash.