### PR TITLE
Simple test to validate declaration emit in presence of `@internal`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Test published files
         run: npm run test-published-files
+
+      - name: Test declarations
+        run: npm run test-declarations

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"format-spec": "node bin/emu-format.js --write spec/index.html",
 		"test": "mocha",
 		"test-baselines": "mocha test/baselines.js",
+		"test-declarations": "tsc -p tsconfig.test.json",
 		"update-baselines": "npm --update-baselines run test-baselines",
 		"pretest-published-files": "rm -rf \"ecmarkup-$npm_package_version.tgz\" package",
 		"test-published-files": "npm pack && tar zxvf \"ecmarkup-$npm_package_version.tgz\" && cp -r test package/test && cd package && npm test && cd ..",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig",
+    "include": ["lib/**/*"],
+    "compilerOptions": {
+        "noEmit": true,
+    }
+}


### PR DESCRIPTION
Ahead of actually fixing issues with the declarations, this adds a simple test that can be manually invoked to validate declaration emit in the presence of `/* @internal */` and `--stripInternal`.

Long term, I would recommend refactoring out internals such that `/* @internal */` is unnecessary.

Related: https://github.com/tc39/ecmarkup/issues/416#issuecomment-1074739611