### PR TITLE
remove --js-out/--css-out; replace with --assets-dir

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     "prettier"
   ],
   "plugins": [
-    "prettier"
+    "prettier",
+    "@typescript-eslint"
   ],
   "env": {
     "node": true,
@@ -49,6 +50,7 @@
     }
   ],
   "rules": {
+    "@typescript-eslint/consistent-type-imports": "error",
     "prettier/prettier": "error",
     "arrow-body-style": "error",
     "prefer-arrow-callback": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,15 +37,15 @@
 				"@types/jsdom": "^16.2.13",
 				"@types/node": "^13.1.8",
 				"@types/parse5": "^6.0.2",
-				"@typescript-eslint/eslint-plugin": "^5.12.0",
-				"@typescript-eslint/parser": "^5.12.0",
+				"@typescript-eslint/eslint-plugin": "^6.3.0",
+				"@typescript-eslint/parser": "^6.3.0",
 				"eslint": "^7.32.0",
 				"eslint-config-prettier": "^6.10.1",
 				"eslint-plugin-prettier": "^3.1.2",
 				"mocha": "^5.2.0",
 				"prettier": "^2.0.4",
 				"safe-publish-latest": "^1.1.4",
-				"typescript": "^4.5.5"
+				"typescript": "^5.1.6"
 			},
 			"engines": {
 				"node": ">= 12 || ^11.10.1 || ^10.13 || ^8.10"
@@ -207,6 +207,42 @@
 			"resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.23.tgz",
 			"integrity": "sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA=="
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+			"integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+			"dev": true,
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -317,9 +353,9 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"version": "7.0.12",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -334,6 +370,12 @@
 			"integrity": "sha512-+hQX+WyJAOne7Fh3zF5CxPemILIbuhNcqHHodzK9caYOLnC8pD5efmPleRnw0z++LfKUC/sVNMwk0Gap+B0baA==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"dev": true
+		},
 		"node_modules/@types/tough-cookie": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
@@ -341,31 +383,34 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.0.tgz",
-			"integrity": "sha512-fwCMkDimwHVeIOKeBHiZhRUfJXU8n6xW1FL9diDxAyGAFvKcH4csy0v7twivOQdQdA0KC8TDr7GGRd3L4Lv0rQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.3.0.tgz",
+			"integrity": "sha512-IZYjYZ0ifGSLZbwMqIip/nOamFiWJ9AH+T/GYNZBWkVcyNQOFGtSMoWV7RvY4poYCMZ/4lHzNl796WOSNxmk8A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.12.0",
-				"@typescript-eslint/type-utils": "5.12.0",
-				"@typescript-eslint/utils": "5.12.0",
-				"debug": "^4.3.2",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.1.8",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.3.0",
+				"@typescript-eslint/type-utils": "6.3.0",
+				"@typescript-eslint/utils": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"natural-compare-lite": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -374,34 +419,35 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.0.tgz",
-			"integrity": "sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.3.0.tgz",
+			"integrity": "sha512-ibP+y2Gr6p0qsUkhs7InMdXrwldjxZw66wpcQq9/PzAroM45wdwyu81T+7RibNCh8oc0AgrsyCwJByncY0Ongg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.12.0",
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/typescript-estree": "5.12.0",
-				"debug": "^4.3.2"
+				"@typescript-eslint/scope-manager": "6.3.0",
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/typescript-estree": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0",
+				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -410,16 +456,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
-			"integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.3.0.tgz",
+			"integrity": "sha512-WlNFgBEuGu74ahrXzgefiz/QlVb+qg8KDTpknKwR7hMH+lQygWyx0CQFoUmMn1zDkQjTBBIn75IxtWss77iBIQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/visitor-keys": "5.12.0"
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -427,24 +473,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.0.tgz",
-			"integrity": "sha512-9j9rli3zEBV+ae7rlbBOotJcI6zfc6SHFMdKI9M3Nc0sy458LJ79Os+TPWeBBL96J9/e36rdJOfCuyRSgFAA0Q==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.3.0.tgz",
+			"integrity": "sha512-7Oj+1ox1T2Yc8PKpBvOKWhoI/4rWFd1j7FA/rPE0lbBPXTKjdbtC+7Ev0SeBjEKkIhKWVeZSP+mR7y1Db1CdfQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.12.0",
-				"debug": "^4.3.2",
-				"tsutils": "^3.21.0"
+				"@typescript-eslint/typescript-estree": "6.3.0",
+				"@typescript-eslint/utils": "6.3.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -453,12 +500,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
-			"integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.3.0.tgz",
+			"integrity": "sha512-K6TZOvfVyc7MO9j60MkRNWyFSf86IbOatTKGrpTQnzarDZPYPVy0oe3myTMq7VjhfsUAbNUW8I5s+2lZvtx1gg==",
 			"dev": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -466,21 +513,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
