### PR TITLE
Fix emu-format --check with multiple files

### DIFF
--- a/src/formatter/cli.ts
+++ b/src/formatter/cli.ts
@@ -99,17 +99,11 @@ function usage() {
   }
 
   const touched = [];
-  if (!write) {
+  if (!write && !check) {
     const input = await fs.readFile(files[0], 'utf8');
     const printed = await printDocument(input);
-    if (check) {
-      if (printed !== input) {
-        touched.push(files[0]);
-      }
-    } else {
-      // printDocument includes a newline
-      process.stdout.write(printed);
-    }
+    // printDocument includes a newline
+    process.stdout.write(printed);
   } else {
     for (const file of files) {
       console.log(`Processing ${file}`);

--- a/test/cli.js
+++ b/test/cli.js
@@ -38,3 +38,32 @@ describe('ecmarkup#cli', function () {
     });
   });
 });
+
+describe('emu-format --check', function () {
+  this.timeout(4000);
+
+  it('exits cleanly if the file needs no formatting', () => {
+    execSync(`${execPath} ./bin/emu-format.js --check test/format-good.html`, {
+      encoding: 'utf8',
+    });
+  });
+
+  it('exits with an error if the file needs formatting', () => {
+    assert.throws(() => {
+      execSync(`${execPath} ./bin/emu-format.js --check test/format-bad.html`, {
+        encoding: 'utf8',
+      });
+    });
+  });
+
+  it('exits with an error if any files in the list need formatting', () => {
+    assert.throws(() => {
+      execSync(
+        `${execPath} ./bin/emu-format.js --check test/format-good.html test/format-bad.html`,
+        {
+          encoding: 'utf8',
+        },
+      );
+    });
+  });
+});

--- a/test/format-bad.html
+++ b/test/format-bad.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="css/elements.css">
+<script src="ecmarkup.js"></script>
+
+<emu-clause id="c1">
+
+  <h1>Clause Foo( _a_, _b_ )</h1>
+
+  <emu-alg>
+    1. Call Foo(_a_).
+    1. Call Bar(`toString`).
+    1. Call Baz(*true*).
+      1. Do something else.
+      1. And again.
+    </emu-alg>
+</emu-clause>

--- a/test/format-good.html
+++ b/test/format-good.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="css/elements.css">
+<script src="ecmarkup.js"></script>
+
+<emu-clause id="c1">
+  <h1>Clause Foo(_a_, _b_)</h1>
+
+  <emu-alg>
+    1. Call Foo(_a_).
+    1. Call Bar(`toString`).
+    1. Call Baz(*true*).
+      1. Do something else.
+      1. And again.
+  </emu-alg>
+</emu-clause>


### PR DESCRIPTION
Previously, running emu-format --check with multiple files would only check the first file. Fix the CLI arguments processing logic so that the only special case for a list of one file is when it needs to be printed to stdout. Move checking into the loop through the file list, as is done with writing.

Closes: #606