### PR TITLE
fix instability in formatting AO headers with no arguments

### DIFF
--- a/src/formatter/header.ts
+++ b/src/formatter/header.ts
@@ -38,8 +38,10 @@ export function printHeader(
   } = parseResult;
   /* eslint-enable prefer-const */
 
+  const multiline = type === 'multi-line' && (params.length > 0 || optionalParams.length > 0);
+
   const result = new LineBuilder(indent);
-  if (type === 'multi-line') {
+  if (multiline) {
     result.firstLineIsPartial = false;
   }
   if (wrappingTag !== null) {
@@ -60,7 +62,7 @@ export function printHeader(
     returnType === null
   ) {
     // do not print a parameter list
-  } else if (type === 'single-line') {
+  } else if (!multiline) {
     result.appendText(' ' + printSimpleParamList(params, optionalParams));
   } else {
     result.appendText(' (');
@@ -80,7 +82,7 @@ export function printHeader(
   if (wrappingTag !== null) {
     result.appendText(`</${wrappingTag}>`);
   }
-  if (type === 'multi-line') {
+  if (multiline) {
     result.linebreak();
   }
 

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -586,6 +586,30 @@ describe('equation formatting', () => {
 });
 
 describe('structured header formatting', () => {
+  it('multiline with no arguments', async () => {
+    await assertDocFormatsAs(
+      `
+      <emu-clause>
+        <h1>
+          Foo (
+          ): ~empty~
+        </h1>
+
+        <dl class="header">
+        </dl>
+      </emu-clause>
+      `,
+      dedentKeepingTrailingNewline`
+      <emu-clause>
+        <h1>Foo ( ): ~empty~</h1>
+
+        <dl class="header">
+        </dl>
+      </emu-clause>
+      `,
+    );
+  });
+
   it('whitespace in inline style', async () => {
     await assertDocFormatsAs(
       `


### PR DESCRIPTION
Previously something like

```html
<h1>
  Foo (
  ): ~empty~
</h1>
```

would be parsed as a multi-line header, and then rendered as

```html
<h1>
  Foo (): ~empty~
</h1>
```
which is a single-line header, which formats as
```html
<h1>Foo ( ): ~empty~</h1>
```
Now it skips to the end state instead of outputting something not completely formatted.