### PR TITLE
Separate toolbox items into independently-wrappable "words"

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -1204,13 +1204,14 @@ li.menu-search-result-term:before {
   background: #ddd;
   border: 1px solid #aaa;
   color: #eee;
-  padding: 5px;
+  padding: 5px 7px;
   border-radius: 3px;
 }
 
 .toolbox a {
   text-decoration: none;
-  padding: 0 5px;
+  padding: 0 3px;
+  white-space: nowrap;
 }
 
 .toolbox a:hover {

--- a/js/menu.js
+++ b/js/menu.js
@@ -902,7 +902,9 @@ let Toolbox = {
       referencePane.showReferencesFor(this.entry);
     });
     this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(document.createTextNode(' '));
     this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(document.createTextNode(' '));
     this.$container.appendChild(this.$refsLink);
     document.body.appendChild(this.$outer);
   },


### PR DESCRIPTION
The current toolbox cannot wrap in between "Permalink" or "Pin" or "Pin" and "References (…)" (and thus can horizontally overflow the viewport when a definition is near the right margin), but _can_ wrap in between "References" and "(…)" (splitting a link and on the second line intruding into what otherwise looks like box padding). This PR disables wrapping inside those links and inserts break opportunities in between them.

<details><summary><b>Before</b></summary>

![screenshot (before change)](https://github.com/tc39/ecmarkup/assets/1199584/6aecf505-9113-456e-a215-c06cd8607575)

</details>

<details><summary><b>After</b></summary>

![screenshot (after change)](https://github.com/tc39/ecmarkup/assets/1199584/62662fa6-4024-4247-b8db-038834dc2cf9)

</details>

The excess horizontal width is a known issue with CSS "shrink-wrapping" that already exists and is not changed by this PR:

<details><summary>current excessive width</summary>

![screenshot of current excessive width](https://github.com/tc39/ecmarkup/assets/1199584/8d8cc0a6-d95e-4660-867f-838749fa8d5c)

</details>