### PR TITLE
print CSS: bump line-height of headings so they wrap nicer

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -21,6 +21,7 @@ p {
 
 h1 {
   text-wrap: balance;
+  line-height: 1.4;
 }
 
 emu-note p,


### PR DESCRIPTION
before:

![image](https://github.com/tc39/ecmarkup/assets/218840/64b42d79-c780-41de-b71b-0fe45d409a53)


after:

![image](https://github.com/tc39/ecmarkup/assets/218840/588ceec6-6173-47b9-a2f5-131d1043f7c9)
