### PR TITLE
bump grammarkdown and account for unescaping of <

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"ecmarkdown": "^8.1.0",
 				"eslint-formatter-codeframe": "^7.32.1",
 				"fast-glob": "^3.2.7",
-				"grammarkdown": "^3.2.0",
+				"grammarkdown": "^3.3.2",
 				"highlight.js": "11.0.1",
 				"html-escape": "^1.0.2",
 				"js-yaml": "^3.13.1",
@@ -1861,12 +1861,13 @@
 			"dev": true
 		},
 		"node_modules/grammarkdown": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.2.0.tgz",
-			"integrity": "sha512-pEVUvG2Kxv/PwM3Dm3kFEU1/GHRkNcFWmk/zkqN/y0uoQtPaZ+5VaBacMQAaFOIL9WGYjHXtqpkT5YRvySsISQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.3.2.tgz",
+			"integrity": "sha512-inNbeEotDr7MENqoZlms3x4gBzvK73wR2NGpNVnw4oEZcsq2METUbAh0J3VWtEqd9t2+U3poEqiJ9CDgBXr5Tg==",
 			"dependencies": {
 				"@esfx/async-canceltoken": "^1.0.0-pre.13",
-				"@esfx/cancelable": "^1.0.0-pre.13"
+				"@esfx/cancelable": "^1.0.0-pre.13",
+				"@esfx/disposable": "^1.0.0-pre.13"
 			},
 			"bin": {
 				"grammarkdown": "bin/grammarkdown"
@@ -4921,12 +4922,13 @@
 			"dev": true
 		},
 		"grammarkdown": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.2.0.tgz",
-			"integrity": "sha512-pEVUvG2Kxv/PwM3Dm3kFEU1/GHRkNcFWmk/zkqN/y0uoQtPaZ+5VaBacMQAaFOIL9WGYjHXtqpkT5YRvySsISQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.3.2.tgz",
+			"integrity": "sha512-inNbeEotDr7MENqoZlms3x4gBzvK73wR2NGpNVnw4oEZcsq2METUbAh0J3VWtEqd9t2+U3poEqiJ9CDgBXr5Tg==",
 			"requires": {
 				"@esfx/async-canceltoken": "^1.0.0-pre.13",
-				"@esfx/cancelable": "^1.0.0-pre.13"
+				"@esfx/cancelable": "^1.0.0-pre.13",
+				"@esfx/disposable": "^1.0.0-pre.13"
 			}
 		},
 		"graphemer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ecmarkup",
-	"version": "18.3.0",
+	"version": "18.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ecmarkup",
-			"version": "18.3.0",
+			"version": "18.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecmarkup",
-	"version": "18.3.0",
+	"version": "18.3.1",
 	"description": "Custom element definitions and core utilities for markup that specifies ECMAScript and related technologies.",
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"ecmarkdown": "^8.1.0",
 		"eslint-formatter-codeframe": "^7.32.1",
 		"fast-glob": "^3.2.7",
-		"grammarkdown": "^3.2.0",
+		"grammarkdown": "^3.3.2",
 		"highlight.js": "11.0.1",
 		"html-escape": "^1.0.2",
 		"js-yaml": "^3.13.1",

--- a/src/formatter/grammarkdown.ts
+++ b/src/formatter/grammarkdown.ts
@@ -6,6 +6,7 @@ import type {
   OneOfList,
   ParameterList,
   Trivia,
+  UnicodeCharacterLiteral,
 } from 'grammarkdown';
 import {
   NewLineKind,
@@ -248,6 +249,20 @@ class EmitterWithComments extends GrammarkdownEmitter {
   emitProse(node: Prose) {
     this.writer.write('&gt; ');
     node.fragments && this.emitNodes(node.fragments);
+  }
+
+  emitUnicodeCharacterLiteral(node: UnicodeCharacterLiteral) {
+    if (node.text?.startsWith('U+')) {
+      return super.emitUnicodeCharacterLiteral(node);
+    }
+    if (!(node.text?.startsWith('<') && node.text?.endsWith('>'))) {
+      throw new Error(
+        `unreachable: unicode character literal is not wrapped in <>: ${JSON.stringify(node.text)}`,
+      );
+    }
+    this.writer.write('&lt;');
+    this.writer.write(node.text.slice(1, -1));
+    this.writer.write('&gt;');
   }
 }
 

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -339,6 +339,8 @@ describe('grammar formatting', () => {
       A :
             B
             C#prod2
+            &lt;ASCII&gt;
+            U+2000
       </emu-grammar>
       `,
       dedentKeepingTrailingNewline`
@@ -351,6 +353,8 @@ describe('grammar formatting', () => {
         A :
           B
           C #prod2
+          &lt;ASCII&gt;
+          U+2000
       </emu-grammar>
       `,
     );

--- a/test/lint.js
+++ b/test/lint.js
@@ -20,7 +20,7 @@ describe('linting whole program', () => {
         {
           ruleId: 'grammarkdown:2008',
           nodeType: 'emu-grammar',
-          message: "Parameter 'a' is unused.",
+          message: "Parameter 'a' is unused",
         },
       );
     });
@@ -56,7 +56,7 @@ describe('linting whole program', () => {
         {
           ruleId: 'grammarkdown:2007',
           nodeType: 'emu-grammar',
-          message: "There is no argument given for parameter 'a'.",
+          message: "There is no argument given for parameter 'a'",
         },
       );
     });
@@ -69,7 +69,7 @@ describe('linting whole program', () => {
         {
           ruleId: 'grammarkdown:2008',
           nodeType: 'emu-grammar',
-          message: "Parameter 'a' is unused.",
+          message: "Parameter 'a' is unused",
         },
       );
     });
@@ -84,7 +84,7 @@ describe('linting whole program', () => {
         {
           ruleId: 'grammarkdown:2000',
           nodeType: 'emu-grammar',
-          message: "Cannot find name: 'Bar'.",
+          message: "Cannot find name: 'Bar'",
         },
       );
     });


### PR DESCRIPTION
Grammarkdown 3.3.0 [changes the internal representation of Unicode character abbreviations](https://github.com/rbuckton/grammarkdown/commit/b4e498aaba578e89799ce584ab8396a18b57d2e8#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17e) so that HTML entities (relevantly `&lt;`) are decoded. That means the formatter needs to be updated to re-encode them.

Includes version bump commit, so please **rebase**, not squash.