### PR TITLE
avoid console warning when hitting number keys beyond pins

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -573,6 +573,7 @@ Menu.prototype.togglePinEntry = function (id) {
 };
 
 Menu.prototype.selectPin = function (num) {
+  if (num >= this.$pinList.children.length) return;
   document.location = this.$pinList.children[num].children[0].href;
 };
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -657,6 +657,7 @@ Menu.prototype.togglePinEntry = function (id) {
 };
 
 Menu.prototype.selectPin = function (num) {
+  if (num >= this.$pinList.children.length) return;
   document.location = this.$pinList.children[num].children[0].href;
 };
 


### PR DESCRIPTION
Repro: open the spec, have < 9 pins, hit 9. You get a console warning. This makes that not happen.