### PR TITLE
Accept dot inside intrinsic name in header

### DIFF
--- a/src/lint/collect-header-diagnostics.ts
+++ b/src/lint/collect-header-diagnostics.ts
@@ -49,11 +49,17 @@ export function collectHeaderDiagnostics(
 
       // CreateForInIterator
       // Object.fromEntries
-      // _NativeError_ [ @@whatever ]
       // Array.prototype [ @@iterator ]
-      // %ForInIteratorPrototype%.next
       // Object.prototype.__defineGetter__
-      /^([%_]?)[A-Za-z][A-Za-z0-9/]*\1(\.[A-Za-z][A-Za-z0-9]*|\.__[a-z][A-Za-z0-9]*__| \[ @@[a-z][a-zA-Z]+ \])*\s*$/,
+      /^[A-Za-z][A-Za-z0-9/]*(\.[A-Za-z][A-Za-z0-9]*|\.__[a-z][A-Za-z0-9]*__| \[ @@[a-z][a-zA-Z]+ \])*\s*$/,
+
+      // _TypedArray_.prototype
+      // _NativeError_ [ @@whatever ]
+      /^_[A-Za-z][A-Za-z0-9/]*_(\.[A-Za-z][A-Za-z0-9]*|\.__[a-z][A-Za-z0-9]*__| \[ @@[a-z][a-zA-Z]+ \])*\s*$/,
+
+      // %ForInIteratorPrototype%.next
+      // %GeneratorFunction.prototype.prototype% [ @@toStringTag ]
+      /^%[A-Za-z][A-Za-z0-9/]*(\.[A-Za-z][A-Za-z0-9]*)*%(\.[A-Za-z][A-Za-z0-9]*|\.__[a-z][A-Za-z0-9]*__| \[ @@[a-z][a-zA-Z]+ \])*\s*$/,
     ].some(r => r.test(name));
 
     if (!nameMatches) {

--- a/test/lint.js
+++ b/test/lint.js
@@ -367,6 +367,9 @@ describe('linting whole program', () => {
           <emu-clause id="i10">
             <h1>_NativeError_ [ @@baz ] ( )</h1>
           </emu-clause>
+          <emu-clause id="i11">
+            <h1>%Foo.prototype%.bar ( )</h1>
+          </emu-clause>
       `);
     });
 


### PR DESCRIPTION
The current rule doesn't accept a dot inside the intrinsic name in header, but there are multiple intrinsics that has dots inside their names, such as `%GeneratorFunction.prototype.prototype%`.

This allows the solution (A) in https://github.com/tc39/ecma262/issues/3230