### PR TITLE
fix "there exists"/"such that" not followed by a var name

### DIFF
--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -289,7 +289,7 @@ function walkAlgorithm(
         if (
           prev.name === 'text' &&
           // prettier-ignore
-          /\b(?:for any |for some |there exists |there is |there does not exist )(\w+ )*$/.test(prev.contents)
+          /\b(?:for any |for some |there exists |there is |there does not exist )((?!of |in )(\w+ ))*$/.test(prev.contents)
         ) {
           scope.declare(varName, part);
           declaredThisLine.add(part);

--- a/test/lint-variable-use-def.js
+++ b/test/lint-variable-use-def.js
@@ -115,6 +115,22 @@ describe('variables are declared and used appropriately', () => {
       );
     });
 
+    it('"there exists a value in _x_ with a property" does not declare _x_"', async () => {
+      await assertLint(
+        positioned`
+          <emu-alg>
+            1. If there exists an integer in ${M}_x_ greater than 0, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        `,
+        {
+          ruleId: 'use-before-def',
+          nodeType: 'emu-alg',
+          message: 'could not find a preceding declaration for "x"',
+        }
+      );
+    });
+
     it('variables in a loop header other than the loop variable must be declared', async () => {
       await assertLint(
         positioned`


### PR DESCRIPTION
Should unblock https://github.com/tc39/ecma262/pull/3102.

Concretely, the problem was that the variable def-use lint treats `there exists [...] _X_` as declaring `_X_`, which is true for uses like `there exists an integer _X_ such that` or `there exists an element _A_ of _B_`, but not for `there exists a value in _X_`, which is the form in used in the relevant line in the PR.

Specifically, the line in 262 is `If there exists a CharSetElement in _A_ containing exactly one character _a_ such that [...]`, which should _use_ `_A_` but _declare_ `_a_`; prior to this PR it was treating both as declarations.

The linter wasn't tripping earlier because a separate issue in ecma262 (introduced in https://github.com/tc39/ecma262/pull/2418 and fixed in https://github.com/tc39/ecma262/pull/3102) caused `_A_` not to be captured, which basically canceled out the bug here.