### PR TITLE
Make the formatter smarter about mutli-line steps

### DIFF
--- a/src/expr-parser.ts
+++ b/src/expr-parser.ts
@@ -10,7 +10,7 @@ type SimpleLocation = { start: { offset: number }; end: { offset: number } };
 type BareText = {
   name: 'text';
   contents: string;
-  location: { start: { offset: number }; end: { offset: number } };
+  location: SimpleLocation;
 }; // like TextNode, but with less complete location information
 type ProsePart = FragmentNode | BareText;
 type List = {

--- a/src/formatter/line-builder.ts
+++ b/src/formatter/line-builder.ts
@@ -58,7 +58,7 @@ export class LineBuilder {
       if (text === '') {
         return;
       }
-      this.last = '  '.repeat(this.indent);
+      this.last += '  '.repeat(this.indent);
     }
     this.last += allowMultiSpace ? text : text.replace(/  +/g, ' ');
   }
@@ -80,7 +80,6 @@ export class LineBuilder {
   }
 
   linebreak(): void {
-    // console.log('linebreak');
     if (this.isEmpty()) {
       this.firstLineIsPartial = false;
       return;
@@ -121,6 +120,6 @@ export class LineBuilder {
       // when firstLineIsPartial, we don't indent the first line
       return false;
     }
-    return this.last === '';
+    return /^ *$/.test(this.last);
   }
 }

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -493,6 +493,29 @@ describe('algorithm formatting', () => {
     );
   });
 
+  it('multiline steps', async () => {
+    await assertDocFormatsAs(
+      `
+      <emu-alg>
+      1. Return the Record {
+                [[Precision]]: *"minute"*,
+                [[Unit]]: *"minute"*,
+                [[Increment]]: 1
+              }.
+      </emu-alg>
+      `,
+      dedentKeepingTrailingNewline`
+      <emu-alg>
+        1. Return the Record {
+            [[Precision]]: *"minute"*,
+            [[Unit]]: *"minute"*,
+            [[Increment]]: 1
+          }.
+      </emu-alg>
+      `,
+    );
+  });
+
   it('nested html', async () => {
     await assertDocFormatsAs(
       `


### PR DESCRIPTION
Some consumers write some steps across multiple line of source, [like this](https://github.com/tc39/proposal-temporal/blob/26e4cebe3c49f56932c1d5064fec9993e981823a/spec/abstractops.html#L621-L625). This makes the formatter smarter in those cases: rather than making all lines be the same indentation, it keeps whatever indentation there is beyond that which is common across all lines.

I would have been happier making it aware of Records explicitly, but that's quite complex: the [expression parser](https://github.com/tc39/ecmarkup/blob/fd938c8a4da2dca309f8c54a72d8c8616f5da009/src/expr-parser.ts#L737-L738) intentionally doesn't represent `<del>` etc, which means its output is not suitable for use in the formatter.