### PR TITLE
basic typechecking

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -776,7 +776,7 @@ table.lightweight-table th {
     background-color: rgba(249, 241, 172, 1);
   }
   100% {
-    background-color: rgba(249, 241, 172, 0)
+    background-color: rgba(249, 241, 172, 0);
   }
 }
 #spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {

--- a/filter-entities.js
+++ b/filter-entities.js
@@ -9,11 +9,17 @@
 let fs = require('fs');
 let entities = require('./entities.json');
 
-let transformed = Object.fromEntries(Object.entries(entities).map(([k, v]) => {
-  // whitespace, default-ignorable, combining characters, control characters
-  if (v.characters === '&' || v.characters === '<' || /\p{White_Space}|\p{DI}|\p{gc=M}|\p{gc=C}/u.test(v.characters)) {
-    return [k, null];
-  }
-  return [k, v.characters];
-}));
+let transformed = Object.fromEntries(
+  Object.entries(entities).map(([k, v]) => {
+    // whitespace, default-ignorable, combining characters, control characters
+    if (
+      v.characters === '&' ||
+      v.characters === '<' ||
+      /\p{White_Space}|\p{DI}|\p{gc=M}|\p{gc=C}/u.test(v.characters)
+    ) {
+      return [k, null];
+    }
+    return [k, v.characters];
+  })
+);
 fs.writeFileSync('./entities-processed.json', JSON.stringify(transformed), 'utf8');

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -34,7 +34,6 @@ export default class Algorithm extends Builder {
     context.inAlg = true;
     const { spec, node, clauseStack } = context;
 
-
     let emdTree: AlgorithmNode | null = null;
     let innerHTML;
     if ('ecmarkdownTree' in node) {

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -34,16 +34,23 @@ export default class Algorithm extends Builder {
     context.inAlg = true;
     const { spec, node, clauseStack } = context;
 
-    const innerHTML = node.innerHTML; // TODO use original slice, forward this from linter
 
     let emdTree: AlgorithmNode | null = null;
+    let innerHTML;
     if ('ecmarkdownTree' in node) {
       emdTree = (node as AlgorithmElementWithTree).ecmarkdownTree;
+      innerHTML = (node as AlgorithmElementWithTree).originalHtml;
     } else {
+      const location = spec.locate(node);
+      const source =
+        location?.source == null || location.endTag == null
+          ? node.innerHTML
+          : location.source.slice(location.startTag.endOffset, location.endTag.startOffset);
+      innerHTML = source;
       try {
-        emdTree = emd.parseAlgorithm(innerHTML);
+        emdTree = emd.parseAlgorithm(source);
         (node as AlgorithmElementWithTree).ecmarkdownTree = emdTree;
-        (node as AlgorithmElementWithTree).originalHtml = innerHTML;
+        (node as AlgorithmElementWithTree).originalHtml = source;
       } catch (e) {
         warnEmdFailure(spec.warn, node, e as SyntaxError);
       }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1964,4 +1964,3 @@ function isScriptNode(
 ): node is HTMLScriptElement {
   return node.nodeName.toLowerCase() === 'script';
 }
-

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -660,8 +660,7 @@ export default class Spec {
     if (!dom) {
       return;
     }
-    // the jsdom types are wrong
-    const loc = dom.nodeLocation(node) as unknown as ElementLocation;
+    const loc = dom.nodeLocation(node);
     if (loc) {
       // we can't just spread `loc` because not all properties are own/enumerable
       const out: ReturnType<Spec['locate']> = {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -7,9 +7,8 @@ import type {
   Production as GMDProduction,
 } from 'grammarkdown';
 import type { Context } from './Context';
-import type { AlgorithmBiblioEntry, ExportedBiblio, StepBiblioEntry, Type } from './Biblio';
+import type { ExportedBiblio, StepBiblioEntry } from './Biblio';
 import type { BuilderInterface } from './Builder';
-import type { AlgorithmElementWithTree } from './Algorithm';
 
 import * as path from 'path';
 import * as fs from 'fs';
@@ -47,12 +46,10 @@ import {
 import { lint } from './lint/lint';
 import { CancellationToken } from 'prex';
 import type { JSDOM } from 'jsdom';
-import type { OrderedListNode } from 'ecmarkdown';
 import { getProductions, rhsMatches, getLocationInGrammarFile } from './lint/utils';
 import type { AugmentedGrammarEle } from './Grammar';
-import { offsetToLineAndColumn } from './utils';
-import type { Expr, PathItem, Seq } from './expr-parser';
-import { parse as parseExpr, walk as walkExpr, isProsePart } from './expr-parser';
+import { zip } from './utils';
+import { typecheck } from './typechecker';
 
 const DRAFT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
   year: 'numeric',
@@ -534,7 +531,7 @@ export default class Spec {
 
     if (this.opts.lintSpec) {
       this.log('Checking types...');
-      this.typecheck();
+      typecheck(this);
     }
     this.log('Propagating effect annotations...');
     this.propagateEffects();
@@ -643,222 +640,6 @@ export default class Spec {
 
   // checks that AOs which do/don't return completion records are invoked appropriately
   // also checks that the appropriate number of arguments are passed
-  private typecheck() {
-    const isUnused = (t: Type) =>
-      t.kind === 'unused' ||
-      (t.kind === 'completion' &&
-        (t.completionType === 'abrupt' || t.typeOfValueIfNormal?.kind === 'unused'));
-    const AOs = this.biblio
-      .localEntries()
-      .filter(e => e.type === 'op' && e.signature?.return != null) as AlgorithmBiblioEntry[];
-    const onlyPerformed: Map<string, null | 'only performed' | 'top'> = new Map(
-      AOs.filter(e => !isUnused(e.signature!.return!)).map(a => [a.aoid, null])
-    );
-    const alwaysAssertedToBeNormal: Map<string, null | 'always asserted normal' | 'top'> = new Map(
-      // prettier-ignore
-      AOs
-        .filter(e => e.signature!.return!.kind === 'completion' && !e.skipGlobalChecks)
-        .map(a => [a.aoid, null])
-    );
-
-    // TODO strictly speaking this needs to be done in the namespace of the current algorithm
-    const opNames = this.biblio.getOpNames(this.namespace);
-
-    // TODO move declarations out of loop
-    for (const node of this.doc.querySelectorAll('emu-alg')) {
-      if (node.hasAttribute('example') || !('ecmarkdownTree' in node)) {
-        continue;
-      }
-      const tree = (node as AlgorithmElementWithTree).ecmarkdownTree;
-      if (tree == null) {
-        continue;
-      }
-      const originalHtml = (node as AlgorithmElementWithTree).originalHtml;
-
-      const expressionVisitor = (expr: Expr, path: PathItem[]) => {
-        if (expr.name !== 'call' && expr.name !== 'sdo-call') {
-          return;
-        }
-
-        const { callee, arguments: args } = expr;
-        if (!(callee.length === 1 && callee[0].name === 'text')) {
-          return;
-        }
-        const calleeName = callee[0].contents;
-
-        const warn = (message: string) => {
-          const { line, column } = offsetToLineAndColumn(
-            originalHtml,
-            callee[0].location.start.offset
-          );
-          this.warn({
-            type: 'contents',
-            ruleId: 'typecheck',
-            message,
-            node,
-            nodeRelativeLine: line,
-            nodeRelativeColumn: column,
-          });
-        };
-
-        const biblioEntry = this.biblio.byAoid(calleeName);
-        if (biblioEntry == null) {
-          if (!['toUppercase', 'toLowercase'].includes(calleeName)) {
-            // TODO make the spec not do this
-            warn(`could not find definition for ${calleeName}`);
-          }
-          return;
-        }
-
-        if (biblioEntry.kind === 'syntax-directed operation' && expr.name === 'call') {
-          warn(
-            `${calleeName} is a syntax-directed operation and should not be invoked like a regular call`
-          );
-        } else if (
-          biblioEntry.kind != null &&
-          biblioEntry.kind !== 'syntax-directed operation' &&
-          expr.name === 'sdo-call'
-        ) {
-          warn(`${calleeName} is not a syntax-directed operation but here is being invoked as one`);
-        }
-
-        if (biblioEntry.signature == null) {
-          return;
-        }
-        const min = biblioEntry.signature.parameters.length;
-        const max = min + biblioEntry.signature.optionalParameters.length;
-        if (args.length < min || args.length > max) {
-          const count = `${min}${min === max ? '' : `-${max}`}`;
-          // prettier-ignore
-          const message = `${calleeName} takes ${count} argument${count === '1' ? '' : 's'}, but this invocation passes ${args.length}`;
-          warn(message);
-        }
-
-        const { return: returnType } = biblioEntry.signature;
-        if (returnType == null) {
-          return;
-        }
-
-        const consumedAsCompletion = isConsumedAsCompletion(expr, path);
-
-        // checks elsewhere ensure that well-formed documents never have a union of completion and non-completion, so checking the first child suffices
-        // TODO: this is for 'a break completion or a throw completion', which is kind of a silly union; maybe address that in some other way?
-        const isCompletion =
-          returnType.kind === 'completion' ||
-          (returnType.kind === 'union' && returnType.types[0].kind === 'completion');
-        if (['Completion', 'ThrowCompletion', 'NormalCompletion'].includes(calleeName)) {
-          if (consumedAsCompletion) {
-            warn(
-              `${calleeName} clearly creates a Completion Record; it does not need to be marked as such, and it would not be useful to immediately unwrap its result`
-            );
-          }
-        } else if (isCompletion && !consumedAsCompletion) {
-          warn(`${calleeName} returns a Completion Record, but is not consumed as if it does`);
-        } else if (!isCompletion && consumedAsCompletion) {
-          warn(`${calleeName} does not return a Completion Record, but is consumed as if it does`);
-        }
-        if (returnType.kind === 'unused' && !isCalledAsPerform(expr, path, false)) {
-          warn(
-            `${calleeName} does not return a meaningful value and should only be invoked as \`Perform ${calleeName}(...).\``
-          );
-        }
-
-        if (onlyPerformed.has(calleeName) && onlyPerformed.get(calleeName) !== 'top') {
-          const old = onlyPerformed.get(calleeName);
-          const performed = isCalledAsPerform(expr, path, true);
-          if (!performed) {
-            onlyPerformed.set(calleeName, 'top');
-          } else if (old === null) {
-            onlyPerformed.set(calleeName, 'only performed');
-          }
-        }
-        if (
-          alwaysAssertedToBeNormal.has(calleeName) &&
-          alwaysAssertedToBeNormal.get(calleeName) !== 'top'
-        ) {
-          const old = alwaysAssertedToBeNormal.get(calleeName);
-          const asserted = isAssertedToBeNormal(expr, path);
-          if (!asserted) {
-            alwaysAssertedToBeNormal.set(calleeName, 'top');
-          } else if (old === null) {
-            alwaysAssertedToBeNormal.set(calleeName, 'always asserted normal');
-          }
-        }
-      };
-      const walkLines = (list: OrderedListNode) => {
-        for (const line of list.contents) {
-          const item = parseExpr(line.contents, opNames);
-          if (item.name === 'failure') {
-            const { line, column } = offsetToLineAndColumn(originalHtml, item.offset);
-            this.warn({
-              type: 'contents',
-              ruleId: 'expression-parsing',
-              message: item.message,
-              node,
-              nodeRelativeLine: line,
-              nodeRelativeColumn: column,
-            });
-          } else {
-            walkExpr(expressionVisitor, item);
-          }
-          if (line.sublist?.name === 'ol') {
-            walkLines(line.sublist);
-          }
-        }
-      };
-      walkLines(tree.contents);
-    }
-
-    for (const [aoid, state] of onlyPerformed) {
-      if (state !== 'only performed') {
-        continue;
-      }
-      const message = `${aoid} is only ever invoked with Perform, so it should return ~unused~ or a Completion Record which, if normal, contains ~unused~`;
-      const ruleId = 'perform-not-unused';
-      const biblioEntry = this.biblio.byAoid(aoid)!;
-      if (biblioEntry._node) {
-        this.spec.warn({
-          type: 'node',
-          ruleId,
-          message,
-          node: biblioEntry._node,
-        });
-      } else {
-        this.spec.warn({
-          type: 'global',
-          ruleId,
-          message,
-        });
-      }
-    }
-
-    for (const [aoid, state] of alwaysAssertedToBeNormal) {
-      if (state !== 'always asserted normal') {
-        continue;
-      }
-      if (aoid === 'AsyncGeneratorAwaitReturn') {
-        // TODO remove this when https://github.com/tc39/ecma262/issues/2412 is fixed
-        continue;
-      }
-      const message = `every call site of ${aoid} asserts the return value is a normal completion; it should be refactored to not return a completion record at all. if this AO is called in ways ecmarkup cannot analyze, add the "skip global checks" attribute to the header.`;
-      const ruleId = 'always-asserted-normal';
-      const biblioEntry = this.biblio.byAoid(aoid)!;
-      if (biblioEntry._node) {
-        this.spec.warn({
-          type: 'node',
-          ruleId,
-          message,
-          node: biblioEntry._node,
-        });
-      } else {
-        this.spec.warn({
-          type: 'global',
-          ruleId,
-          message,
-        });
-      }
-    }
-  }
 
   private toHTML() {
     const htmlEle = this.doc.documentElement;
@@ -2184,98 +1965,3 @@ function isScriptNode(
   return node.nodeName.toLowerCase() === 'script';
 }
 
-function parentSkippingBlankSpace(expr: Expr, path: PathItem[]): PathItem | null {
-  for (let pointer: Expr = expr, i = path.length - 1; i >= 0; pointer = path[i].parent, --i) {
-    const { parent } = path[i];
-    if (
-      parent.name === 'seq' &&
-      parent.items.every(
-        i => i === pointer || i.name === 'tag' || (i.name === 'text' && /^\s*$/.test(i.contents))
-      )
-    ) {
-      // if parent is just whitespace/tags around the call, walk up the tree further
-      continue;
-    }
-    return path[i];
-  }
-  return null;
-}
-
-function previousText(expr: Expr, path: PathItem[]): string | null {
-  const part = parentSkippingBlankSpace(expr, path);
-  if (part == null) {
-    return null;
-  }
-  const { parent, index } = part;
-  if (parent.name === 'seq') {
-    return textFromPreviousPart(parent, index);
-  }
-  return null;
-}
-
-function textFromPreviousPart(seq: Seq, index: number): string | null {
-  let prevIndex = index - 1;
-  let prev;
-  while (isProsePart((prev = seq.items[prevIndex]))) {
-    if (prev.name === 'text') {
-      return prev.contents;
-    } else if (prev.name === 'tag') {
-      --prevIndex;
-    } else {
-      break;
-    }
-  }
-  return null;
-}
-
-function isCalledAsPerform(expr: Expr, path: PathItem[], allowQuestion: boolean) {
-  const prev = previousText(expr, path);
-  return prev != null && (allowQuestion ? /\bperform ([?!]\s)?$/i : /\bperform $/i).test(prev);
-}
-
-function isAssertedToBeNormal(expr: Expr, path: PathItem[]) {
-  const prev = previousText(expr, path);
-  return prev != null && /\s!\s$/.test(prev);
-}
-
-function isConsumedAsCompletion(expr: Expr, path: PathItem[]) {
-  const part = parentSkippingBlankSpace(expr, path);
-  if (part == null) {
-    return false;
-  }
-  const { parent, index } = part;
-  if (parent.name === 'seq') {
-    // if the previous text ends in `! ` or `? `, this is a completion
-    const text = textFromPreviousPart(parent, index);
-    if (text != null && /[!?]\s$/.test(text)) {
-      return true;
-    }
-  } else if (parent.name === 'call' && index === 0 && parent.arguments.length === 1) {
-    // if this is `Completion(Expr())`, this is a completion
-    const parts = parent.callee;
-    if (parts.length === 1 && parts[0].name === 'text' && parts[0].contents === 'Completion') {
-      return true;
-    }
-  }
-  return false;
-}
-
-function* zip<A, B>(as: Iterable<A>, bs: Iterable<B>): Iterable<[A, B]> {
-  const iterA = as[Symbol.iterator]();
-  const iterB = bs[Symbol.iterator]();
-
-  while (true) {
-    const iterResultA = iterA.next();
-    const iterResultB = iterB.next();
-
-    if (iterResultA.done !== iterResultB.done) {
-      throw new Error('zipping iterators which ended at different times');
-    }
-
-    if (iterResultA.done) {
-      break;
-    }
-
-    yield [iterResultA.value, iterResultB.value];
-  }
-}

--- a/src/expr-parser.ts
+++ b/src/expr-parser.ts
@@ -54,7 +54,7 @@ export type Seq = {
   name: 'seq';
   items: NonSeq[];
 };
-type NonSeq = ProsePart | List | Record | RecordSpec | Call | SDOCall | Paren | Figure;
+export type NonSeq = ProsePart | List | Record | RecordSpec | Call | SDOCall | Paren | Figure;
 export type Expr = NonSeq | Seq;
 type Failure = { name: 'failure'; message: string; offset: number };
 

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -38,7 +38,7 @@ export function collectAlgorithmDiagnostics(
   report: (e: Warning) => void,
   spec: Spec,
   mainSource: string,
-  algorithms: { element: Element; tree?: EcmarkdownNode, source?: string }[]
+  algorithms: { element: Element; tree?: EcmarkdownNode; source?: string }[]
 ) {
   for (const algorithm of algorithms) {
     const element = algorithm.element;

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -38,7 +38,7 @@ export function collectAlgorithmDiagnostics(
   report: (e: Warning) => void,
   spec: Spec,
   mainSource: string,
-  algorithms: { element: Element; tree?: EcmarkdownNode }[]
+  algorithms: { element: Element; tree?: EcmarkdownNode, source?: string }[]
 ) {
   for (const algorithm of algorithms) {
     const element = algorithm.element;
@@ -68,6 +68,8 @@ export function collectAlgorithmDiagnostics(
       location.startTag.endOffset,
       location.endTag.startOffset
     );
+    algorithm.source = algorithmSource;
+
     let tree;
     try {
       tree = parseAlgorithm(algorithmSource);

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -9,7 +9,7 @@ type CollectNodesReturnType =
       mainGrammar: { element: Element; source: string }[];
       sdos: { grammar: Element; alg: Element }[];
       earlyErrors: { grammar: Element; lists: HTMLUListElement[] }[];
-      algorithms: { element: Element; tree?: AlgorithmNode, source?: string }[];
+      algorithms: { element: Element; tree?: AlgorithmNode; source?: string }[];
     }
   | {
       success: false;

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -9,7 +9,7 @@ type CollectNodesReturnType =
       mainGrammar: { element: Element; source: string }[];
       sdos: { grammar: Element; alg: Element }[];
       earlyErrors: { grammar: Element; lists: HTMLUListElement[] }[];
-      algorithms: { element: Element; tree?: AlgorithmNode }[];
+      algorithms: { element: Element; tree?: AlgorithmNode, source?: string }[];
     }
   | {
       success: false;

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -86,7 +86,7 @@ export async function lint(
     if ('tree' in pair) {
       const element = pair.element as AlgorithmElementWithTree;
       element.ecmarkdownTree = pair.tree ?? null;
-      element.originalHtml = pair.element.innerHTML;
+      element.originalHtml = pair.source ?? pair.element.innerHTML;
     }
   }
 }

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -600,8 +600,7 @@ function serialize(type: Type): string {
     case 'integer':
     case 'non-negative integer':
     case 'null':
-    case 'undefined':
-    case 'string': {
+    case 'undefined': {
       return type.kind;
     }
     case 'concrete string':
@@ -623,6 +622,9 @@ function serialize(type: Type): string {
     }
     case 'boolean': {
       return 'Boolean';
+    }
+    case 'string': {
+      return 'String';
     }
     case 'number': {
       return 'Number';

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -762,7 +762,7 @@ function typeFromExprType(type: BiblioType): Type {
       if (text === 'an ECMAScript language value' || text === 'ECMAScript language values') {
         return { kind: 'ES value' };
       }
-      if (text === 'a string' || text === 'strings') {
+      if (text === 'a String' || text === 'Strings') {
         return { kind: 'string' };
       }
       if (text === 'a Number' || text === 'Numbers') {

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -121,7 +121,7 @@ export function typecheck(spec: Spec) {
               items[0].location.start.offset
             );
             const argDescriptor =
-              argType.kind.startsWith('concrete') || argType.kind === 'enum value'
+              argType.kind.startsWith('concrete') || argType.kind === 'enum value' || argType.kind === 'null' || argType.kind === 'undefined'
                 ? `(${serialize(argType)})`
                 : `type (${serialize(argType)})`;
 
@@ -391,6 +391,7 @@ type Type =
   | { kind: 'bigint' }
   | { kind: 'boolean' }
   | { kind: 'null' }
+  | { kind: 'undefined' }
   | { kind: 'concrete string'; value: string }
   | { kind: 'concrete number'; value: string }
   | { kind: 'concrete bigint'; value: string }
@@ -412,6 +413,8 @@ const simpleKinds = new Set<Type['kind']>([
   'integral number',
   'bigint',
   'boolean',
+  'null',
+  'undefined',
 ]);
 
 const dominateGraph: Partial<Record<Type['kind'], Type['kind'][]>> = {
@@ -426,6 +429,8 @@ const dominateGraph: Partial<Record<Type['kind'], Type['kind'][]>> = {
     'integral number',
     'bigint',
     'boolean',
+    'null',
+    'undefined',
     'concrete string',
     'concrete number',
     'concrete bigint',
@@ -586,6 +591,7 @@ function serialize(type: Type): string {
     case 'integer':
     case 'non-negative integer':
     case 'null':
+    case 'undefined':
     case 'string': {
       return type.kind;
     }
@@ -696,6 +702,8 @@ export function typeFromExpr(expr: Expr, biblio: Biblio): Type {
         const text = expr.contents[0].contents;
         if (text === 'null') {
           return { kind: 'null' };
+        } else if (text === 'undefined') {
+          return { kind: 'undefined' };
         } else if (text === 'true') {
           return { kind: 'concrete boolean', value: true };
         } else if (text === 'false') {
@@ -762,6 +770,12 @@ function typeFromExprType(type: BiblioType): Type {
       }
       if (text === 'a non-negative integer' || text === 'non-negative integers') {
         return { kind: 'non-negative integer' };
+      }
+      if (text === '*null*') {
+        return { kind: 'null' };
+      }
+      if (text === '*undefined*') {
+        return { kind: 'undefined' };
       }
       break;
     }

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -604,7 +604,6 @@ function serialize(type: Type): string {
       return type.kind;
     }
     case 'concrete string':
-    case 'concrete bigint':
     case 'concrete real': {
       return type.value;
     }
@@ -616,6 +615,9 @@ function serialize(type: Type): string {
     }
     case 'concrete number': {
       return `*${type.value}*<sub>𝔽</sub>`;
+    }
+    case 'concrete bigint': {
+      return `*${type.value}*<sub>ℤ</sub>`;
     }
     case 'ES value': {
       return 'ECMAScript language value';
@@ -772,6 +774,9 @@ function typeFromExprType(type: BiblioType): Type {
       }
       if (text === 'a Boolean' || text === 'Booleans') {
         return { kind: 'boolean' };
+      }
+      if (text === 'a BigInt' || text === 'BigInts') {
+        return { kind: 'bigint' };
       }
       if (text === 'an integral Number' || text === 'integral Numbers') {
         return { kind: 'integral number' };

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -585,9 +585,11 @@ function serialize(type: Type): string {
     }
     case 'concrete string':
     case 'concrete bigint':
-    case 'concrete real':
-    case 'enum value': {
+    case 'concrete real': {
       return type.value;
+    }
+    case 'enum value': {
+      return `~${type.value}~`;
     }
     case 'concrete number': {
       return `*${type.value}*<sub>𝔽</sub>`;
@@ -673,7 +675,7 @@ export function typeFromExpr(expr: Expr, biblio: Biblio): Type {
     }
     case 'tilde': {
       if (expr.contents.length === 1 && expr.contents[0].name === 'text') {
-        return { kind: 'enum value', value: `~${expr.contents[0].contents}~` };
+        return { kind: 'enum value', value: expr.contents[0].contents };
       }
       break;
     }
@@ -722,7 +724,7 @@ function typeFromExprType(type: BiblioType): Type {
         return { kind: 'concrete string', value: text.slice(1, -1) };
       }
       if (text.startsWith('~') && text.endsWith('~')) {
-        return { kind: 'enum value', value: text };
+        return { kind: 'enum value', value: text.slice(1, -1) };
       }
       if (text === 'a string' || text === 'strings') {
         return { kind: 'string' };

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -1,0 +1,300 @@
+import { OrderedListNode } from 'ecmarkdown';
+import type { AlgorithmElementWithTree } from './Algorithm';
+import type { AlgorithmBiblioEntry, Type } from './Biblio';
+import type Spec from './Spec';
+import type { Expr, PathItem } from './expr-parser';
+import { walk as walkExpr, parse as parseExpr, isProsePart, Seq } from './expr-parser';
+import { offsetToLineAndColumn } from './utils';
+
+export function typecheck(spec: Spec) {
+  const isUnused = (t: Type) =>
+    t.kind === 'unused' ||
+    (t.kind === 'completion' &&
+      (t.completionType === 'abrupt' || t.typeOfValueIfNormal?.kind === 'unused'));
+  const AOs = spec.biblio
+    .localEntries()
+    .filter(e => e.type === 'op' && e.signature?.return != null) as AlgorithmBiblioEntry[];
+  const onlyPerformed: Map<string, null | 'only performed' | 'top'> = new Map(
+    AOs.filter(e => !isUnused(e.signature!.return!)).map(a => [a.aoid, null])
+  );
+  const alwaysAssertedToBeNormal: Map<string, null | 'always asserted normal' | 'top'> = new Map(
+    // prettier-ignore
+    AOs
+      .filter(e => e.signature!.return!.kind === 'completion' && !e.skipGlobalChecks)
+      .map(a => [a.aoid, null])
+  );
+
+  // TODO strictly speaking this needs to be done in the namespace of the current algorithm
+  const opNames = spec.biblio.getOpNames(spec.namespace);
+
+  // TODO move declarations out of loop
+  for (const node of spec.doc.querySelectorAll('emu-alg')) {
+    if (node.hasAttribute('example') || !('ecmarkdownTree' in node)) {
+      continue;
+    }
+    const tree = (node as AlgorithmElementWithTree).ecmarkdownTree;
+    if (tree == null) {
+      continue;
+    }
+    const originalHtml = (node as AlgorithmElementWithTree).originalHtml;
+
+    const expressionVisitor = (expr: Expr, path: PathItem[]) => {
+      if (expr.name !== 'call' && expr.name !== 'sdo-call') {
+        return;
+      }
+
+      const { callee, arguments: args } = expr;
+      if (!(callee.length === 1 && callee[0].name === 'text')) {
+        return;
+      }
+      const calleeName = callee[0].contents;
+
+      const warn = (message: string) => {
+        const { line, column } = offsetToLineAndColumn(
+          originalHtml,
+          callee[0].location.start.offset
+        );
+        spec.warn({
+          type: 'contents',
+          ruleId: 'typecheck',
+          message,
+          node,
+          nodeRelativeLine: line,
+          nodeRelativeColumn: column,
+        });
+      };
+
+      const biblioEntry = spec.biblio.byAoid(calleeName);
+      if (biblioEntry == null) {
+        if (!['toUppercase', 'toLowercase'].includes(calleeName)) {
+          // TODO make the spec not do this
+          warn(`could not find definition for ${calleeName}`);
+        }
+        return;
+      }
+
+      if (biblioEntry.kind === 'syntax-directed operation' && expr.name === 'call') {
+        warn(
+          `${calleeName} is a syntax-directed operation and should not be invoked like a regular call`
+        );
+      } else if (
+        biblioEntry.kind != null &&
+        biblioEntry.kind !== 'syntax-directed operation' &&
+        expr.name === 'sdo-call'
+      ) {
+        warn(`${calleeName} is not a syntax-directed operation but here is being invoked as one`);
+      }
+
+      if (biblioEntry.signature == null) {
+        return;
+      }
+      const min = biblioEntry.signature.parameters.length;
+      const max = min + biblioEntry.signature.optionalParameters.length;
+      if (args.length < min || args.length > max) {
+        const count = `${min}${min === max ? '' : `-${max}`}`;
+        // prettier-ignore
+        const message = `${calleeName} takes ${count} argument${count === '1' ? '' : 's'}, but this invocation passes ${args.length}`;
+        warn(message);
+      }
+
+      const { return: returnType } = biblioEntry.signature;
+      if (returnType == null) {
+        return;
+      }
+
+      const consumedAsCompletion = isConsumedAsCompletion(expr, path);
+
+      // checks elsewhere ensure that well-formed documents never have a union of completion and non-completion, so checking the first child suffices
+      // TODO: this is for 'a break completion or a throw completion', which is kind of a silly union; maybe address that in some other way?
+      const isCompletion =
+        returnType.kind === 'completion' ||
+        (returnType.kind === 'union' && returnType.types[0].kind === 'completion');
+      if (['Completion', 'ThrowCompletion', 'NormalCompletion'].includes(calleeName)) {
+        if (consumedAsCompletion) {
+          warn(
+            `${calleeName} clearly creates a Completion Record; it does not need to be marked as such, and it would not be useful to immediately unwrap its result`
+          );
+        }
+      } else if (isCompletion && !consumedAsCompletion) {
+        warn(`${calleeName} returns a Completion Record, but is not consumed as if it does`);
+      } else if (!isCompletion && consumedAsCompletion) {
+        warn(`${calleeName} does not return a Completion Record, but is consumed as if it does`);
+      }
+      if (returnType.kind === 'unused' && !isCalledAsPerform(expr, path, false)) {
+        warn(
+          `${calleeName} does not return a meaningful value and should only be invoked as \`Perform ${calleeName}(...).\``
+        );
+      }
+
+      if (onlyPerformed.has(calleeName) && onlyPerformed.get(calleeName) !== 'top') {
+        const old = onlyPerformed.get(calleeName);
+        const performed = isCalledAsPerform(expr, path, true);
+        if (!performed) {
+          onlyPerformed.set(calleeName, 'top');
+        } else if (old === null) {
+          onlyPerformed.set(calleeName, 'only performed');
+        }
+      }
+      if (
+        alwaysAssertedToBeNormal.has(calleeName) &&
+        alwaysAssertedToBeNormal.get(calleeName) !== 'top'
+      ) {
+        const old = alwaysAssertedToBeNormal.get(calleeName);
+        const asserted = isAssertedToBeNormal(expr, path);
+        if (!asserted) {
+          alwaysAssertedToBeNormal.set(calleeName, 'top');
+        } else if (old === null) {
+          alwaysAssertedToBeNormal.set(calleeName, 'always asserted normal');
+        }
+      }
+    };
+    const walkLines = (list: OrderedListNode) => {
+      for (const line of list.contents) {
+        const item = parseExpr(line.contents, opNames);
+        if (item.name === 'failure') {
+          const { line, column } = offsetToLineAndColumn(originalHtml, item.offset);
+          spec.warn({
+            type: 'contents',
+            ruleId: 'expression-parsing',
+            message: item.message,
+            node,
+            nodeRelativeLine: line,
+            nodeRelativeColumn: column,
+          });
+        } else {
+          walkExpr(expressionVisitor, item);
+        }
+        if (line.sublist?.name === 'ol') {
+          walkLines(line.sublist);
+        }
+      }
+    };
+    walkLines(tree.contents);
+  }
+
+  for (const [aoid, state] of onlyPerformed) {
+    if (state !== 'only performed') {
+      continue;
+    }
+    const message = `${aoid} is only ever invoked with Perform, so it should return ~unused~ or a Completion Record which, if normal, contains ~unused~`;
+    const ruleId = 'perform-not-unused';
+    const biblioEntry = spec.biblio.byAoid(aoid)!;
+    if (biblioEntry._node) {
+      spec.spec.warn({
+        type: 'node',
+        ruleId,
+        message,
+        node: biblioEntry._node,
+      });
+    } else {
+      spec.spec.warn({
+        type: 'global',
+        ruleId,
+        message,
+      });
+    }
+  }
+
+  for (const [aoid, state] of alwaysAssertedToBeNormal) {
+    if (state !== 'always asserted normal') {
+      continue;
+    }
+    if (aoid === 'AsyncGeneratorAwaitReturn') {
+      // TODO remove this when https://github.com/tc39/ecma262/issues/2412 is fixed
+      continue;
+    }
+    const message = `every call site of ${aoid} asserts the return value is a normal completion; it should be refactored to not return a completion record at all. if this AO is called in ways ecmarkup cannot analyze, add the "skip global checks" attribute to the header.`;
+    const ruleId = 'always-asserted-normal';
+    const biblioEntry = spec.biblio.byAoid(aoid)!;
+    if (biblioEntry._node) {
+      spec.spec.warn({
+        type: 'node',
+        ruleId,
+        message,
+        node: biblioEntry._node,
+      });
+    } else {
+      spec.spec.warn({
+        type: 'global',
+        ruleId,
+        message,
+      });
+    }
+  }
+}
+
+function isCalledAsPerform(expr: Expr, path: PathItem[], allowQuestion: boolean) {
+  const prev = previousText(expr, path);
+  return prev != null && (allowQuestion ? /\bperform ([?!]\s)?$/i : /\bperform $/i).test(prev);
+}
+
+function isAssertedToBeNormal(expr: Expr, path: PathItem[]) {
+  const prev = previousText(expr, path);
+  return prev != null && /\s!\s$/.test(prev);
+}
+
+function isConsumedAsCompletion(expr: Expr, path: PathItem[]) {
+  const part = parentSkippingBlankSpace(expr, path);
+  if (part == null) {
+    return false;
+  }
+  const { parent, index } = part;
+  if (parent.name === 'seq') {
+    // if the previous text ends in `! ` or `? `, this is a completion
+    const text = textFromPreviousPart(parent, index);
+    if (text != null && /[!?]\s$/.test(text)) {
+      return true;
+    }
+  } else if (parent.name === 'call' && index === 0 && parent.arguments.length === 1) {
+    // if this is `Completion(Expr())`, this is a completion
+    const parts = parent.callee;
+    if (parts.length === 1 && parts[0].name === 'text' && parts[0].contents === 'Completion') {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parentSkippingBlankSpace(expr: Expr, path: PathItem[]): PathItem | null {
+  for (let pointer: Expr = expr, i = path.length - 1; i >= 0; pointer = path[i].parent, --i) {
+    const { parent } = path[i];
+    if (
+      parent.name === 'seq' &&
+      parent.items.every(
+        i => i === pointer || i.name === 'tag' || (i.name === 'text' && /^\s*$/.test(i.contents))
+      )
+    ) {
+      // if parent is just whitespace/tags around the call, walk up the tree further
+      continue;
+    }
+    return path[i];
+  }
+  return null;
+}
+
+function previousText(expr: Expr, path: PathItem[]): string | null {
+  const part = parentSkippingBlankSpace(expr, path);
+  if (part == null) {
+    return null;
+  }
+  const { parent, index } = part;
+  if (parent.name === 'seq') {
+    return textFromPreviousPart(parent, index);
+  }
+  return null;
+}
+
+function textFromPreviousPart(seq: Seq, index: number): string | null {
+  let prevIndex = index - 1;
+  let prev;
+  while (isProsePart((prev = seq.items[prevIndex]))) {
+    if (prev.name === 'text') {
+      return prev.contents;
+    } else if (prev.name === 'tag') {
+      --prevIndex;
+    } else {
+      break;
+    }
+  }
+  return null;
+}

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -617,7 +617,9 @@ function serialize(type: Type): string {
     case 'undefined': {
       return type.kind;
     }
-    case 'concrete string':
+    case 'concrete string': {
+      return `"${type.value}"`;
+    }
     case 'concrete real': {
       return type.value;
     }
@@ -737,7 +739,7 @@ export function typeFromExpr(expr: Expr, biblio: Biblio): Type {
         } else if (text === 'false') {
           return { kind: 'concrete boolean', value: false };
         } else if (text.startsWith('"') && text.endsWith('"')) {
-          return { kind: 'concrete string', value: text };
+          return { kind: 'concrete string', value: text.slice(1, -1) };
         }
       }
 

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -121,7 +121,10 @@ export function typecheck(spec: Spec) {
               items[0].location.start.offset
             );
             const argDescriptor =
-              argType.kind.startsWith('concrete') || argType.kind === 'enum value' || argType.kind === 'null' || argType.kind === 'undefined'
+              argType.kind.startsWith('concrete') ||
+              argType.kind === 'enum value' ||
+              argType.kind === 'null' ||
+              argType.kind === 'undefined'
                 ? `(${serialize(argType)})`
                 : `type (${serialize(argType)})`;
 
@@ -483,7 +486,13 @@ function dominates(a: Type, b: Type): boolean {
   }
   if (
     a.kind === b.kind &&
-    ['concrete string', 'concrete number', 'concrete bigint', 'concrete boolean', 'enum value'].includes(a.kind)
+    [
+      'concrete string',
+      'concrete number',
+      'concrete bigint',
+      'concrete boolean',
+      'enum value',
+    ].includes(a.kind)
   ) {
     // @ts-expect-error TS is not quite smart enough for this
     return a.value === b.value;

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -750,6 +750,9 @@ function typeFromExprType(type: BiblioType): Type {
       if (text.startsWith('~') && text.endsWith('~')) {
         return { kind: 'enum value', value: text.slice(1, -1) };
       }
+      if (text === 'an ECMAScript language value' || text === 'ECMAScript language values') {
+        return { kind: 'ES value' };
+      }
       if (text === 'a string' || text === 'strings') {
         return { kind: 'string' };
       }

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -131,19 +131,19 @@ export function typecheck(spec: Spec) {
             let hint = '';
             if (argType.kind === 'concrete number' && dominates({ kind: 'real' }, paramType)) {
               hint =
-                '\nhint: you passed an ES number, but this position takes a mathematical value';
+                '\nhint: you passed an ES language Number, but this position takes a mathematical value';
             } else if (
               argType.kind === 'concrete real' &&
               dominates({ kind: 'number' }, paramType)
             ) {
               hint =
-                '\nhint: you passed a real number, but this position takes an ES language Number';
+                '\nhint: you passed a mathematical value, but this position takes an ES language Number';
             } else if (
               argType.kind === 'concrete real' &&
               dominates({ kind: 'bigint' }, paramType)
             ) {
               hint =
-                '\nhint: you passed a real number, but this position takes an ES language BigInt';
+                '\nhint: you passed a mathematical value, but this position takes an ES language BigInt';
             }
 
             spec.warn({

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -867,6 +867,9 @@ function typeFromExprType(type: BiblioType): Type {
       if (text === 'a positive integer' || text === 'positive integers') {
         return { kind: 'positive integer' };
       }
+      if (text === 'a time value' || text === 'time values') {
+        return { kind: 'union', of: [ { kind: 'integral number' }, { kind: 'concrete number', value: 0/0 } ] };
+      }
       if (text === '*null*') {
         return { kind: 'null' };
       }

--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -428,7 +428,13 @@ const dominateGraph: Partial<Record<Type['kind'], Type['kind'][]>> = {
   // @ts-expect-error TS does not know about __proto__
   __proto__: null,
   record: ['completion'],
-  real: ['integer', 'non-negative integer', 'negative integer', 'positive integer', 'concrete real'],
+  real: [
+    'integer',
+    'non-negative integer',
+    'negative integer',
+    'positive integer',
+    'concrete real',
+  ],
   integer: ['non-negative integer', 'negative integer', 'positive integer'],
   'non-negative integer': ['positive integer'],
   'ES value': [
@@ -630,7 +636,7 @@ function serialize(type: Type): string {
       return `~${type.value}~`;
     }
     case 'concrete number': {
-      if (Object.is(type.value, 0/0)) {
+      if (Object.is(type.value, 0 / 0)) {
         return '*NaN*';
       }
       let repr;
@@ -764,7 +770,7 @@ export function typeFromExpr(expr: Expr, biblio: Biblio): Type {
         } else if (text === 'undefined') {
           return { kind: 'undefined' };
         } else if (text === 'NaN') {
-          return { kind: 'concrete number', value: 0/0 };
+          return { kind: 'concrete number', value: 0 / 0 };
         } else if (text === 'true') {
           return { kind: 'concrete boolean', value: true };
         } else if (text === 'false') {
@@ -829,7 +835,7 @@ function typeFromExprType(type: BiblioType): Type {
         return { kind: 'concrete number', value };
       }
       if (text === '*NaN*') {
-        return { kind: 'concrete number', value: 0/0 };
+        return { kind: 'concrete number', value: 0 / 0 };
       }
       if (text.startsWith('*') && text.endsWith('*<sub>ℤ</sub>')) {
         return { kind: 'concrete bigint', value: BigInt(text.slice(1, -14)) };
@@ -868,7 +874,10 @@ function typeFromExprType(type: BiblioType): Type {
         return { kind: 'positive integer' };
       }
       if (text === 'a time value' || text === 'time values') {
-        return { kind: 'union', of: [ { kind: 'integral number' }, { kind: 'concrete number', value: 0/0 } ] };
+        return {
+          kind: 'union',
+          of: [{ kind: 'integral number' }, { kind: 'concrete number', value: 0 / 0 }],
+        };
       }
       if (text === '*null*') {
         return { kind: 'null' };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -293,7 +293,11 @@ export function doesEffectPropagateToParent(node: Element, effect: string) {
   return true;
 }
 
-export function* zip<A, B>(as: Iterable<A>, bs: Iterable<B>): Iterable<[A, B]> {
+export function* zip<A, B>(
+  as: Iterable<A>,
+  bs: Iterable<B>,
+  allowMismatchedLengths = false
+): Iterable<[A, B]> {
   const iterA = as[Symbol.iterator]();
   const iterB = bs[Symbol.iterator]();
 
@@ -302,6 +306,14 @@ export function* zip<A, B>(as: Iterable<A>, bs: Iterable<B>): Iterable<[A, B]> {
     const iterResultB = iterB.next();
 
     if (iterResultA.done !== iterResultB.done) {
+      if (allowMismatchedLengths) {
+        if (iterResultA.done) {
+          iterB.return?.();
+        } else {
+          iterA.return?.();
+        }
+        break;
+      }
       throw new Error('zipping iterators which ended at different times');
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -292,3 +292,23 @@ export function doesEffectPropagateToParent(node: Element, effect: string) {
   }
   return true;
 }
+
+export function* zip<A, B>(as: Iterable<A>, bs: Iterable<B>): Iterable<[A, B]> {
+  const iterA = as[Symbol.iterator]();
+  const iterB = bs[Symbol.iterator]();
+
+  while (true) {
+    const iterResultA = iterA.next();
+    const iterResultB = iterB.next();
+
+    if (iterResultA.done !== iterResultB.done) {
+      throw new Error('zipping iterators which ended at different times');
+    }
+
+    if (iterResultA.done) {
+      break;
+    }
+
+    yield [iterResultA.value, iterResultB.value];
+  }
+}

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1491,6 +1491,12 @@ describe('type system', () => {
 
     await assertNoTypeError('a List of strings', '« »');
   });
+
+  it('unknown types', async () => {
+    await assertNoTypeError('a Foo', 'something');
+    await assertNoTypeError('a Foo', '42');
+    await assertNoTypeError('an integer', 'something');
+  });
 });
 
 describe('error location', () => {

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1492,3 +1492,29 @@ describe('type system', () => {
     await assertNoTypeError('a List of strings', '« »');
   });
 });
+
+describe('error location', () => {
+  it('handles entities', async () => {
+    await assertLint(
+      positioned`
+        <emu-clause id="example" type="abstract operation">
+          <h1>
+            Example (
+              _x_: a List of integers,
+              _y_: an integer,
+            ): ~unused~
+          </h1>
+          <dl class="header"></dl>
+        </emu-clause>
+        <emu-alg>
+          1. Perform Example(&laquo; 0 &raquo;, ${M}~enum~).
+        </emu-alg>
+      `,
+      {
+        ruleId: 'typecheck',
+        nodeType: 'emu-alg',
+        message: 'argument (~enum~) does not look plausibly assignable to parameter type (integer)',
+      }
+    );
+  });
+});

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1229,6 +1229,7 @@ describe('type system', () => {
     );
 
     await assertNoTypeError('~sync~ or ~async~', '~sync~');
+    await assertNoTypeError('~sync~ or ~async~', '~async~');
   });
 
   it('boolean', async () => {

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1209,7 +1209,7 @@ describe('type system', () => {
           <h1>
             Example (
               arg: ${paramType}
-            )
+            ): ~unused~
           </h1>
           <dl class="header"></dl>
         </emu-clause>

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1316,7 +1316,7 @@ describe('type system', () => {
       'a BigInt',
       '5',
       'argument (5) does not look plausibly assignable to parameter type (BigInt)\n' +
-        'hint: you passed a real number, but this position takes an ES language BigInt'
+        'hint: you passed a mathematical value, but this position takes an ES language BigInt'
     );
 
     await assertTypeError(
@@ -1363,14 +1363,14 @@ describe('type system', () => {
       'a mathematical value',
       '*5*<sub>𝔽</sub>',
       'argument (*5*<sub>𝔽</sub>) does not look plausibly assignable to parameter type (mathematical value)\n' +
-        'hint: you passed an ES number, but this position takes a mathematical value'
+        'hint: you passed an ES language Number, but this position takes a mathematical value'
     );
 
     await assertTypeError(
       'an integral Number',
       '5',
       'argument (5) does not look plausibly assignable to parameter type (integral Number)\n' +
-        'hint: you passed a real number, but this position takes an ES language Number'
+        'hint: you passed a mathematical value, but this position takes an ES language Number'
     );
   });
 

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1404,6 +1404,25 @@ describe('type system', () => {
     );
   });
 
+  it('time value', async () => {
+    await assertTypeError(
+      'a time value',
+      '~enum-value~',
+      'argument (~enum-value~) does not look plausibly assignable to parameter type (integral Number or *NaN*)'
+    );
+
+    await assertTypeError(
+      'a time value',
+      '5',
+      'argument (5) does not look plausibly assignable to parameter type (integral Number or *NaN*)\n' +
+        'hint: you passed a mathematical value, but this position takes an ES language Number'
+    );
+
+    await assertNoTypeError('a time value', '*2*<sub>𝔽</sub>');
+    await assertNoTypeError('a time value', '*-2*<sub>𝔽</sub>');
+    await assertNoTypeError('a time value', '*NaN*');
+  });
+
   it('ES language value', async () => {
     await assertTypeError(
       'an ECMAScript language value',

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1247,6 +1247,36 @@ describe('type system', () => {
     await assertNoTypeError('a Boolean', '*false*');
   });
 
+  it('null/undefined', async () => {
+    await assertTypeError(
+      '*null*',
+      '*undefined*',
+      'argument (undefined) does not look plausibly assignable to parameter type (null)'
+    );
+    await assertTypeError(
+      'a Boolean or *null*',
+      '*undefined*',
+      'argument (undefined) does not look plausibly assignable to parameter type (Boolean or null)'
+    );
+    await assertTypeError(
+      '*undefined*',
+      '*null*',
+      'argument (null) does not look plausibly assignable to parameter type (undefined)'
+    );
+    await assertTypeError(
+      'a Boolean or *undefined*',
+      '*null*',
+      'argument (null) does not look plausibly assignable to parameter type (Boolean or undefined)'
+    );
+
+    await assertNoTypeError('an ECMAScript language value', '*null*');
+    await assertNoTypeError('an ECMAScript language value', '*undefined*');
+    await assertNoTypeError('*null* or *undefined*', '*null*');
+    await assertNoTypeError('*null* or *undefined*', '*undefined*');
+    await assertNoTypeError('a Boolean or *null*', '*null*');
+    await assertNoTypeError('a Boolean or *undefined*', '*undefined*');
+  });
+
   it('number', async () => {
     await assertTypeError(
       'an integer',

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1543,6 +1543,19 @@ describe('type system', () => {
     await assertNoTypeError('0 or 1', '1');
   });
 
+  it('strings', async () => {
+    await assertTypeError(
+      '"type"',
+      '*"value"*',
+      'argument ("value") does not look plausibly assignable to parameter type ("type")'
+    );
+
+    await assertNoTypeError('"a"', '*"a"*');
+    await assertNoTypeError('"b"', '*"b"*');
+    await assertNoTypeError('"a" or "b"', '*"a"*');
+    await assertNoTypeError('"a" or "b"', '*"b"*');
+  });
+
   it('unknown types', async () => {
     await assertNoTypeError('a Foo', 'something');
     await assertNoTypeError('a Foo', '42');

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1311,6 +1311,23 @@ describe('type system', () => {
     await assertNoTypeError('a Boolean or *undefined*', '*undefined*');
   });
 
+  it('bigint', async () => {
+    await assertTypeError(
+      'a BigInt',
+      '5',
+      'argument (5) does not look plausibly assignable to parameter type (BigInt)\n' +
+        'hint: you passed a real number, but this position takes an ES language BigInt'
+    );
+
+    await assertTypeError(
+      'an integer',
+      '*5*<sub>ℤ</sub>',
+      'argument (*5*<sub>ℤ</sub>) does not look plausibly assignable to parameter type (integer)'
+    );
+
+    await assertNoTypeError('a BigInt', '*5*<sub>ℤ</sub>');
+  });
+
   it('number', async () => {
     await assertTypeError(
       'an integer',

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1433,16 +1433,16 @@ describe('type system', () => {
     `);
 
     await assertTypeError(
-      'a string',
+      'a String',
       'ReturnsNumber()',
-      'argument type (Number) does not look plausibly assignable to parameter type (string)',
+      'argument type (Number) does not look plausibly assignable to parameter type (String)',
       [biblio]
     );
 
     await assertTypeError(
-      'a string',
+      'a String',
       '! ReturnsCompletionOfNumber()',
-      'argument type (Number) does not look plausibly assignable to parameter type (string)',
+      'argument type (Number) does not look plausibly assignable to parameter type (String)',
       [biblio]
     );
 
@@ -1455,7 +1455,7 @@ describe('type system', () => {
     let biblio = await getBiblio(`
       <emu-clause id="sec-returns-number" type="abstract operation">
         <h1>
-          ReturnsListOfNumberOrString (): a List of either Numbers or strings
+          ReturnsListOfNumberOrString (): a List of either Numbers or Strings
         </h1>
         <dl class="header"></dl>
         <emu-alg>
@@ -1467,29 +1467,29 @@ describe('type system', () => {
     await assertTypeError(
       'an integer',
       'ReturnsListOfNumberOrString()',
-      'argument type (List of Number or string) does not look plausibly assignable to parameter type (integer)',
+      'argument type (List of Number or String) does not look plausibly assignable to parameter type (integer)',
       [biblio]
     );
 
-    await assertNoTypeError('List of strings', 'ReturnsListOfNumberOrString()', [biblio]);
+    await assertNoTypeError('List of Strings', 'ReturnsListOfNumberOrString()', [biblio]);
   });
 
   it('list', async () => {
     await assertTypeError(
-      'a string',
+      'a String',
       '« »',
-      'argument type (empty List) does not look plausibly assignable to parameter type (string)'
+      'argument type (empty List) does not look plausibly assignable to parameter type (String)'
     );
 
     await assertTypeError(
-      'a List of strings',
+      'a List of Strings',
       '« 0.5 »',
-      'argument type (List of 0.5) does not look plausibly assignable to parameter type (List of string)'
+      'argument type (List of 0.5) does not look plausibly assignable to parameter type (List of String)'
     );
 
-    await assertNoTypeError('a List of strings', '« "something" »');
+    await assertNoTypeError('a List of Strings', '« "something" »');
 
-    await assertNoTypeError('a List of strings', '« »');
+    await assertNoTypeError('a List of Strings', '« »');
   });
 
   it('unknown types', async () => {

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1406,11 +1406,7 @@ describe('type system', () => {
       'NormalCompletion(*false*)',
       [completionBiblio]
     );
-    await assertNoTypeError(
-      'a Boolean',
-      '! Throwy()',
-      [completionBiblio]
-    );
+    await assertNoTypeError('a Boolean', '! Throwy()', [completionBiblio]);
   });
 
   it('call', async () => {

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1509,6 +1509,40 @@ describe('type system', () => {
     await assertNoTypeError('a List of Strings', '« »');
   });
 
+  it('integers', async () => {
+    await assertTypeError(
+      '0',
+      '1',
+      'argument (1) does not look plausibly assignable to parameter type (0)'
+    );
+    await assertTypeError(
+      'a positive integer',
+      '0',
+      'argument (0) does not look plausibly assignable to parameter type (positive integer)'
+    );
+    await assertTypeError(
+      'a non-negative integer',
+      '-1',
+      'argument (-1) does not look plausibly assignable to parameter type (non-negative integer)'
+    );
+    await assertTypeError(
+      'a negative integer',
+      '0',
+      'argument (0) does not look plausibly assignable to parameter type (negative integer)'
+    );
+
+    await assertNoTypeError('a mathematical value', '0');
+    await assertNoTypeError('an integer', '0');
+    await assertNoTypeError('a non-negative integer', '0');
+    await assertNoTypeError('a positive integer', '1');
+    await assertNoTypeError('a negative integer', '-1');
+    await assertNoTypeError('0', '0');
+    await assertNoTypeError('1', '1');
+    await assertNoTypeError('-1', '-1');
+    await assertNoTypeError('0 or 1', '0');
+    await assertNoTypeError('0 or 1', '1');
+  });
+
   it('unknown types', async () => {
     await assertNoTypeError('a Foo', 'something');
     await assertNoTypeError('a Foo', '42');

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1346,11 +1346,41 @@ describe('type system', () => {
     await assertNoTypeError('a non-negative integer', '3');
 
     await assertTypeError(
+      '*1*<sub>𝔽</sub>',
+      '*2*<sub>𝔽</sub>',
+      'argument (*2*<sub>𝔽</sub>) does not look plausibly assignable to parameter type (*1*<sub>𝔽</sub>)'
+    );
+
+    await assertTypeError(
+      '*+0*<sub>𝔽</sub>',
+      '*-0*<sub>𝔽</sub>',
+      'argument (*-0*<sub>𝔽</sub>) does not look plausibly assignable to parameter type (*+0*<sub>𝔽</sub>)'
+    );
+
+    await assertTypeError(
       'an integral Number',
       '*0.5*<sub>𝔽</sub>',
       'argument (*0.5*<sub>𝔽</sub>) does not look plausibly assignable to parameter type (integral Number)'
     );
 
+    await assertTypeError(
+      'an integral Number',
+      '*NaN*',
+      'argument (*NaN*) does not look plausibly assignable to parameter type (integral Number)'
+    );
+
+    await assertTypeError(
+      'an integral Number',
+      '*+&infin;*<sub>𝔽</sub>',
+      'argument (*+&infin;*<sub>𝔽</sub>) does not look plausibly assignable to parameter type (integral Number)'
+    );
+
+    await assertNoTypeError('*2*<sub>𝔽</sub>', '*2*<sub>𝔽</sub>');
+    await assertNoTypeError('a Number', '*2*<sub>𝔽</sub>');
+    await assertNoTypeError('a Number', '*+&infin;*<sub>𝔽</sub>');
+    await assertNoTypeError('a Number', '*-&infin;*<sub>𝔽</sub>');
+    await assertNoTypeError('a Number', '*NaN*');
+    await assertNoTypeError('*NaN*', '*NaN*');
     await assertNoTypeError('an integral Number', '*2*<sub>𝔽</sub>');
 
     await assertTypeError(

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -1231,6 +1231,22 @@ describe('type system', () => {
     await assertNoTypeError('~sync~ or ~async~', '~sync~');
   });
 
+  it('boolean', async () => {
+    await assertTypeError(
+      'a Number',
+      '*false*',
+      'argument (false) does not look plausibly assignable to parameter type (Number)'
+    );
+
+    await assertTypeError(
+      'a Boolean',
+      '*1*<sub>𝔽</sub>',
+      'argument (*1*<sub>𝔽</sub>) does not look plausibly assignable to parameter type (Boolean)'
+    );
+
+    await assertNoTypeError('a Boolean', '*false*');
+  });
+
   it('number', async () => {
     await assertTypeError(
       'an integer',


### PR DESCRIPTION
Catches errors like https://github.com/tc39/proposal-joint-iteration/pull/11#discussion_r1442155330 via a very basic type system.

The checks only apply to call arguments, and specifically only to arguments which are either literals or themselves calls (including `! Foo()`-style unwrapped calls). There's no tracking of variables or anything yet.

Also, we can't generally infer types precisely. For example, imagine `Identity(x)` which returns its input and accepts any value: `TakesInteger(Identity(42))` would be a reasonable thing to write, but the type system here is much to weak to know that. So we check only that the intersection (that is, the meet) of the argument type and parameter type is nonempty.

The first commit is just moving code around. I recommend reviewing commits individually.