### PR TITLE
add a persistent indicator to link targets

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -769,6 +769,16 @@ table.lightweight-table th {
   vertical-align: baseline;
 }
 
+/* add a more subtle persistent indicator to link targets */
+emu-clause:target, emu-annex:target, emu-table:target figure, emu-production:target {
+  border-left: 0.5em solid #FFC107;
+  padding-left: 1em;
+  margin-left: -1em;
+}
+:not(emu-clause, emu-annex, emu-table, emu-production):target {
+  text-decoration: wavy underline #FF9800;
+}
+
 /* diff styles */
 ins {
   background-color: #e0f8e0;


### PR DESCRIPTION
Split from #441, which only gives a temporary highlight to link targets. This is a further enhancement to add a persistent indicator.