-			"integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.3.0.tgz",
+			"integrity": "sha512-Xh4NVDaC4eYKY4O3QGPuQNp5NxBAlEvNQYOqJquR2MePNxO11E5K3t5x4M4Mx53IZvtpW+mBxIT0s274fLUocg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/visitor-keys": "5.12.0",
-				"debug": "^4.3.2",
-				"globby": "^11.0.4",
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -493,58 +540,41 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.0.tgz",
-			"integrity": "sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.3.0.tgz",
+			"integrity": "sha512-hLLg3BZE07XHnpzglNBG8P/IXq/ZVXraEbgY7FM0Cnc1ehM8RMdn9mat3LubJ3KBeYXXPxV1nugWbQPjGeJk6Q==",
 			"dev": true,
 			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.12.0",
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/typescript-estree": "5.12.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.3.0",
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/typescript-estree": "6.3.0",
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
-			"integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.3.0.tgz",
+			"integrity": "sha512-kEhRRj7HnvaSjux1J9+7dBen15CdWmDnwrpyiHsFX6Qx2iW5LOBUgNefOFeh2PjWPlNwN8TOn6+4eBU3J/gupw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.12.0",
-				"eslint-visitor-keys": "^3.0.0"
+				"@typescript-eslint/types": "6.3.0",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -552,12 +582,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/abab": {
@@ -1004,9 +1037,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1756,9 +1789,9 @@
 			}
 		},
 		"node_modules/globby/node_modules/ignore": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -1781,6 +1814,12 @@
 			"bin": {
 				"grammarkdown": "bin/grammarkdown"
 			}
+		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
 		},
 		"node_modules/growl": {
 			"version": "1.10.5",
@@ -2358,6 +2397,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"node_modules/natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true
+		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2860,9 +2905,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -3199,31 +3244,22 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+			"integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.13.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/tsutils/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -3250,16 +3286,16 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/typical": {
@@ -3704,6 +3740,29 @@
 			"resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.23.tgz",
 			"integrity": "sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA=="
 		},
+		"@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+					"dev": true
+				}
+			}
+		},
+		"@eslint-community/regexpp": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+			"integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+			"dev": true
+		},
 		"@eslint/eslintrc": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -3796,9 +3855,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"version": "7.0.12",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
 		},
 		"@types/node": {
@@ -3813,6 +3872,12 @@
 			"integrity": "sha512-+hQX+WyJAOne7Fh3zF5CxPemILIbuhNcqHHodzK9caYOLnC8pD5efmPleRnw0z++LfKUC/sVNMwk0Gap+B0baA==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"dev": true
+		},
 		"@types/tough-cookie": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
