### PR TITLE
reduce document width on wider displays

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -110,11 +110,17 @@ body {
 
 #spec-container {
   padding: 0 20px;
+  max-width: max(50rem, 50%);
+  margin: 0 auto;
   flex-grow: 1;
   flex-basis: 66%;
   box-sizing: border-box;
   overflow: hidden;
   padding-bottom: 1em;
+}
+
+p {
+  text-align: justify;
 }
 
 body.oldtoc {
@@ -319,6 +325,7 @@ emu-note {
   border-left: 5px solid #52e052;
   background: #e9fbe9;
   padding: 10px 10px 10px 0;
+  overflow-x: auto;
 }
 
 emu-note > span.note {
@@ -728,7 +735,8 @@ emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
 /* Figures and tables */
 figure {
   display: block;
-  margin: 1em 0 3em 0;
+  overflow-x: auto;
+  margin: 1.5em 0;
 }
 figure object {
   display: block;

--- a/css/elements.css
+++ b/css/elements.css
@@ -119,10 +119,6 @@ body {
   padding-bottom: 1em;
 }
 
-p {
-  text-align: justify;
-}
-
 body.oldtoc {
   margin: 0 auto;
 }

--- a/css/elements.css
+++ b/css/elements.css
@@ -110,7 +110,7 @@ body {
 
 #spec-container {
   padding: 0 20px;
-  max-width: max(50rem, 50%);
+  max-width: 80rem;
   margin: 0 auto;
   flex-grow: 1;
   flex-basis: 66%;


### PR DESCRIPTION
before:

![image](https://github.com/tc39/ecmarkup/assets/218840/2b51c147-e260-4af1-9758-b14e49947153)

after:

![image](https://github.com/tc39/ecmarkup/assets/218840/ff0ab01d-eb3b-4c58-9fbc-90a89f03ff7d)

We could reduce it more but I figured I'd start with a smaller change.

/cc @devsnek 