### PR TITLE
Add indentation to hidden counter text

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -125,6 +125,7 @@ body.oldtoc {
 
 span[aria-hidden='true'] {
   font-size: 0;
+  white-space: pre;
 }
 
 a {

--- a/js/listNumbers.js
+++ b/js/listNumbers.js
@@ -129,19 +129,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Omit indendation when copying a single algorithm step.
 document.addEventListener('copy', evt => {
-  const selection = getSelection();
-  const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
-  const container = singleRange?.commonAncestorContainer;
-  if (!container?.querySelector("span[aria-hidden='true']")) {
+  const doc = document.implementation.createHTMLDocument('');
+  const domRoot = doc.createElement('div');
+  const html = evt.clipboardData.getData('text/html');
+  if (html) {
+    domRoot.innerHTML = html;
+  } else {
+    const selection = getSelection();
+    const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
+    const container = singleRange?.commonAncestorContainer;
+    if (!container?.querySelector?.("span[aria-hidden='true']")) {
+      return;
+    }
+    domRoot.append(singleRange.cloneContents());
+  }
+  const hiddenElems = [...domRoot.querySelectorAll("span[aria-hidden='true']")];
+  const lastHidden = hiddenElems.at(-1);
+  if (lastHidden?.parentNode !== domRoot || lastHidden.previousSibling) {
+    // Manipulation is not appropriate, either because there is more than one
+    // hidden element or because the only one is not at the beginning.
     return;
   }
-  const clone = document.createElement('div');
-  clone.append(singleRange.cloneContents());
-  const lastHidden = [...clone.querySelectorAll("span[aria-hidden='true']")].at(-1);
-  if (lastHidden.previousSibling || lastHidden.parentNode !== clone) {
-    return;
+  evt.clipboardData.setData('text/plain', domRoot.textContent.trimStart());
+  if (!html) {
+    evt.clipboardData.setData('text/html', domRoot.innerHTML);
   }
-  evt.clipboardData.setData('text/plain', clone.textContent.trimStart());
-  evt.clipboardData.setData('text/html', clone.innerHTML);
   evt.preventDefault();
 });

--- a/js/listNumbers.js
+++ b/js/listNumbers.js
@@ -126,3 +126,22 @@ document.addEventListener('DOMContentLoaded', () => {
     addStepNumberText(ol);
   });
 });
+
+// Omit indendation when copying a single algorithm step.
+document.addEventListener('copy', evt => {
+  const selection = getSelection();
+  const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
+  const container = singleRange?.commonAncestorContainer;
+  if (!container?.querySelector("span[aria-hidden='true']")) {
+    return;
+  }
+  const clone = document.createElement('div');
+  clone.append(singleRange.cloneContents());
+  const lastHidden = [...clone.querySelectorAll("span[aria-hidden='true']")].at(-1);
+  if (lastHidden.previousSibling || lastHidden.parentNode !== clone) {
+    return;
+  }
+  evt.clipboardData.setData('text/plain', clone.textContent.trimStart());
+  evt.clipboardData.setData('text/html', clone.innerHTML);
+  evt.preventDefault();
+});

--- a/js/listNumbers.js
+++ b/js/listNumbers.js
@@ -108,6 +108,7 @@ function addStepNumberText(
     const extraIndent = ' '.repeat(markerText.length + 2);
     marker.textContent = `${indent}${markerText}. `;
     marker.setAttribute('aria-hidden', 'true');
+    marker.setAttribute('class', 'list-marker');
     const attributesContainer = li.querySelector('.attributes-tag');
     if (attributesContainer == null) {
       li.prepend(marker);
@@ -129,6 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Omit indendation when copying a single algorithm step.
 document.addEventListener('copy', evt => {
+  // Construct a DOM from the selection.
   const doc = document.implementation.createHTMLDocument('');
   const domRoot = doc.createElement('div');
   const html = evt.clipboardData.getData('text/html');
@@ -138,18 +140,33 @@ document.addEventListener('copy', evt => {
     const selection = getSelection();
     const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
     const container = singleRange?.commonAncestorContainer;
-    if (!container?.querySelector?.("span[aria-hidden='true']")) {
+    if (!container?.querySelector?.('.list-marker')) {
       return;
     }
     domRoot.append(singleRange.cloneContents());
   }
-  const hiddenElems = [...domRoot.querySelectorAll("span[aria-hidden='true']")];
-  const lastHidden = hiddenElems.at(-1);
-  if (lastHidden?.parentNode !== domRoot || lastHidden.previousSibling) {
-    // Manipulation is not appropriate, either because there is more than one
-    // hidden element or because the only one is not at the beginning.
+
+  // Preserve the indentation if there is no hidden list marker, or if selection
+  // of more than one step is indicated by either multiple such markers or by
+  // visible text before the first one.
+  const listMarkers = domRoot.querySelectorAll('.list-marker');
+  if (listMarkers.length !== 1) {
     return;
   }
+  const treeWalker = document.createTreeWalker(domRoot, undefined, {
+    acceptNode(node) {
+      return node.nodeType === Node.TEXT_NODE || node === listMarkers[0]
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_SKIP;
+    },
+  });
+  while (treeWalker.nextNode()) {
+    const node = treeWalker.currentNode;
+    if (node.nodeType === Node.ELEMENT_NODE) break;
+    if (/\S/u.test(node.data)) return;
+  }
+
+  // Strip leading indentation from the plain text representation.
   evt.clipboardData.setData('text/plain', domRoot.textContent.trimStart());
   if (!html) {
     evt.clipboardData.setData('text/html', domRoot.innerHTML);

--- a/js/listNumbers.js
+++ b/js/listNumbers.js
@@ -80,6 +80,7 @@ const counterByDepth = [];
 function addStepNumberText(
   ol,
   depth = 0,
+  indent = '',
   special = [...ol.classList].some(c => c.startsWith('nested-')),
 ) {
   let counter = !special && counterByDepth[depth];
@@ -103,7 +104,9 @@ function addStepNumberText(
   let i = (Number(ol.getAttribute('start')) || 1) - 1;
   for (const li of ol.children) {
     const marker = document.createElement('span');
-    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    const markerText = i < cache.length ? cache[i] : getTextForIndex(i);
+    const extraIndent = ' '.repeat(markerText.length + 2);
+    marker.textContent = `${indent}${markerText}. `;
     marker.setAttribute('aria-hidden', 'true');
     const attributesContainer = li.querySelector('.attributes-tag');
     if (attributesContainer == null) {
@@ -112,7 +115,7 @@ function addStepNumberText(
       attributesContainer.insertAdjacentElement('afterend', marker);
     }
     for (const sublist of li.querySelectorAll(':scope > ol')) {
-      addStepNumberText(sublist, depth + 1, special);
+      addStepNumberText(sublist, depth + 1, indent + extraIndent, special);
     }
     i++;
   }

--- a/spec/index.html
+++ b/spec/index.html
@@ -367,7 +367,10 @@ markEffects: true
       1. Set _length_ to _length_ + 1.
       1. Let _weight_ be GetWeight of _node_.
       1. If _length_ = 10&lt;sup>9&lt;/sup> or _weight_ &gt; 2&lt;sup>_length_ + 1&lt;/sup>, then
-        1. Throw a *RangeError* exception.
+        1. NOTE: This is an out-of-bounds state.
+        1. If _ignoreErrors_ is not *true*, then
+          1. Throw a *RangeError* exception.
+        1. Set _hadError_ to *true*.
     &lt;/emu-alg>
   </code></pre>
 
@@ -386,7 +389,10 @@ markEffects: true
       1. Set _length_ to _length_ + 1.
       1. Let _weight_ be GetWeight of _node_.
       1. If _length_ = 10<sup>9</sup> or _weight_ > 2<sup>_length_ + 1</sup>, then
-        1. Throw a *RangeError* exception.
+        1. NOTE: This is an out-of-bounds state.
+        1. If _ignoreErrors_ is not *true*, then
+          1. Throw a *RangeError* exception.
+        1. Set _hadError_ to *true*.
     </emu-alg>
   </aside>
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1486,6 +1486,25 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+// Omit indendation when copying a single algorithm step.
+document.addEventListener('copy', evt => {
+  const selection = getSelection();
+  const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
+  const container = singleRange?.commonAncestorContainer;
+  if (!container?.querySelector("span[aria-hidden='true']")) {
+    return;
+  }
+  const clone = document.createElement('div');
+  clone.append(singleRange.cloneContents());
+  const lastHidden = [...clone.querySelectorAll("span[aria-hidden='true']")].at(-1);
+  if (lastHidden.previousSibling || lastHidden.parentNode !== clone) {
+    return;
+  }
+  evt.clipboardData.setData('text/plain', clone.textContent.trimStart());
+  evt.clipboardData.setData('text/html', clone.innerHTML);
+  evt.preventDefault();
+});
+
 'use strict';
 
 // Update superscripts to not suffer misinterpretation when copied and pasted as plain text.

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1488,20 +1488,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Omit indendation when copying a single algorithm step.
 document.addEventListener('copy', evt => {
-  const selection = getSelection();
-  const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
-  const container = singleRange?.commonAncestorContainer;
-  if (!container?.querySelector("span[aria-hidden='true']")) {
+  const doc = document.implementation.createHTMLDocument('');
+  const domRoot = doc.createElement('div');
+  const html = evt.clipboardData.getData('text/html');
+  if (html) {
+    domRoot.innerHTML = html;
+  } else {
+    const selection = getSelection();
+    const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
+    const container = singleRange?.commonAncestorContainer;
+    if (!container?.querySelector?.("span[aria-hidden='true']")) {
+      return;
+    }
+    domRoot.append(singleRange.cloneContents());
+  }
+  const hiddenElems = [...domRoot.querySelectorAll("span[aria-hidden='true']")];
+  const lastHidden = hiddenElems.at(-1);
+  if (lastHidden?.parentNode !== domRoot || lastHidden.previousSibling) {
+    // Manipulation is not appropriate, either because there is more than one
+    // hidden element or because the only one is not at the beginning.
     return;
   }
-  const clone = document.createElement('div');
-  clone.append(singleRange.cloneContents());
-  const lastHidden = [...clone.querySelectorAll("span[aria-hidden='true']")].at(-1);
-  if (lastHidden.previousSibling || lastHidden.parentNode !== clone) {
-    return;
+  evt.clipboardData.setData('text/plain', domRoot.textContent.trimStart());
+  if (!html) {
+    evt.clipboardData.setData('text/html', domRoot.innerHTML);
   }
-  evt.clipboardData.setData('text/plain', clone.textContent.trimStart());
-  evt.clipboardData.setData('text/html', clone.innerHTML);
   evt.preventDefault();
 });
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1439,6 +1439,7 @@ const counterByDepth = [];
 function addStepNumberText(
   ol,
   depth = 0,
+  indent = '',
   special = [...ol.classList].some(c => c.startsWith('nested-')),
 ) {
   let counter = !special && counterByDepth[depth];
@@ -1462,7 +1463,9 @@ function addStepNumberText(
   let i = (Number(ol.getAttribute('start')) || 1) - 1;
   for (const li of ol.children) {
     const marker = document.createElement('span');
-    marker.textContent = `${i < cache.length ? cache[i] : getTextForIndex(i)}. `;
+    const markerText = i < cache.length ? cache[i] : getTextForIndex(i);
+    const extraIndent = ' '.repeat(markerText.length + 2);
+    marker.textContent = `${indent}${markerText}. `;
     marker.setAttribute('aria-hidden', 'true');
     const attributesContainer = li.querySelector('.attributes-tag');
     if (attributesContainer == null) {
@@ -1471,7 +1474,7 @@ function addStepNumberText(
       attributesContainer.insertAdjacentElement('afterend', marker);
     }
     for (const sublist of li.querySelectorAll(':scope > ol')) {
-      addStepNumberText(sublist, depth + 1, special);
+      addStepNumberText(sublist, depth + 1, indent + extraIndent, special);
     }
     i++;
   }
@@ -1684,6 +1687,7 @@ body.oldtoc {
 
 span[aria-hidden='true'] {
   font-size: 0;
+  white-space: pre;
 }
 
 a {

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1467,6 +1467,7 @@ function addStepNumberText(
     const extraIndent = ' '.repeat(markerText.length + 2);
     marker.textContent = `${indent}${markerText}. `;
     marker.setAttribute('aria-hidden', 'true');
+    marker.setAttribute('class', 'list-marker');
     const attributesContainer = li.querySelector('.attributes-tag');
     if (attributesContainer == null) {
       li.prepend(marker);
@@ -1488,6 +1489,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Omit indendation when copying a single algorithm step.
 document.addEventListener('copy', evt => {
+  // Construct a DOM from the selection.
   const doc = document.implementation.createHTMLDocument('');
   const domRoot = doc.createElement('div');
   const html = evt.clipboardData.getData('text/html');
@@ -1497,18 +1499,33 @@ document.addEventListener('copy', evt => {
     const selection = getSelection();
     const singleRange = selection?.rangeCount === 1 && selection.getRangeAt(0);
     const container = singleRange?.commonAncestorContainer;
-    if (!container?.querySelector?.("span[aria-hidden='true']")) {
+    if (!container?.querySelector?.('.list-marker')) {
       return;
     }
     domRoot.append(singleRange.cloneContents());
   }
-  const hiddenElems = [...domRoot.querySelectorAll("span[aria-hidden='true']")];
-  const lastHidden = hiddenElems.at(-1);
-  if (lastHidden?.parentNode !== domRoot || lastHidden.previousSibling) {
-    // Manipulation is not appropriate, either because there is more than one
-    // hidden element or because the only one is not at the beginning.
+
+  // Preserve the indentation if there is no hidden list marker, or if selection
+  // of more than one step is indicated by either multiple such markers or by
+  // visible text before the first one.
+  const listMarkers = domRoot.querySelectorAll('.list-marker');
+  if (listMarkers.length !== 1) {
     return;
   }
+  const treeWalker = document.createTreeWalker(domRoot, undefined, {
+    acceptNode(node) {
+      return node.nodeType === Node.TEXT_NODE || node === listMarkers[0]
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_SKIP;
+    },
+  });
+  while (treeWalker.nextNode()) {
+    const node = treeWalker.currentNode;
+    if (node.nodeType === Node.ELEMENT_NODE) break;
+    if (/\S/u.test(node.data)) return;
+  }
+
+  // Strip leading indentation from the plain text representation.
   evt.clipboardData.setData('text/plain', domRoot.textContent.trimStart());
   if (!html) {
     evt.clipboardData.setData('text/html', domRoot.innerHTML);


### PR DESCRIPTION
This results in better copied text, e.g.
```
b. Set length to length + 1.
c. Let weight be GetWeight of node.
d. If length = 10**9 or weight > 2**(length + 1), then
   i. NOTE: This is an out-of-bounds state.
   ii. If ignoreErrors is not true, then
       1. Throw a RangeError exception.
   iii. Set hadError to true.
```
rather than
```
b. Set length to length + 1.
c. Let weight be GetWeight of node.
d. If length = 10**9 or weight > 2**(length + 1), then
i. NOTE: This is an out-of-bounds state.
ii. If ignoreErrors is not true, then
1. Throw a RangeError exception.
iii. Set hadError to true.
```