@@ -3820,123 +3885,118 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.0.tgz",
-			"integrity": "sha512-fwCMkDimwHVeIOKeBHiZhRUfJXU8n6xW1FL9diDxAyGAFvKcH4csy0v7twivOQdQdA0KC8TDr7GGRd3L4Lv0rQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.3.0.tgz",
+			"integrity": "sha512-IZYjYZ0ifGSLZbwMqIip/nOamFiWJ9AH+T/GYNZBWkVcyNQOFGtSMoWV7RvY4poYCMZ/4lHzNl796WOSNxmk8A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.12.0",
-				"@typescript-eslint/type-utils": "5.12.0",
-				"@typescript-eslint/utils": "5.12.0",
-				"debug": "^4.3.2",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.1.8",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.3.0",
+				"@typescript-eslint/type-utils": "6.3.0",
+				"@typescript-eslint/utils": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"natural-compare-lite": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"dependencies": {
 				"ignore": {
-					"version": "5.1.9",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-					"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+					"version": "5.2.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 					"dev": true
 				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.0.tgz",
-			"integrity": "sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.3.0.tgz",
+			"integrity": "sha512-ibP+y2Gr6p0qsUkhs7InMdXrwldjxZw66wpcQq9/PzAroM45wdwyu81T+7RibNCh8oc0AgrsyCwJByncY0Ongg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.12.0",
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/typescript-estree": "5.12.0",
-				"debug": "^4.3.2"
+				"@typescript-eslint/scope-manager": "6.3.0",
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/typescript-estree": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0",
+				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
-			"integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.3.0.tgz",
+			"integrity": "sha512-WlNFgBEuGu74ahrXzgefiz/QlVb+qg8KDTpknKwR7hMH+lQygWyx0CQFoUmMn1zDkQjTBBIn75IxtWss77iBIQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/visitor-keys": "5.12.0"
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.0.tgz",
-			"integrity": "sha512-9j9rli3zEBV+ae7rlbBOotJcI6zfc6SHFMdKI9M3Nc0sy458LJ79Os+TPWeBBL96J9/e36rdJOfCuyRSgFAA0Q==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.3.0.tgz",
+			"integrity": "sha512-7Oj+1ox1T2Yc8PKpBvOKWhoI/4rWFd1j7FA/rPE0lbBPXTKjdbtC+7Ev0SeBjEKkIhKWVeZSP+mR7y1Db1CdfQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.12.0",
-				"debug": "^4.3.2",
-				"tsutils": "^3.21.0"
+				"@typescript-eslint/typescript-estree": "6.3.0",
+				"@typescript-eslint/utils": "6.3.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
-			"integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.3.0.tgz",
+			"integrity": "sha512-K6TZOvfVyc7MO9j60MkRNWyFSf86IbOatTKGrpTQnzarDZPYPVy0oe3myTMq7VjhfsUAbNUW8I5s+2lZvtx1gg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
-			"integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.3.0.tgz",
+			"integrity": "sha512-Xh4NVDaC4eYKY4O3QGPuQNp5NxBAlEvNQYOqJquR2MePNxO11E5K3t5x4M4Mx53IZvtpW+mBxIT0s274fLUocg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/visitor-keys": "5.12.0",
-				"debug": "^4.3.2",
-				"globby": "^11.0.4",
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/visitor-keys": "6.3.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.0.tgz",
-			"integrity": "sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.3.0.tgz",
+			"integrity": "sha512-hLLg3BZE07XHnpzglNBG8P/IXq/ZVXraEbgY7FM0Cnc1ehM8RMdn9mat3LubJ3KBeYXXPxV1nugWbQPjGeJk6Q==",
 			"dev": true,
 			"requires": {
-				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.12.0",
-				"@typescript-eslint/types": "5.12.0",
-				"@typescript-eslint/typescript-estree": "5.12.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
-			},
-			"dependencies": {
-				"eslint-utils": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				}
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.3.0",
+				"@typescript-eslint/types": "6.3.0",
+				"@typescript-eslint/typescript-estree": "6.3.0",
+				"semver": "^7.5.4"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
-			"integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.3.0.tgz",
+			"integrity": "sha512-kEhRRj7HnvaSjux1J9+7dBen15CdWmDnwrpyiHsFX6Qx2iW5LOBUgNefOFeh2PjWPlNwN8TOn6+4eBU3J/gupw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.12.0",
-				"eslint-visitor-keys": "^3.0.0"
+				"@typescript-eslint/types": "6.3.0",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"dependencies": {
 				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 					"dev": true
 				}
 			}
@@ -4291,9 +4351,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -4857,9 +4917,9 @@
 			},
 			"dependencies": {
 				"ignore": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+					"version": "5.2.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+					"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 					"dev": true
 				}
 			}
