### PR TITLE
handle ins/del in completion-record typechecks

### DIFF
--- a/src/typechecker.ts
+++ b/src/typechecker.ts
@@ -347,17 +347,19 @@ function previousText(expr: Expr, path: PathItem[]): string | null {
 
 function textFromPreviousPart(seq: Seq, index: number): string | null {
   let prevIndex = index - 1;
+  let text = null;
   let prev;
   while (isProsePart((prev = seq.items[prevIndex]))) {
     if (prev.name === 'text') {
-      return prev.contents;
+      text = prev.contents + (text ?? '');
+      --prevIndex;
     } else if (prev.name === 'tag') {
       --prevIndex;
     } else {
       break;
     }
   }
-  return null;
+  return text;
 }
 
 function stripWhitespace(items: NonSeq[]) {

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -204,6 +204,7 @@ describe('typechecking completions', () => {
             1. Set _a_ to ! ExampleAlg().
             1. Return ? ExampleAlg().
             1. Return <ins>?</ins> ExampleAlg().
+            1. Return <del>?</del> <ins>!</ins> ExampleAlg().
             1. Let _foo_ be 0.
             1. Set _a_ to Completion(ExampleSDO of _foo_).
             1. Set _a_ to Completion(ExampleSDO of _foo_ with argument 0).

--- a/test/typecheck.js
+++ b/test/typecheck.js
@@ -203,6 +203,7 @@ describe('typechecking completions', () => {
             1. Set _a_ to Completion(<emu-meta suppress-effects="user-code">ExampleAlg()</emu-meta>).
             1. Set _a_ to ! ExampleAlg().
             1. Return ? ExampleAlg().
+            1. Return <ins>?</ins> ExampleAlg().
             1. Let _foo_ be 0.
             1. Set _a_ to Completion(ExampleSDO of _foo_).
             1. Set _a_ to Completion(ExampleSDO of _foo_ with argument 0).
@@ -284,6 +285,7 @@ describe('typechecking completions', () => {
         </dl>
         <emu-alg>
           1. Return ExampleAlg().
+          1. Return <del>!</del> ExampleAlg().
         </emu-alg>
         </emu-clause>
       `);


### PR DESCRIPTION
Fixes https://github.com/tc39/ecmarkup/issues/608.

The typechecker is already using the expr-parser output, which strips ins/del, but the result of that parse can have multiple adjacent `name: 'text'` items in sequence, which the typechecker didn't account for here. Specifically, with the input `<ins>?</ins> Foo()` we end up with `[{ name: 'text', content: '?' }, { name: 'text', content: ' ' }, foo]`. Adjust the logic to handle this case.