### PR TITLE
force page background colour to white

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -90,6 +90,10 @@
   src: local(IBM Plex Mono Bold Italic), local(IBMPlexMono-BoldItalic);
 }
 
+html {
+  background-color: #fff;
+}
+
 body {
   display: flex;
   word-wrap: break-word;


### PR DESCRIPTION
Fixes #244. If a user has their default UA background colour set to something dark, the body text may be unreadable. This sidesteps the issue by just setting the background colour to white.