### PR TITLE
Suppress line breaks before field/slot references

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -222,6 +222,10 @@ var.field {
   font: inherit;
   color: inherit;
 }
+/* suppress line break opportunities between `.` and `[[FieldName]]` */
+var.field::before {
+  content: '\2060'
+}
 
 var.referenced {
   color: inherit;

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1781,6 +1781,10 @@ var.field {
   font: inherit;
   color: inherit;
 }
+/* suppress line break opportunities between `.` and `[[FieldName]]` */
+var.field::before {
+  content: '\2060'
+}
 
 var.referenced {
   color: inherit;


### PR DESCRIPTION
I found an instance where a line break after the period in _specAlias_.[[SlotName]] made for confusing reading, making it look like a sentence was ending prematurely. This CSS change suppresses such line breaks by generating a non-copyable [word joiner](https://en.wikipedia.org/wiki/Word_joiner) before each field/slot reference.

<details><summary><b>Before</b></summary>

Note the line break after "[[Block]] is _buffer_." and before the "[[ArrayBufferByteLengthData]]" that is connected to _buffer_:

![screenshot (before change)](https://github.com/user-attachments/assets/525c9a72-59f6-414f-b62d-54d3730ea425)

</details>

<details><summary><b>After</b></summary>

Note the line break moving to after "[[Block]] is" and before "_buffer_.[[ArrayBufferByteLengthData]]", keeping the latter together as a single unit:

![screenshot (after change)](https://github.com/user-attachments/assets/9ea56740-1c71-48df-b3b3-a82565b4aadd)

</details>