@@ -4878,6 +4938,12 @@
 				"@esfx/async-canceltoken": "^1.0.0-pre.13",
 				"@esfx/cancelable": "^1.0.0-pre.13"
 			}
+		},
+		"graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -5328,6 +5394,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true
+		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -5681,9 +5753,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
@@ -5946,27 +6018,17 @@
 				"punycode": "^2.1.1"
 			}
 		},
+		"ts-api-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+			"integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+			"dev": true,
+			"requires": {}
+		},
 		"tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-		},
-		"tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.8.1"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
-				}
-			}
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -5984,9 +6046,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
 			"dev": true
 		},
 		"typical": {

--- a/package.json
+++ b/package.json
@@ -69,15 +69,15 @@
 		"@types/jsdom": "^16.2.13",
 		"@types/node": "^13.1.8",
 		"@types/parse5": "^6.0.2",
-		"@typescript-eslint/eslint-plugin": "^5.12.0",
-		"@typescript-eslint/parser": "^5.12.0",
+		"@typescript-eslint/eslint-plugin": "^6.3.0",
+		"@typescript-eslint/parser": "^6.3.0",
 		"eslint": "^7.32.0",
 		"eslint-config-prettier": "^6.10.1",
 		"eslint-plugin-prettier": "^3.1.2",
 		"mocha": "^5.2.0",
 		"prettier": "^2.0.4",
 		"safe-publish-latest": "^1.1.4",
-		"typescript": "^4.5.5"
+		"typescript": "^5.1.6"
 	},
 	"prettier": {
 		"singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"build": "tsc -sourceMap",
 		"build-release": "tsc",
-		"build-spec": "mkdir -p docs && node bin/ecmarkup.js spec/index.html docs/index.html --css-out docs/elements.css --js-out docs/ecmarkup.js",
+		"build-spec": "mkdir -p docs && node bin/ecmarkup.js spec/index.html docs/index.html --assets-dir=docs",
 		"prepack": "safe-publish-latest && npm run build-release",
 		"format-spec": "node bin/emu-format.js --write spec/index.html",
 		"test": "mocha",

--- a/spec/index.html
+++ b/spec/index.html
@@ -50,9 +50,8 @@ markEffects: true
       <tr><td>`--watch`</td><td></td><td>Rebuild when files change.</td></tr>
       <tr><td>`--verbose`</td><td></td><td>Print verbose logging info.</td></tr>
       <tr><td>`--write-biblio`</td><td></td><td>Emit a biblio file to the specified path.</td></tr>
-      <tr><td>`--assets`</td><td>`assets`</td><td>"none" for no CSS/JS, "inline" for inline CSS/JS.</td></tr>
-      <tr><td>`--css-out`</td><td>`cssOut`</td><td>Emit the Ecmarkup CSS file to the specified path.</td></tr>
-      <tr><td>`--js-out`</td><td>`jsOut`</td><td>Emit the Ecmarkup JS file to the specified path.</td></tr>
+      <tr><td>`--assets`</td><td>`assets`</td><td>"none" for no CSS/JS/etc, "inline" for inline CSS/JS/etc, "external" for external CSS/JS/etc.</td></tr>
+      <tr><td>`--assets-dir`</td><td>`assetsDir`</td><td>Directory in which to place assets when using `--assets=external`.</td></tr>
       <tr><td>`--lint-spec`</td><td>`lintSpec`</td><td>Enforce some style and correctness checks.</td></tr>
       <tr><td>`--error-formatter`</td><td></td><td>The <a href="https://eslint.org/docs/user-guide/formatters/">eslint formatter</a> to be used for printing warnings and errors when using `--verbose`. Either the name of a built-in eslint formatter or the package name of an installed eslint compatible formatter.</td></tr>
       <tr><td>`--strict`</td><td></td><td>Exit with an error if there are warnings. Cannot be used with `--watch`.</td></tr>

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -6,13 +6,8 @@ import type { Context } from './Context';
 
 import { ParseError, TypeParser } from './type-parser';
 import Builder from './Builder';
-import {
-  formatPreamble,
-  parseStructuredHeaderDl,
-  formatHeader,
-  parseH1,
-  ParsedHeader,
-} from './header-parser';
+import type { ParsedHeader } from './header-parser';
+import { formatPreamble, parseStructuredHeaderDl, formatHeader, parseH1 } from './header-parser';
 import { offsetToLineAndColumn, traverseWhile } from './utils';
 
 const aoidTypes = [

--- a/src/Dfn.ts
+++ b/src/Dfn.ts
@@ -1,4 +1,5 @@
-import { getKeys, PartialBiblioEntry, TermBiblioEntry } from './Biblio';
+import type { PartialBiblioEntry, TermBiblioEntry } from './Biblio';
+import { getKeys } from './Biblio';
 import type { Context } from './Context';
 
 import Builder from './Builder';

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -1,9 +1,9 @@
 import type { Context } from './Context';
-import type { SourceFile } from 'grammarkdown';
+import type { SourceFile, CompilerOptions } from 'grammarkdown';
 
 import Builder from './Builder';
 import { collectNonterminalsFromGrammar } from './lint/utils';
-import { CoreAsyncHost, CompilerOptions, Grammar as GrammarFile, EmitFormat } from 'grammarkdown';
+import { CoreAsyncHost, Grammar as GrammarFile, EmitFormat } from 'grammarkdown';
 
 const endTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/i;
 const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/gi;

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -18,7 +18,8 @@ import * as yaml from 'js-yaml';
 import * as utils from './utils';
 import * as hljs from 'highlight.js';
 // Builders
-import Import, { EmuImportElement } from './Import';
+import type { EmuImportElement } from './Import';
+import Import from './Import';
 import Clause from './Clause';
 import ClauseNumbers from './clauseNums';
 import Algorithm from './Algorithm';
@@ -50,14 +51,8 @@ import type { OrderedListNode } from 'ecmarkdown';
 import { getProductions, rhsMatches, getLocationInGrammarFile } from './lint/utils';
 import type { AugmentedGrammarEle } from './Grammar';
 import { offsetToLineAndColumn } from './utils';
-import {
-  parse as parseExpr,
-  walk as walkExpr,
-  Expr,
-  PathItem,
-  Seq,
-  isProsePart,
-} from './expr-parser';
+import type { Expr, PathItem, Seq } from './expr-parser';
+import { parse as parseExpr, walk as walkExpr, isProsePart } from './expr-parser';
 
 const DRAFT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
   year: 'numeric',

--- a/src/args.ts
+++ b/src/args.ts
@@ -28,20 +28,16 @@ export const options = [
   {
     name: 'assets',
     type: String,
-    typeLabel: 'none|inline|external', // TODO I don't think we actually distinguish between inline and external
-    description: 'Link to css and js assets (default: inline, unless --multipage)',
+    typeLabel: 'none|inline|external',
+    description:
+      'Omit assets, inline them, or add them as external. Default: inline, unless --multipage or --assets-dir are specified, in which case external.',
   },
   {
-    name: 'css-out',
+    name: 'assets-dir',
     type: String,
-    typeLabel: '{underline file}',
-    description: 'Path to a file where the CSS assets should be written',
-  },
-  {
-    name: 'js-out',
-    type: String,
-    typeLabel: '{underline file}',
-    description: 'Path to a file where the JS assets should be written',
+    typeLabel: '{underline dir}',
+    description:
+      'The directory in which to place generated assets when using --assets=external. Implies --assets=external. Defaults to [outfile]/assets.',
   },
   {
     name: 'no-toc',
@@ -74,8 +70,7 @@ export const options = [
   {
     name: 'multipage',
     type: Boolean,
-    description:
-      'Generate a multipage version of the spec. Cannot be used with --js-out or --css-out.',
+    description: 'Generate a multipage version of the spec. Implies --assets=external.',
   },
   {
     name: 'strict',
@@ -98,5 +93,15 @@ export const options = [
     type: String,
     multiple: true,
     defaultOption: true,
+  },
+
+  // removed; still defined here so we can give better errors
+  {
+    name: 'css-out',
+    type: String,
+  },
+  {
+    name: 'js-out',
+    type: String,
   },
 ] as const;

--- a/src/clauseNums.ts
+++ b/src/clauseNums.ts
@@ -114,7 +114,7 @@ export default function iterator(spec: Spec): ClauseNumberIterator {
           // strictly greater than the value in `ids[level]` at the first
           // index where they differ).
           const i = nums.findIndex((num, i) => num !== ids[level][i]);
-          if (i < 0 || !(nums[i] > ids[level][i])) {
+          if (i < 0 || !(nums[i] > (ids[level] as number[])[i])) {
             spec.warn({
               type: 'attr-value',
               node,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ function usage() {
       },
       {
         header: 'Options',
-        hide: ['files'],
+        hide: ['files', 'js-out', 'css-out'],
         optionList: options as unknown as commandLineUsage.OptionDefinition[],
       },
     ])
@@ -64,18 +64,21 @@ if (args.strict && args.watch) {
   fail('Cannot use --strict with --watch');
 }
 
-if (args.assets != null && !['none', 'inline', 'external'].includes(args.assets)) {
-  fail('--assets requires "none", "inline", or "external"');
+if (args['js-out'] || args['css-out']) {
+  fail('--js-out and --css-out have been removed; specify --assets-dir instead');
 }
 
-// TODO just drop these
-if (!outfile && (args['js-out'] || args['css-out'])) {
-  fail('When using --js-out or --css-out you must specify an output file');
+if (args.assets != null && !['none', 'inline', 'external'].includes(args.assets)) {
+  fail('--assets must be "none", "inline", or "external"');
+}
+
+if (args.assets != null && args.assets !== 'external' && args['assets-dir'] != null) {
+  fail(`--assets=${args.assets} cannot be used --assets-dir"`);
 }
 
 if (args.multipage) {
-  if (args['js-out'] || args['css-out']) {
-    fail('Cannot use --multipage with --js-out or --css-out');
+  if (args.assets != null && !['none', 'inline'].includes(args.assets)) {
+    fail('--multipage implies --assets=external');
   }
 
   if (!outfile) {
@@ -97,8 +100,6 @@ const build = debounce(async function build() {
     const opts: Options = {
       multipage: args.multipage,
       outfile,
-      jsOut: args['js-out'],
-      cssOut: args['css-out'],
       extraBiblios: [],
       lintSpec: !!args['lint-spec'],
     };
@@ -114,9 +115,14 @@ const build = debounce(async function build() {
     if (args['old-toc'] != null) {
       opts.oldToc = args['old-toc'];
     }
+
     if (args.assets != null) {
       opts.assets = args.assets as 'none' | 'inline' | 'external';
     }
+    if (args['assets-dir'] != null) {
+      opts.assetsDir = args['assets-dir'];
+    }
+
     let warned = false;
 
     for (let toResolve of args['load-biblio'] ?? []) {

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -38,9 +38,10 @@ export interface Options {
   oldToc?: boolean;
   markEffects?: boolean;
   lintSpec?: boolean;
-  cssOut?: string;
-  jsOut?: string;
+  cssOut?: never;
+  jsOut?: never;
   assets?: 'none' | 'inline' | 'external';
+  assetsDir?: string;
   outfile?: string;
   boilerplate?: Boilerplate;
   log?: (msg: string) => void;

--- a/src/formatter/grammarkdown.ts
+++ b/src/formatter/grammarkdown.ts
@@ -1,19 +1,21 @@
-import {
+import type {
   CompilerOptions,
+  Node,
+  Prose,
+  RightHandSide,
+  OneOfList,
+  ParameterList,
+  Trivia,
+} from 'grammarkdown';
+import {
   NewLineKind,
   CoreAsyncHost,
   Grammar,
   GrammarkdownEmitter,
-  Node,
   SyntaxKind,
-  Prose,
-  RightHandSide,
   SourceFile,
   Production,
-  OneOfList,
   RightHandSideList,
-  ParameterList,
-  Trivia,
 } from 'grammarkdown';
 import { LineBuilder } from './line-builder';
 
@@ -90,7 +92,7 @@ class EmitterWithComments extends GrammarkdownEmitter {
 
           const newRhses: RightHandSide[] = prods.flatMap(p => {
             if (p.body!.kind === SyntaxKind.RightHandSide) {
-              return [p.body! as RightHandSide];
+              return [p.body!];
             } else if (p.body!.kind === SyntaxKind.RightHandSideList) {
               return (p.body as RightHandSideList).elements!;
             } else {

--- a/src/formatter/header.ts
+++ b/src/formatter/header.ts
@@ -1,5 +1,5 @@
-import { ParsedHeaderOrFailure, printSimpleParamList } from '../header-parser';
-import type { Param } from '../header-parser';
+import { printSimpleParamList } from '../header-parser';
+import type { Param, ParsedHeaderOrFailure } from '../header-parser';
 import { LineBuilder } from './line-builder';
 
 function printTypedParam(param: Param, optional: boolean) {

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -13,7 +13,8 @@ import lintForEachElement from './rules/for-each-element';
 import lintStepAttributes from './rules/step-attributes';
 import lintIfElseConsistency from './rules/if-else-consistency';
 import { checkVariableUsage } from './rules/variable-use-def';
-import { parse, Seq } from '../expr-parser';
+import type { Seq } from '../expr-parser';
+import { parse } from '../expr-parser';
 
 type LineRule = (
   report: Reporter,

--- a/src/lint/collect-grammar-diagnostics.ts
+++ b/src/lint/collect-grammar-diagnostics.ts
@@ -1,14 +1,12 @@
 import type { default as Spec, Warning } from '../Spec';
 
+import type { SymbolSpan, Production, Parameter } from 'grammarkdown';
 import {
   Grammar as GrammarFile,
   CoreAsyncHost,
   EmitFormat,
   SyntaxKind,
-  SymbolSpan,
   Diagnostics,
-  Production,
-  Parameter,
 } from 'grammarkdown';
 
 import { getProductions, rhsMatches, getLocationInGrammarFile } from './utils';

--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -6,7 +6,8 @@ import type {
   TextNode,
 } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
-import { Seq, walk as walkExpr } from '../../expr-parser';
+import type { Seq } from '../../expr-parser';
+import { walk as walkExpr } from '../../expr-parser';
 import { offsetToLineAndColumn } from '../../utils';
 
 /*

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -11,10 +11,11 @@ import type {
   OneOfSymbol,
   ArgumentList,
   SourceFile,
+  Grammar as GrammarFile,
 } from 'grammarkdown';
 import type { Node as EcmarkdownNode } from 'ecmarkdown';
 
-import { Grammar as GrammarFile, SyntaxKind, skipTrivia, NodeVisitor } from 'grammarkdown';
+import { SyntaxKind, skipTrivia, NodeVisitor } from 'grammarkdown';
 import * as emd from 'ecmarkdown';
 
 export function getProductions(sourceFiles: readonly SourceFile[]) {

--- a/test/baselines/generated-reference/multipage.html/multipage/index.html
+++ b/test/baselines/generated-reference/multipage.html/multipage/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <head><meta charset="utf-8">
 <link rel="icon" href="../img/favicon.ico">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><link rel="stylesheet" href="../ecmarkup.css"><script src="multipage.js?cache=9g6w4CbH" defer=""></script><script src="../ecmarkup.js?cache=DRYFOrHn" defer=""></script><link rel="canonical" href="../#sec-intro"></head>
+<link rel="canonical" href="../#sec-intro"></head>
 <body><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="./#sec-intro" title="Intro">Intro</a></li><li><span class="item-toggle-none"></span><a href="second.html#sec-second" title="Second Clause"><span class="secnum">1</span> Second Clause</a></li><li><span class="item-toggle">◢</span><a href="third.html#sec-third" title="Third Clause"><span class="secnum">2</span> Third Clause</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="third.html#sec-alg" title="Algorithm"><span class="secnum">2.1</span> Algorithm</a></li></ol></li></ol></div></div>
 <div id="menu-spacer" class="menu-spacer"></div>
 <div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">

--- a/test/baselines/generated-reference/multipage.html/multipage/second.html
+++ b/test/baselines/generated-reference/multipage.html/multipage/second.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <head><meta charset="utf-8">
 <link rel="icon" href="../img/favicon.ico">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><link rel="stylesheet" href="../ecmarkup.css"><script src="multipage.js?cache=9g6w4CbH" defer=""></script><script src="../ecmarkup.js?cache=DRYFOrHn" defer=""></script><link rel="canonical" href="../#sec-second"></head>
+<link rel="canonical" href="../#sec-second"></head>
 <body><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="./#sec-intro" title="Intro">Intro</a></li><li><span class="item-toggle-none"></span><a href="second.html#sec-second" title="Second Clause"><span class="secnum">1</span> Second Clause</a></li><li><span class="item-toggle">◢</span><a href="third.html#sec-third" title="Third Clause"><span class="secnum">2</span> Third Clause</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="third.html#sec-alg" title="Algorithm"><span class="secnum">2.1</span> Algorithm</a></li></ol></li></ol></div></div>
 <div id="menu-spacer" class="menu-spacer"></div>
 <div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">

--- a/test/baselines/generated-reference/multipage.html/multipage/third.html
+++ b/test/baselines/generated-reference/multipage.html/multipage/third.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <head><meta charset="utf-8">
 <link rel="icon" href="../img/favicon.ico">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><link rel="stylesheet" href="../ecmarkup.css"><script src="multipage.js?cache=9g6w4CbH" defer=""></script><script src="../ecmarkup.js?cache=DRYFOrHn" defer=""></script><link rel="canonical" href="../#sec-third"></head>
+<link rel="canonical" href="../#sec-third"></head>
 <body><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="./#sec-intro" title="Intro">Intro</a></li><li><span class="item-toggle-none"></span><a href="second.html#sec-second" title="Second Clause"><span class="secnum">1</span> Second Clause</a></li><li><span class="item-toggle">◢</span><a href="third.html#sec-third" title="Third Clause"><span class="secnum">2</span> Third Clause</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="third.html#sec-alg" title="Algorithm"><span class="secnum">2.1</span> Algorithm</a></li></ol></li></ol></div></div>
 <div id="menu-spacer" class="menu-spacer"></div>
 <div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
         "strict": true,
         "declaration": true,
         "stripInternal": true,
-        "importsNotUsedAsValues": "error",
         "outDir": "lib",
         "lib": ["es2020", "dom", "dom.iterable"],
         "typeRoots": [


### PR DESCRIPTION
This is a breaking change. It significantly simplifies things as we introduce more assets, e.g. in https://github.com/tc39/ecmarkup/pull/539.

Had to update typescript to fix some issues with the older version, which required some other related changes. I suggest reviewing commits individually.