### PR TITLE
Move `@internal` markers to individual members

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Test published files
         run: npm run test-published-files
+
+      - name: Test declarations
+        run: npm run test-declarations

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"format-spec": "node bin/emu-format.js --write spec/index.html",
 		"test": "mocha",
 		"test-baselines": "mocha test/baselines.js",
+		"test-declarations": "tsc -p tsconfig.test.json",
 		"update-baselines": "npm --update-baselines run test-baselines",
 		"pretest-published-files": "rm -rf \"ecmarkup-$npm_package_version.tgz\" package",
 		"test-published-files": "npm pack && tar zxvf \"ecmarkup-$npm_package_version.tgz\" && cp -r test package/test && cd package && npm test && cd ..",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "lib/ecmarkup.js",
 	"typings": "lib/ecmarkup.d.ts",
 	"scripts": {
-		"build": "tsc -sourceMap",
+		"build": "tsc -sourceMap -declarationMap",
 		"build-release": "tsc",
 		"build-spec": "mkdir -p docs && node bin/ecmarkup.js spec/index.html docs/index.html --assets-dir=docs",
 		"prepack": "safe-publish-latest && npm run build-release",

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -28,7 +28,6 @@ export type AlgorithmElementWithTree = HTMLElement & {
   originalHtml: string;
 };
 
-/*@internal*/
 export default class Algorithm extends Builder {
   static async enter(context: Context) {
     context.inAlg = true;
@@ -216,7 +215,8 @@ export default class Algorithm extends Builder {
   static exit(context: Context) {
     context.inAlg = false;
   }
-  static elements = ['EMU-ALG'];
+
+  static readonly elements = ['EMU-ALG'] as const;
 }
 
 function getStepNumbers(item: Element) {

--- a/src/Biblio.ts
+++ b/src/Biblio.ts
@@ -65,7 +65,6 @@ class EnvRec {
   }
 }
 
-/*@internal*/
 export default class Biblio {
   private _byId: { [id: string]: BiblioEntry };
   private _location: string;
@@ -185,6 +184,7 @@ export default class Biblio {
     return undefined;
   }
 
+  /** @internal*/
   add(entry: PartialBiblioEntry & { location?: string }, ns?: string | null) {
     ns = ns || this._location;
     const env = this._nsToEnvRec[ns]!;
@@ -209,6 +209,7 @@ export default class Biblio {
     }
   }
 
+  /** @internal*/
   createNamespace(ns: string, parent: string) {
     const existingNs = this._nsToEnvRec[ns];
     if (existingNs) {
@@ -252,6 +253,7 @@ export default class Biblio {
     return root;
   }
 
+  /** @internal*/
   addExternalBiblio(biblio: ExportedBiblio) {
     for (const item of biblio.entries) {
       this.add({ location: biblio.location, ...item }, 'external');
@@ -342,13 +344,13 @@ export interface AlgorithmBiblioEntry extends BiblioEntryBase {
   signature: null | Signature;
   effects: string[];
   skipGlobalChecks?: boolean;
-  /*@internal*/ _node?: Element;
+  /** @internal*/ _node?: Element;
 }
 
 export interface ProductionBiblioEntry extends BiblioEntryBase {
   type: 'production';
   name: string;
-  /*@internal*/ _instance?: Production;
+  /** @internal*/ _instance?: Production;
 }
 
 export interface ClauseBiblioEntry extends BiblioEntryBase {

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -2,14 +2,8 @@ import type Spec from './Spec';
 import type { Context } from './Context';
 
 // We use this instead of `typeof Builder` because using the class as the type also requires derived constructors to be subtypes of the base constructor, which is irritating.
-/*@internal*/
-export interface BuilderInterface {
-  elements: string[];
-  enter(context: Context): void;
-  exit(context: Context): void;
-}
+export type BuilderInterface = Omit<typeof Builder, never>;
 
-/*@internal*/
 export default class Builder {
   public spec: Spec;
   public node: HTMLElement;
@@ -40,5 +34,5 @@ export default class Builder {
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static exit(context: Context): void {}
-  static elements: string[] = [];
+  static readonly elements: readonly string[] = [];
 }

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -38,26 +38,23 @@ export function extractStructuredHeader(header: Element): Element | null {
   return dl;
 }
 
-/*@internal*/
 export default class Clause extends Builder {
-  id: string;
-  namespace: string;
-  parentClause: Clause;
-  header: Element | null;
-  // @ts-ignore skipping the strictPropertyInitialization check
-  title: string | null;
-  // @ts-ignore skipping the strictPropertyInitialization check
-  titleHTML: string;
-  subclauses: Clause[];
-  number: string;
-  aoid: string | null;
-  type: string | null;
-  notes: Note[];
-  editorNotes: Note[];
-  examples: Example[];
-  readonly effects: string[]; // this is held by identity and mutated by Spec.ts
-  signature: Signature | null;
-  skipGlobalChecks: boolean;
+  /** @internal */ id: string;
+  /** @internal */ namespace: string;
+  /** @internal */ parentClause: Clause;
+  /** @internal */ header: Element | null;
+  /** @internal */ title!: string | null;
+  /** @internal */ titleHTML!: string;
+  /** @internal */ subclauses: Clause[];
+  /** @internal */ number: string;
+  /** @internal */ aoid: string | null;
+  /** @internal */ type: string | null;
+  /** @internal */ notes: Note[];
+  /** @internal */ editorNotes: Note[];
+  /** @internal */ examples: Example[];
+  /** @internal */ readonly effects: string[]; // this is held by identity and mutated by Spec.ts
+  /** @internal */ signature: Signature | null;
+  /** @internal */ skipGlobalChecks: boolean;
 
   constructor(spec: Spec, node: HTMLElement, parent: Clause, number: string) {
     super(spec, node);
@@ -131,7 +128,7 @@ export default class Clause extends Builder {
     }
   }
 
-  buildStructuredHeader(header: Element, headerSurrogate: Element = header) {
+  /** @internal */ buildStructuredHeader(header: Element, headerSurrogate: Element = header) {
     const dl = extractStructuredHeader(headerSurrogate);
     if (dl === null) {
       return;
@@ -250,7 +247,7 @@ export default class Clause extends Builder {
     }
   }
 
-  buildNotes() {
+  /** @internal */ buildNotes() {
     if (this.notes.length === 1) {
       this.notes[0].build();
     } else {
@@ -263,7 +260,7 @@ export default class Clause extends Builder {
     this.editorNotes.forEach(note => note.build());
   }
 
-  buildExamples() {
+  /** @internal */ buildExamples() {
     if (this.examples.length === 1) {
       this.examples[0].build();
     } else {

--- a/src/Dfn.ts
+++ b/src/Dfn.ts
@@ -4,7 +4,6 @@ import type { Context } from './Context';
 
 import Builder from './Builder';
 
-/*@internal*/
 export default class Dfn extends Builder {
   static async enter({ spec, node, clauseStack }: Context) {
     if (!node.hasAttribute('tabindex')) {

--- a/src/Eqn.ts
+++ b/src/Eqn.ts
@@ -4,10 +4,9 @@ import Builder from './Builder';
 import * as emd from 'ecmarkdown';
 import * as utils from './utils';
 
-/*@internal*/
 export default class Eqn extends Builder {
   // @ts-ignore
-  constructor() {
+  private constructor() {
     throw new Error('not actually constructible');
   }
 

--- a/src/Example.ts
+++ b/src/Example.ts
@@ -4,12 +4,11 @@ import type { Context } from './Context';
 
 import Builder from './Builder';
 
-/*@internal*/
 export default class Example extends Builder {
-  clause: Clause;
-  caption: string | null;
-  id: string | undefined;
-  static elements = ['EMU-EXAMPLE'];
+  /** @internal */ clause: Clause;
+  /** @internal */ caption: string | null;
+  /** @internal */ id: string | undefined;
+  static readonly elements = ['EMU-EXAMPLE'] as const;
 
   constructor(spec: Spec, node: HTMLElement, clause: Clause) {
     super(spec, node);

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -13,7 +13,6 @@ export type AugmentedGrammarEle = HTMLElement & {
   grammarSource: SourceFile;
 };
 
-/*@internal*/
 export default class Grammar extends Builder {
   static async enter({ spec, node, clauseStack }: Context) {
     if ('grammarkdownOut' in node) {
@@ -96,5 +95,5 @@ export default class Grammar extends Builder {
     });
   }
 
-  static elements = ['EMU-GRAMMAR'];
+  static readonly elements = ['EMU-GRAMMAR'] as const;
 }

--- a/src/GrammarAnnotation.ts
+++ b/src/GrammarAnnotation.ts
@@ -3,9 +3,8 @@ import type Production from './Production';
 
 import Builder from './Builder';
 
-/*@internal*/
 export default class GrammarAnnotation extends Builder {
-  production: Production;
+  /** @internal */ production: Production;
 
   constructor(spec: Spec, prod: Production, node: HTMLElement) {
     super(spec, node);

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -5,11 +5,10 @@ import * as utils from './utils';
 import * as path from 'path';
 import type { JSDOM } from 'jsdom';
 
-/*@internal*/
 export default class Import extends Builder {
-  public importLocation: string;
-  public relativeRoot: string;
-  public source: string;
+  /** @internal */ public importLocation: string;
+  /** @internal */ public relativeRoot: string;
+  /** @internal */ public source: string;
 
   constructor(
     spec: Spec,
@@ -77,7 +76,6 @@ export default class Import extends Builder {
   }
 }
 
-/*@internal*/
 export interface EmuImportElement extends HTMLElement {
   href: string;
   dom?: JSDOM;

--- a/src/Menu.ts
+++ b/src/Menu.ts
@@ -3,7 +3,6 @@ import type Spec from './Spec';
 
 import Toc from './Toc';
 
-/*@internal*/
 export default function makeMenu(spec: Spec) {
   const pinContainer = spec.doc.createElement('div');
   pinContainer.setAttribute('id', 'menu-pins');

--- a/src/NonTerminal.ts
+++ b/src/NonTerminal.ts
@@ -4,14 +4,13 @@ import type { BiblioEntry } from './Biblio';
 
 import Builder from './Builder';
 
-/*@internal*/
 export default class NonTerminal extends Builder {
-  params: string | null;
-  optional: boolean;
-  namespace: string;
-  entry?: BiblioEntry;
+  /** @internal */ params: string | null;
+  /** @internal */ optional: boolean;
+  /** @internal */ namespace: string;
+  /** @internal */ entry?: BiblioEntry;
 
-  static elements = ['EMU-NT'];
+  static readonly elements = ['EMU-NT'] as const;
 
   constructor(spec: Spec, node: HTMLElement, namespace: string) {
     super(spec, node);

--- a/src/Note.ts
+++ b/src/Note.ts
@@ -4,12 +4,11 @@ import type { Context } from './Context';
 
 import Builder from './Builder';
 
-/*@internal*/
 export default class Note extends Builder {
-  clause: Clause;
-  id?: string;
-  type: string; // normal, editor
-  static elements = ['EMU-NOTE'];
+  /** @internal */ clause: Clause;
+  /** @internal */ id?: string;
+  /** @internal */ type: string; // normal, editor
+  static readonly elements = ['EMU-NOTE'] as const;
 
   constructor(spec: Spec, node: HTMLElement, clause: Clause) {
     super(spec, node);

--- a/src/ProdRef.ts
+++ b/src/ProdRef.ts
@@ -4,12 +4,11 @@ import type Spec from './Spec';
 import Builder from './Builder';
 import { shouldInline } from './utils';
 
-/*@internal*/
 export default class ProdRef extends Builder {
-  public namespace: string;
-  public name: string;
+  /** @internal */ public namespace: string;
+  /** @internal */ public name: string;
 
-  static elements = ['EMU-PRODREF'];
+  static readonly elements = ['EMU-PRODREF'] as const;
 
   constructor(spec: Spec, node: HTMLElement, namespace: string) {
     super(spec, node);

--- a/src/Production.ts
+++ b/src/Production.ts
@@ -8,20 +8,19 @@ import Terminal from './Terminal';
 import Builder from './Builder';
 import * as utils from './utils';
 
-/*@internal*/
 export default class Production extends Builder {
-  static byName = {};
+  /** @internal */ static byName = {};
 
-  type: string | null;
-  name: string;
-  params: string | null;
-  optional: boolean;
-  oneOf: boolean;
-  rhses: RHS[];
-  rhsesById: { [id: string]: RHS };
-  namespace: string;
-  primary: boolean;
-  id: string | undefined;
+  /** @internal */ type: string | null;
+  /** @internal */ name: string;
+  /** @internal */ params: string | null;
+  /** @internal */ optional: boolean;
+  /** @internal */ oneOf: boolean;
+  /** @internal */ rhses: RHS[];
+  /** @internal */ rhsesById: { [id: string]: RHS };
+  /** @internal */ namespace: string;
+  /** @internal */ primary: boolean;
+  /** @internal */ id: string | undefined;
 
   constructor(spec: Spec, node: HTMLElement, namespace: string) {
     super(spec, node);
@@ -147,5 +146,5 @@ export default class Production extends Builder {
     }
   }
 
-  static elements = ['EMU-PRODUCTION'];
+  static readonly elements = ['EMU-PRODUCTION'] as const;
 }

--- a/src/RHS.ts
+++ b/src/RHS.ts
@@ -3,11 +3,10 @@ import type Production from './Production';
 
 import Builder from './Builder';
 
-/*@internal*/
 export default class RHS extends Builder {
-  production: Production;
-  constraints: string | null;
-  alternativeId: string | null;
+  /** @internal */ production: Production;
+  /** @internal */ constraints: string | null;
+  /** @internal */ alternativeId: string | null;
 
   constructor(spec: Spec, prod: Production, node: HTMLElement) {
     super(spec, node);

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -125,17 +125,6 @@ const visitorMap = builders.reduce((map, T) => {
   return map;
 }, {} as VisitorMap);
 
-// NOTE: This is the public API for spec as used in the types. Do not remove.
-export default interface Spec {
-  spec: this;
-  opts: Options;
-  rootPath: string;
-  rootDir: string;
-  namespace: string;
-  exportBiblio(): any;
-  generatedFiles: Map<string | null, string | Buffer>;
-}
-
 export type Warning =
   | {
       type: 'global';
@@ -304,46 +293,46 @@ export function maybeAddClauseToEffectWorklist(
   }
 }
 
-/*@internal*/
 export default class Spec {
   spec: this;
   opts: Options;
-  assets: { type: 'none' } | { type: 'inline' } | { type: 'external'; directory: string };
   rootPath: string;
   rootDir: string;
-  sourceText: string;
   namespace: string;
-  biblio: Biblio;
-  dom: JSDOM;
-  doc: Document;
-  imports: Import[];
-  node: HTMLElement;
-  nodeIds: Set<string>;
-  subclauses: Clause[];
-  replacementAlgorithmToContainedLabeledStepEntries: Map<Element, StepBiblioEntry[]>; // map from re to its labeled nodes
-  labeledStepsToBeRectified: Set<string>;
-  replacementAlgorithms: { element: Element; target: string }[];
-  cancellationToken: CancellationToken;
   generatedFiles: Map<string | null, string | Buffer>;
-  log: (msg: string) => void;
-  warn: (err: Warning) => void | undefined;
+  /** @internal */ assets: { type: 'none' } | { type: 'inline' } | { type: 'external'; directory: string };
+  /** @internal */ sourceText: string;
+  /** @internal */ biblio: Biblio;
+  /** @internal */ dom: JSDOM;
+  /** @internal */ doc: Document;
+  /** @internal */ imports: Import[];
+  /** @internal */ node: HTMLElement;
+  /** @internal */ nodeIds: Set<string>;
+  /** @internal */ subclauses: Clause[];
+  /** @internal */ replacementAlgorithmToContainedLabeledStepEntries: Map<Element, StepBiblioEntry[]>; // map from re to its labeled nodes
+  /** @internal */ labeledStepsToBeRectified: Set<string>;
+  /** @internal */ replacementAlgorithms: { element: Element; target: string }[];
+  /** @internal */ cancellationToken: CancellationToken;
 
-  _figureCounts: { [type: string]: number };
-  _xrefs: Xref[];
-  _ntRefs: NonTerminal[];
-  _ntStringRefs: {
+  readonly log: (msg: string) => void;
+  readonly warn: (err: Warning) => void | undefined;
+
+  /** @internal */ _figureCounts: { [type: string]: number };
+  /** @internal */ _xrefs: Xref[];
+  /** @internal */ _ntRefs: NonTerminal[];
+  /** @internal */ _ntStringRefs: {
     name: string;
     loc: { line: number; column: number };
     node: Element | Text;
     namespace: string;
   }[];
-  _prodRefs: ProdRef[];
-  _textNodes: { [s: string]: [TextNodeContext] };
-  _effectWorklist: Map<string, WorklistItem[]>;
-  _effectfulAOs: Map<string, string[]>;
-  _emuMetasToRender: Set<HTMLElement>;
-  _emuMetasToRemove: Set<HTMLElement>;
-  refsByClause: { [refId: string]: [string] };
+  /** @internal */ _prodRefs: ProdRef[];
+  /** @internal */ _textNodes: { [s: string]: [TextNodeContext] };
+  /** @internal */ _effectWorklist: Map<string, WorklistItem[]>;
+  /** @internal */ _effectfulAOs: Map<string, string[]>;
+  /** @internal */ _emuMetasToRender: Set<HTMLElement>;
+  /** @internal */ _emuMetasToRemove: Set<HTMLElement>;
+  /** @internal */ refsByClause: { [refId: string]: [string] };
 
   private _fetch: (file: string, token: CancellationToken) => PromiseLike<string>;
 
@@ -464,10 +453,12 @@ export default class Spec {
     this.biblio = new Biblio(this.opts.location);
   }
 
+  /** @internal */
   public fetch(file: string) {
     return this._fetch(file, this.cancellationToken);
   }
 
+  /** @internal */
   public async build() {
     /*
     The Ecmarkup build process proceeds as follows:
@@ -650,6 +641,7 @@ export default class Spec {
     return '<!doctype html>\n' + (htmlEle.hasAttributes() ? htmlEle.outerHTML : htmlEle.innerHTML);
   }
 
+  /** @internal */
   public locate(
     node: Element | Node,
   ): ({ file?: string; source: string } & ElementLocation) | undefined {
@@ -811,6 +803,7 @@ export default class Spec {
     }
   }
 
+  /** @internal */
   public getEffectsByAoid(aoid: string): string[] | null {
     if (this._effectfulAOs.has(aoid)) {
       return this._effectfulAOs.get(aoid)!;
@@ -1817,6 +1810,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
     }
   }
 
+  /** @internal */
   public autolink() {
     this.log('Autolinking terms and abstract ops...');
     const namespaces = Object.keys(this._textNodes);
@@ -1832,6 +1826,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
     }
   }
 
+  /** @internal */
   public setCharset() {
     let current = this.spec.doc.querySelector('meta[charset]');
 

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -300,7 +300,10 @@ export default class Spec {
   rootDir: string;
   namespace: string;
   generatedFiles: Map<string | null, string | Buffer>;
-  /** @internal */ assets: { type: 'none' } | { type: 'inline' } | { type: 'external'; directory: string };
+  /** @internal */ assets:
+    | { type: 'none' }
+    | { type: 'inline' }
+    | { type: 'external'; directory: string };
   /** @internal */ sourceText: string;
   /** @internal */ biblio: Biblio;
   /** @internal */ dom: JSDOM;
@@ -309,7 +312,10 @@ export default class Spec {
   /** @internal */ node: HTMLElement;
   /** @internal */ nodeIds: Set<string>;
   /** @internal */ subclauses: Clause[];
-  /** @internal */ replacementAlgorithmToContainedLabeledStepEntries: Map<Element, StepBiblioEntry[]>; // map from re to its labeled nodes
+  /** @internal */ replacementAlgorithmToContainedLabeledStepEntries: Map<
+    Element,
+    StepBiblioEntry[]
+  >; // map from re to its labeled nodes
   /** @internal */ labeledStepsToBeRectified: Set<string>;
   /** @internal */ replacementAlgorithms: { element: Element; target: string }[];
   /** @internal */ cancellationToken: CancellationToken;

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -3,10 +3,9 @@ import type Production from './Production';
 
 import Builder from './Builder';
 
-/*@internal*/
 export default class Terminal extends Builder {
-  production: Production;
-  optional: boolean;
+  /** @internal */ production: Production;
+  /** @internal */ optional: boolean;
 
   constructor(spec: Spec, prod: Production, node: HTMLElement) {
     super(spec, node);

--- a/src/Toc.ts
+++ b/src/Toc.ts
@@ -1,13 +1,13 @@
 import type Spec from './Spec';
 import type Clause from './Clause';
 
-/*@internal*/
 export default class Toc {
-  spec: Spec;
+  /** @internal */ spec: Spec;
   constructor(spec: Spec) {
     this.spec = spec;
   }
 
+  /** @internal */
   build(maxDepth: number = Infinity) {
     if (this.spec.subclauses.length === 0) {
       return;

--- a/src/Xref.ts
+++ b/src/Xref.ts
@@ -6,19 +6,18 @@ import type Clause from './Clause';
 import Builder from './Builder';
 import { validateEffects, doesEffectPropagateToParent } from './utils';
 
-/*@internal*/
 export default class Xref extends Builder {
-  namespace: string;
-  href: string;
-  aoid: string;
-  isInvocation: boolean;
-  clause: Clause | null;
-  id: string;
-  entry: Biblio.BiblioEntry | undefined;
-  addEffects: string[] | null;
-  suppressEffects: string[] | null;
+  /** @internal */ namespace: string;
+  /** @internal */ href: string;
+  /** @internal */ aoid: string;
+  /** @internal */ isInvocation: boolean;
+  /** @internal */ clause: Clause | null;
+  /** @internal */ id: string;
+  /** @internal */ entry: Biblio.BiblioEntry | undefined;
+  /** @internal */ addEffects: string[] | null;
+  /** @internal */ suppressEffects: string[] | null;
 
-  static elements = ['EMU-XREF'];
+  static readonly elements = ['EMU-XREF'] as const;
 
   constructor(
     spec: Spec,
@@ -155,6 +154,7 @@ export default class Xref extends Builder {
     spec._xrefs.push(xref);
   }
 
+  /** @internal */
   build() {
     const spec = this.spec;
     const href = this.href;

--- a/src/clauseNums.ts
+++ b/src/clauseNums.ts
@@ -1,12 +1,10 @@
 import type Clause from './Clause';
 import type { Spec } from './ecmarkup';
 
-/*@internal*/
 export interface ClauseNumberIterator {
   next(clauseStack: Clause[], node: HTMLElement): string;
 }
 
-/*@internal*/
 export default function iterator(spec: Spec): ClauseNumberIterator {
   const ids: (string | number[])[] = [];
   let inAnnex = false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ export function wrapEmdFailure(src: string) {
   return `#### ECMARKDOWN PARSE FAILED ####<pre>${src}</pre>`;
 }
 
-/*@internal*/
+/** @internal */
 export function emdTextNode(spec: Spec, node: Text, namespace: string) {
   const loc = spec.locate(node);
   let c;
@@ -73,7 +73,7 @@ export function emdTextNode(spec: Spec, node: Text, namespace: string) {
   replaceTextNode(node, template.content);
 }
 
-/*@internal*/
+/** @internal */
 export function htmlToDom(html: string) {
   const virtualConsole = new jsdom.VirtualConsole();
   virtualConsole.on('error', () => {
@@ -82,7 +82,7 @@ export function htmlToDom(html: string) {
   return new jsdom.JSDOM(html, { includeNodeLocations: true, virtualConsole });
 }
 
-/*@internal*/
+/** @internal */
 export function domWalkBackward(root: Node, cb: (node: Element) => boolean | undefined) {
   const childNodes = root.childNodes;
   const childLen = childNodes.length;
@@ -98,7 +98,7 @@ export function domWalkBackward(root: Node, cb: (node: Element) => boolean | und
   }
 }
 
-/*@internal*/
+/** @internal */
 export function replaceTextNode(node: Node, frag: DocumentFragment) {
   // Append all the nodes
   const parent = node.parentNode;
@@ -121,7 +121,7 @@ export function replaceTextNode(node: Node, frag: DocumentFragment) {
   return newXrefNodes;
 }
 
-/*@internal*/
+/** @internal */
 export function traverseWhile<P extends string, T extends Record<P, T | null>>(
   node: T | null,
   relationship: P,
@@ -136,20 +136,20 @@ export function traverseWhile<P extends string, T extends Record<P, T | null>>(
   return node;
 }
 
-/*@internal*/
+/** @internal */
 export function logVerbose(str: string) {
   const dateString = new Date().toISOString();
   console.error(chalk.gray('[' + dateString + '] ') + str);
 }
 
-/*@internal*/
+/** @internal */
 export function logWarning(str: string) {
   const dateString = new Date().toISOString();
   console.error(chalk.gray('[' + dateString + '] ') + chalk.red(str));
 }
 
 const CLAUSE_LIKE = ['EMU-ANNEX', 'EMU-CLAUSE', 'EMU-INTRO', 'EMU-NOTE', 'BODY'];
-/*@internal*/
+/** @internal */
 export function shouldInline(node: Node) {
   const surrogateParentTags = ['EMU-GRAMMAR', 'EMU-IMPORT', 'INS', 'DEL'];
   const parent = traverseWhile(node.parentNode, 'parentNode', node =>
@@ -163,21 +163,21 @@ export function shouldInline(node: Node) {
   return !clauseLikeParent;
 }
 
-/*@internal*/
+/** @internal */
 export function readFile(file: string) {
   return new Promise<string>((resolve, reject) => {
     fs.readFile(file, 'utf8', (err, data) => (err ? reject(err) : resolve(data)));
   });
 }
 
-/*@internal*/
+/** @internal */
 export function readBinaryFile(file: string) {
   return new Promise<Buffer>((resolve, reject) => {
     fs.readFile(file, (err, data) => (err ? reject(err) : resolve(data)));
   });
 }
 
-/*@internal*/
+/** @internal */
 export function writeFile(file: string, content: string | Buffer) {
   return new Promise<void>((resolve, reject) => {
     // we could do this async, but it's not worth worrying about
@@ -191,7 +191,7 @@ export function writeFile(file: string, content: string | Buffer) {
   });
 }
 
-/*@internal*/
+/** @internal */
 export async function copyFile(src: string, dest: string) {
   const content = await readFile(src);
   await writeFile(dest, content);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,5 @@
         "stripInternal": true,
         "outDir": "lib",
         "lib": ["es2020", "dom", "dom.iterable"],
-        "typeRoots": [
-            "node_modules/@types"
-        ]
     }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig",
+    "include": ["lib/**/*"],
+    "compilerOptions": {
+        "noEmit": true,
+    }
+}


### PR DESCRIPTION
This builds on #591 by moving `/*@internal*/` markers from classes to individual class elements so that class types are preserved broadly while still allowing us to remove individual `/*@internal*/` markers on a case-by-case basis.

Fixes #416