### PR TITLE
Support Dark Mode

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -1563,7 +1563,7 @@ li.menu-search-result-term::before {
 
 emu-normative-optional::before {
   display: block;
-  color: #884400;
+  color: var(--attributes-tag-foreground-color);
   content: "NORMATIVE OPTIONAL";
 }
 

--- a/css/elements.css
+++ b/css/elements.css
@@ -79,7 +79,7 @@
 }
 
 @supports (color-scheme: dark) {
-  @media (prefers-color-scheme: dark) {
+  @media only screen and (prefers-color-scheme: dark) {
     :root {
       --foreground-color: #fcfcfc;
       --background-color: #171717;
@@ -387,7 +387,7 @@ var {
 }
 
 @supports (color-scheme: dark) {
-  @media (prefers-color-scheme: dark) {
+  @media only screen and (prefers-color-scheme: dark) {
     var {
       mix-blend-mode: normal;
     }

--- a/css/elements.css
+++ b/css/elements.css
@@ -60,6 +60,8 @@
   --control-input-background-color: #bbb;
   --control-input-border-color: #999;
 
+  --menu-header-background-color: #bbb;
+  --menu-revealed-link-foreground-color: #206ca7;
   --menu-unpin-hover-foreground-color: #bb1212;
 
   --menu-trace-list-foreground-color: #999;
@@ -77,85 +79,87 @@
 }
 
 @supports (color-scheme: dark) {
-@media (prefers-color-scheme: dark) {
-:root {
-  --foreground-color: #fcfcfc;
-  --background-color: #171717;
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --foreground-color: #fcfcfc;
+      --background-color: #171717;
 
-  --link-foreground-color: #439de2;
-  --link-hover-foreground-color: #80cafb;
+      --link-foreground-color: #439de2;
+      --link-hover-foreground-color: #80cafb;
 
-  --user-code-foreground-color: brown;
+      --user-code-foreground-color: brown;
 
-  --var-foreground-color: #4fb6ab;
+      --var-foreground-color: #4fb6ab;
 
-  --referenced0-background-color: #9c9c1d;
-  --referenced1-background-color: #7e171c;
-  --referenced2-background-color: #1f6211;
-  --referenced3-background-color: #1a7a6b;
-  --referenced4-background-color: #7b4719;
-  --referenced5-background-color: #185870;
-  --referenced6-background-color: #731761;
+      --referenced0-background-color: #6d6d1e;
+      --referenced1-background-color: #7e171c;
+      --referenced2-background-color: #1f6211;
+      --referenced3-background-color: #1a7a6b;
+      --referenced4-background-color: #7b4719;
+      --referenced5-background-color: #185870;
+      --referenced6-background-color: #731761;
 
-  --note-background-color: #223c22;
-  --note-border-color: #31a331;
-  --note-editor-border-color: #801e1e;
+      --note-background-color: #1b2f1b;
+      --note-border-color: #31a331;
+      --note-editor-border-color: #801e1e;
 
-  --nt-link-foreground-color: #d0d0d0;
+      --nt-link-foreground-color: #d0d0d0;
 
-  --production-rhs-background-color: #4d4d4d;
-  --production-rhs-border-color: #888;
+      --production-rhs-background-color: #4d4d4d;
+      --production-rhs-border-color: #888;
 
-  --params-foreground-color: #57d0c7;
-  --opt-foreground-color: #d8b750;
+      --params-foreground-color: #57d0c7;
+      --opt-foreground-color: #d8b750;
 
-  --title-foreground-color: #f60;
+      --title-foreground-color: #f60;
 
-  --caption-foreground-color: #b0b0b0;
+      --caption-foreground-color: #b0b0b0;
 
-  --table-header-background-color: #404040;
+      --table-header-background-color: #303030;
 
-  --highlight-background-color-start: rgba(114, 105, 24, 1);
-  --highlight-background-color-end: rgba(114, 105, 24, 0);
+      --highlight-background-color-start: rgba(114, 105, 24, 1);
+      --highlight-background-color-end: rgba(114, 105, 24, 0);
 
-  --highlight-background-color: rgba(114, 105, 24, 1);
+      --highlight-background-color: rgba(114, 105, 24, 1);
 
-  --ins-background-color: #1e4a1e;
-  --ins-border-color: #61d89b;
+      --ins-background-color: #1e4a1e;
+      --ins-border-color: #61d89b;
 
-  --del-background-color: #4a1f1f;
+      --del-background-color: #4a1f1f;
 
-  --control-foreground-color: #101010;
-  --control-dimmed-foreground-color: #d0d0d0;
-  --control-background-color: #303030;
-  --control-dark-background-color: #505050;
-  --control-border-color: #505050;
-  --control-light-border-color: #606060;
-  --control-shortcut-background-color: #505050;
-  --control-shortcut-shadow-color: #000000;
-  --control-dialog-fade-color: rgba(0, 0, 0, 0.6);
+      --control-foreground-color: #101010;
+      --control-dimmed-foreground-color: #d0d0d0;
+      --control-background-color: #202020;
+      --control-dark-background-color: #303030;
+      --control-border-color: #505050;
+      --control-light-border-color: #606060;
+      --control-shortcut-background-color: #505050;
+      --control-shortcut-shadow-color: #000000;
+      --control-dialog-fade-color: rgba(0, 0, 0, 0.6);
 
-  --control-link-foreground-color: #7ebce9;
+      --control-link-foreground-color: #7ebce9;
 
-  --control-input-background-color: #606060;
-  --control-input-border-color: #a0a0a0;
+      --control-input-background-color: #606060;
+      --control-input-border-color: #a0a0a0;
 
-  --menu-unpin-hover-foreground-color: #e77373;
+      --menu-header-background-color: #404040;
+      --menu-revealed-link-foreground-color: #9bd0f7;
+      --menu-unpin-hover-foreground-color: #f29c9c;
 
-  --menu-trace-list-foreground-color: #222;
-  --menu-trace-list-background-color: #999;
+      --menu-trace-list-foreground-color: #222;
+      --menu-trace-list-background-color: #999;
 
-  --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
-  --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+      --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+      --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
 
-  --normative-optional-background-color: #352c24;
-  --normative-optional-border-color: #ff6600;
+      --normative-optional-background-color: #352c24;
+      --normative-optional-border-color: #ff6600;
 
-  --attributes-tag-foreground-color: #b9824b;
+      --attributes-tag-foreground-color: #e6a96d;
 
-  --figure-background: #fff;
-}
-}
+      --figure-background: #fff;
+    }
+  }
 }
 
 /* IBM Plex fonts (Latin subset) have been downloaded from Google Fonts and modified to add support back in for the `zero` substitution (slashed zeroes) */
@@ -383,11 +387,11 @@ var {
 }
 
 @supports (color-scheme: dark) {
-@media (prefers-color-scheme: dark) {
-var {
-  mix-blend-mode: normal;
-}
-}
+  @media (prefers-color-scheme: dark) {
+    var {
+      mix-blend-mode: normal;
+    }
+  }
 }
 
 var.field {
@@ -396,7 +400,7 @@ var.field {
 }
 /* suppress line break opportunities between `.` and `[[FieldName]]` */
 var.field::before {
-  content: '\2060'
+  content: '\2060';
 }
 
 var.referenced {
@@ -978,7 +982,7 @@ table.lightweight-table th {
     background-color: var(--highlight-background-color-start);
   }
   100% {
-    background-color: var(--highlight-background-color-end)
+    background-color: var(--highlight-background-color-end);
   }
 }
 #spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {
@@ -1232,7 +1236,7 @@ tr.del > td {
 }
 
 #menu-toc li.revealed-leaf > a {
-  color: var(--link-foreground-color);
+  color: var(--menu-revealed-link-foreground-color);
 }
 
 #menu-toc li.revealed > ol {
@@ -1249,7 +1253,7 @@ tr.del > td {
 
 .menu-pane-header {
   padding: 2px 8px;
-  background-color: var(--control-light-border-color);
+  background-color: var(--menu-header-background-color);
   font-weight: bold;
   letter-spacing: 1px;
   flex-grow: 0;
@@ -1274,6 +1278,10 @@ tr.del > td {
 
 .menu-pane-header emu-geq {
   margin-left: 0px;
+}
+
+.menu-pane-header a {
+  color: var(--control-link-foreground-color);
 }
 
 a.menu-pane-header-production {

--- a/css/elements.css
+++ b/css/elements.css
@@ -1,3 +1,163 @@
+:root {
+  --foreground-color: #111;
+  --background-color: #fff;
+
+  --link-foreground-color: #206ca7;
+  --link-hover-foreground-color: #239dee;
+
+  --user-code-foreground-color: brown;
+
+  --var-foreground-color: #218379;
+
+  --referenced0-background-color: #ffff6c;
+  --referenced1-background-color: #ffa4a8;
+  --referenced2-background-color: #96e885;
+  --referenced3-background-color: #3eeed2;
+  --referenced4-background-color: #eacfb6;
+  --referenced5-background-color: #82ddff;
+  --referenced6-background-color: #ffbcf2;
+
+  --note-background-color: #e9fbe9;
+  --note-border-color: #52e052;
+  --note-editor-border-color: #faa;
+
+  --nt-link-foreground-color: #333;
+
+  --production-rhs-background-color: #f0f0f0;
+  --production-rhs-border-color: #888;
+
+  --params-foreground-color: #2aa198;
+  --opt-foreground-color: #b58900;
+
+  --title-foreground-color: #f60;
+
+  --caption-foreground-color: #555555;
+
+  --table-header-background-color: #eeeeee;
+
+  --highlight-background-color-start: rgba(249, 241, 172, 1);
+  --highlight-background-color-end: rgba(249, 241, 172, 0);
+
+  --highlight-background-color: rgba(249, 241, 172, 1);
+
+  --ins-background-color: #e0f8e0;
+  --ins-border-color: #396;
+
+  --del-background-color: #fee;
+
+  --control-foreground-color: #eee;
+  --control-dimmed-foreground-color: #666;
+  --control-background-color: #ddd;
+  --control-dark-background-color: #ccc;
+  --control-border-color: #aaa;
+  --control-light-border-color: #bbb;
+  --control-shortcut-background-color: #eee;
+  --control-shortcut-shadow-color: #ccc;
+  --control-dialog-fade-color: rgba(255, 255, 255, 0.6);
+
+  --control-link-foreground-color: #1567a2;
+
+  --control-input-background-color: #bbb;
+  --control-input-border-color: #999;
+
+  --menu-unpin-hover-foreground-color: #bb1212;
+
+  --menu-trace-list-foreground-color: #999;
+  --menu-trace-list-background-color: #222;
+
+  --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+  --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+
+  --normative-optional-background-color: #ffeedd;
+  --normative-optional-border-color: #ff6600;
+
+  --attributes-tag-foreground-color: #884400;
+
+  --figure-background: #fff;
+}
+
+@supports (color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
+:root {
+  --foreground-color: #fcfcfc;
+  --background-color: #171717;
+
+  --link-foreground-color: #439de2;
+  --link-hover-foreground-color: #80cafb;
+
+  --user-code-foreground-color: brown;
+
+  --var-foreground-color: #4fb6ab;
+
+  --referenced0-background-color: #9c9c1d;
+  --referenced1-background-color: #7e171c;
+  --referenced2-background-color: #1f6211;
+  --referenced3-background-color: #1a7a6b;
+  --referenced4-background-color: #7b4719;
+  --referenced5-background-color: #185870;
+  --referenced6-background-color: #731761;
+
+  --note-background-color: #223c22;
+  --note-border-color: #31a331;
+  --note-editor-border-color: #801e1e;
+
+  --nt-link-foreground-color: #d0d0d0;
+
+  --production-rhs-background-color: #4d4d4d;
+  --production-rhs-border-color: #888;
+
+  --params-foreground-color: #57d0c7;
+  --opt-foreground-color: #d8b750;
+
+  --title-foreground-color: #f60;
+
+  --caption-foreground-color: #b0b0b0;
+
+  --table-header-background-color: #404040;
+
+  --highlight-background-color-start: rgba(114, 105, 24, 1);
+  --highlight-background-color-end: rgba(114, 105, 24, 0);
+
+  --highlight-background-color: rgba(114, 105, 24, 1);
+
+  --ins-background-color: #1e4a1e;
+  --ins-border-color: #61d89b;
+
+  --del-background-color: #4a1f1f;
+
+  --control-foreground-color: #101010;
+  --control-dimmed-foreground-color: #d0d0d0;
+  --control-background-color: #303030;
+  --control-dark-background-color: #505050;
+  --control-border-color: #505050;
+  --control-light-border-color: #606060;
+  --control-shortcut-background-color: #505050;
+  --control-shortcut-shadow-color: #000000;
+  --control-dialog-fade-color: rgba(0, 0, 0, 0.6);
+
+  --control-link-foreground-color: #7ebce9;
+
+  --control-input-background-color: #606060;
+  --control-input-border-color: #a0a0a0;
+
+  --menu-unpin-hover-foreground-color: #e77373;
+
+  --menu-trace-list-foreground-color: #222;
+  --menu-trace-list-background-color: #999;
+
+  --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+  --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+
+  --normative-optional-background-color: #352c24;
+  --normative-optional-border-color: #ff6600;
+
+  --attributes-tag-foreground-color: #b9824b;
+
+  --figure-background: #fff;
+}
+}
+}
+
 /* IBM Plex fonts (Latin subset) have been downloaded from Google Fonts and modified to add support back in for the `zero` substitution (slashed zeroes) */
 
 /* https://fonts.googleapis.com/css2?family=IBM%20Plex%20Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap */
@@ -91,7 +251,7 @@
 }
 
 html {
-  background-color: #fff;
+  background-color: var(--background-color);
 }
 
 body {
@@ -105,7 +265,7 @@ body {
   font-variant-numeric: slashed-zero;
   padding: 0;
   margin: 0;
-  color: #111;
+  color: var(--foreground-color);
 }
 
 #spec-container {
@@ -132,16 +292,16 @@ span[aria-hidden='true'] {
 
 a {
   text-decoration: none;
-  color: #206ca7;
+  color: var(--link-foreground-color);
 }
 
 a:visited {
-  color: #206ca7;
+  color: var(--link-foreground-color);
 }
 
 a:hover {
   text-decoration: underline;
-  color: #239dee;
+  color: var(--link-hover-foreground-color);
 }
 
 a.e-user-code,
@@ -152,9 +312,9 @@ span.e-user-code {
 a.e-user-code::before,
 span.e-user-code::before {
   display: none;
-  color: brown;
-  background-color: white;
-  border: 2pt solid brown;
+  color: var(--user-code-foreground-color);
+  background-color: var(--background-color);
+  border: 2pt solid var(--user-code-foreground-color);
   padding: 0.3ex;
   margin: 0 0.25em 0 0;
   line-height: normal;
@@ -169,8 +329,8 @@ span.e-user-code::before {
 
 a.e-user-code:hover::before,
 span.e-user-code:hover::before {
-  background-color: brown;
-  color: white;
+  background-color: var(--user-code-foreground-color);
+  color: var(--background-color);
 }
 
 html.show-ao-annotations a.e-user-code::before,
@@ -197,7 +357,7 @@ pre code {
 }
 
 pre code.hljs {
-  background-color: #fff;
+  background-color: var(--background-color);
   margin: 0;
   padding: 0;
 }
@@ -214,13 +374,22 @@ ol.toc ol.toc {
 
 var {
   border-radius: 5px;
-  color: #218379;
+  color: var(--var-foreground-color);
   transition: all 0.25s ease-out;
   cursor: pointer;
   padding: 0 4px;
   margin: 0 -4px;
   mix-blend-mode: multiply;
 }
+
+@supports (color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
+var {
+  mix-blend-mode: normal;
+}
+}
+}
+
 var.field {
   font: inherit;
   color: inherit;
@@ -235,25 +404,25 @@ var.referenced {
 }
 
 var.referenced0 {
-  background-color: #ffff6c;
+  background-color: var(--referenced0-background-color);
 }
 var.referenced1 {
-  background-color: #ffa4a8;
+  background-color: var(--referenced1-background-color);
 }
 var.referenced2 {
-  background-color: #96e885;
+  background-color: var(--referenced2-background-color);
 }
 var.referenced3 {
-  background-color: #3eeed2;
+  background-color: var(--referenced3-background-color);
 }
 var.referenced4 {
-  background-color: #eacfb6;
+  background-color: var(--referenced4-background-color);
 }
 var.referenced5 {
-  background-color: #82ddff;
+  background-color: var(--referenced5-background-color);
 }
 var.referenced6 {
-  background-color: #ffbcf2;
+  background-color: var(--referenced6-background-color);
 }
 
 emu-const {
@@ -326,8 +495,8 @@ emu-note {
   gap: 1em;
   flex-direction: row;
   color: inherit;
-  border-left: 5px solid #52e052;
-  background: #e9fbe9;
+  border-left: 5px solid var(--note-border-color);
+  background: var(--note-background-color);
   padding: 10px 10px 10px 0;
   overflow-x: auto;
 }
@@ -341,7 +510,7 @@ emu-note > span.note {
 }
 
 emu-note[type='editor'] {
-  border-left-color: #faa;
+  border-left-color: var(--note-editor-border-color);
 }
 
 emu-note > div.note-contents {
@@ -450,7 +619,7 @@ emu-nt {
 
 emu-nt a,
 emu-nt a:visited {
-  color: #333;
+  color: var(--nt-link-foreground-color);
 }
 
 emu-rhs emu-nt {
@@ -482,8 +651,8 @@ emu-production:not([collapsed]) emu-rhs {
 }
 
 emu-production:not([collapsed]) emu-rhs:hover {
-  border-color: #888;
-  background-color: #f0f0f0;
+  border-color: var(--production-rhs-border-color);
+  background-color: var(--production-rhs-background-color);
 }
 
 emu-mods {
@@ -503,11 +672,11 @@ emu-opt {
 
 emu-params,
 emu-constraints {
-  color: #2aa198;
+  color: var(--params-foreground-color);
 }
 
 emu-opt {
-  color: #b58900;
+  color: var(--opt-foreground-color);
 }
 
 emu-gprose {
@@ -522,18 +691,18 @@ emu-production emu-gprose {
 }
 
 h1.shortname {
-  color: #f60;
+  color: var(--title-foreground-color);
   font-size: 1.5em;
   margin: 0;
 }
 
 h1.version {
-  color: #f60;
+  color: var(--title-foreground-color);
   font-size: 1.5em;
 }
 
 h1.title {
-  color: #f60;
+  color: var(--title-foreground-color);
 }
 
 h1,
@@ -750,9 +919,12 @@ figure table.real-table {
 }
 figure figcaption {
   display: block;
-  color: #555555;
+  color: var(--caption-foreground-color);
   font-weight: bold;
   text-align: center;
+}
+figure img {
+  background: var(--figure-background);
 }
 
 emu-table table {
@@ -768,18 +940,18 @@ emu-table td,
 emu-table th,
 table.real-table td,
 table.real-table th {
-  border: 1px solid black;
+  border: 1px solid var(--foreground-color);
   padding: 0.4em;
   vertical-align: baseline;
 }
 emu-table th,
 emu-table thead td,
 table.real-table th {
-  background-color: #eeeeee;
+  background-color: var(--table-header-background-color);
 }
 
 emu-table td {
-  background: #fff;
+  background: var(--background-color);
 }
 
 td[colspan]:not([colspan="1"]), th[colspan]:not([colspan="1"]) {
@@ -803,10 +975,10 @@ table.lightweight-table th {
    and a persistent focus-associated highlight */
 @keyframes highlight-target-bg {
   0% {
-    background-color: rgba(249, 241, 172, 1);
+    background-color: var(--highlight-background-color-start);
   }
   100% {
-    background-color: rgba(249, 241, 172, 0);
+    background-color: var(--highlight-background-color-end)
   }
 }
 #spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {
@@ -814,18 +986,18 @@ table.lightweight-table th {
 }
 #spec-container :target:focus-within:not(:has(:not(a))) {
   animation: none;
-  background-color: rgba(249, 241, 172, 1);
+  background-color: var(--highlight-background-color);
 }
 
 /* diff styles */
 ins {
-  background-color: #e0f8e0;
+  background-color: var(--ins-background-color);
   text-decoration: none;
-  border-bottom: 1px solid #396;
+  border-bottom: 1px solid var(--ins-border-color);
 }
 
 del {
-  background-color: #fee;
+  background-color: var(--del-background-color);
 }
 
 ins.block,
@@ -846,11 +1018,11 @@ tr.ins > td > ins {
 }
 
 tr.ins > td {
-  background-color: #e0f8e0;
+  background-color: var(--ins-background-color);
 }
 
 tr.del > td {
-  background-color: #fee;
+  background-color: var(--del-background-color);
 }
 
 /* Menu Styles */
@@ -864,8 +1036,8 @@ tr.del > td {
   height: 1.5em;
   z-index: 3;
   visibility: hidden;
-  color: #1567a2;
-  background-color: #fff;
+  color: var(--control-link-foreground-color);
+  background-color: var(--background-color);
 
   line-height: 1.5em;
   text-align: center;
@@ -886,14 +1058,14 @@ tr.del > td {
   height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
-  background-color: #ddd;
+  background-color: var(--control-background-color);
   overflow: hidden;
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
   left: 0;
   top: 0;
-  border-right: 2px solid #bbb;
+  border-right: 2px solid var(--control-light-border-color);
 
   z-index: 2;
 }
@@ -906,7 +1078,7 @@ tr.del > td {
 }
 
 #menu a {
-  color: #1567a2;
+  color: var(--control-link-foreground-color);
 }
 
 #menu.active {
@@ -926,7 +1098,7 @@ tr.del > td {
 
 #menu-pins .unpin-all {
   border: none;
-  background: #ccc;
+  background: var(--control-dark-background-color);
   border-radius: 4px;
   height: 18px;
   font-size: 12px;
@@ -934,7 +1106,7 @@ tr.del > td {
   font-family: 'IBM Plex Sans', sans-serif;
 }
 #menu-pins .unpin-all:hover {
-  background: #ddd;
+  background: var(--control-background-color);
 }
 
 #menu-pins-list {
@@ -968,16 +1140,17 @@ tr.del > td {
 }
 #menu-pins-list > li::before,
 #menu-pins-list > li > .unpin:hover {
-  background: #ccc;
+  background: var(--control-dark-background-color);
 }
 
 #menu-pins-list > li > .unpin,
 #menu-pins .unpin-all {
   cursor: pointer;
+  color: var(--foreground-color);
 }
 #menu-pins-list > li > .unpin:hover,
 #menu-pins .unpin-all:hover {
-  color: #bb1212;
+  color: var(--menu-unpin-hover-foreground-color);
 }
 
 #menu-pins-list > li::before {
@@ -1054,12 +1227,12 @@ tr.del > td {
 }
 
 #menu-toc li.revealed > a {
-  background-color: #ccc;
+  background-color: var(--control-dark-background-color);
   font-weight: bold;
 }
 
 #menu-toc li.revealed-leaf > a {
-  color: #206ca7;
+  color: var(--link-foreground-color);
 }
 
 #menu-toc li.revealed > ol {
@@ -1076,7 +1249,7 @@ tr.del > td {
 
 .menu-pane-header {
   padding: 2px 8px;
-  background-color: #bbb;
+  background-color: var(--control-light-border-color);
   font-weight: bold;
   letter-spacing: 1px;
   flex-grow: 0;
@@ -1149,8 +1322,9 @@ a.menu-pane-header-production {
   margin: 5px 0 0 0;
   font-size: 1em;
   padding: 2px;
-  background-color: #bbb;
-  border: 1px solid #999;
+  color: var(--foreground-color);
+  background-color: var(--control-input-background-color);
+  border: 1px solid var(--control-input-border-color);
 }
 
 #menu-search-results {
@@ -1164,7 +1338,7 @@ li.menu-search-result-clause::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 li.menu-search-result-op::before {
@@ -1173,7 +1347,7 @@ li.menu-search-result-op::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 
@@ -1183,7 +1357,7 @@ li.menu-search-result-prod::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 
@@ -1193,7 +1367,7 @@ li.menu-search-result-term::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 
@@ -1222,9 +1396,9 @@ li.menu-search-result-term::before {
 }
 #menu-trace-list li::before {
   content: counter(item) ' ';
-  background-color: #222;
+  background-color: var(--menu-trace-list-background-color);
   counter-increment: item;
-  color: #999;
+  color: var(--menu-trace-list-foreground-color);
   width: 20px;
   height: 20px;
   line-height: 20px;
@@ -1290,9 +1464,9 @@ li.menu-search-result-term::before {
 
 .toolbox {
   position: relative;
-  background: #ddd;
-  border: 1px solid #aaa;
-  color: #eee;
+  background: var(--control-background-color);
+  border: 1px solid var(--control-border-color);
+  color: var(--control-foreground-color);
   padding: 5px 7px;
   border-radius: 3px;
 }
@@ -1320,14 +1494,14 @@ li.menu-search-result-term::before {
 }
 
 .toolbox::after {
-  border-color: rgba(0, 0, 0, 0);
-  border-top-color: #ddd;
+  border-color: var(--toolbox-tail-background-outside-color);
+  border-top-color: var(--control-background-color);
   border-width: 10px;
   margin-left: -10px;
 }
 .toolbox::before {
-  border-color: rgba(204, 204, 204, 0);
-  border-top-color: #aaa;
+  border-color: var(--toolbox-tail-border-outside-color);
+  border-top-color: var(--control-border-color);
   border-width: 12px;
   margin-left: -12px;
 }
@@ -1338,7 +1512,7 @@ li.menu-search-result-term::before {
   left: 0;
   right: 0;
   display: none;
-  background-color: #ddd;
+  background-color: var(--control-background-color);
   z-index: 1;
 }
 
@@ -1389,19 +1563,19 @@ emu-normative-optional,
 [normative-optional],
 [deprecated],
 [legacy] {
-  border-left: 5px solid #ff6600;
+  border-left: 5px solid var(--normative-optional-border-color);
   display: block;
   padding: 0.5em;
-  background: #ffeedd;
+  background: var(--normative-optional-background-color);
 }
 
 .attributes-tag {
   text-transform: uppercase;
-  color: #884400;
+  color: var(--attributes-tag-foreground-color);
 }
 
 .attributes-tag a {
-  color: #884400;
+  color: var(--attributes-tag-foreground-color);
 }
 
 /* Shortcuts help dialog */
@@ -1416,10 +1590,10 @@ emu-normative-optional,
   top: calc(5vw + 5vh);
   padding: 30px 90px;
   max-width: 500px;
-  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  outline: solid 10000px var(--control-dialog-fade-color);
   border-radius: 5px;
   border-width: 1px 1px 0 1px;
-  background-color: #ddd;
+  background-color: var(--control-background-color);
   display: none;
 }
 
@@ -1440,7 +1614,11 @@ emu-normative-optional,
   padding: 3px 10px;
   border-radius: 3px;
   border-width: 1px 1px 0 1px;
-  border-color: #bbb;
-  background-color: #eee;
-  box-shadow: inset 0 -1px 0 #ccc;
+  border-color: var(--control-light-border-color);
+  background-color: var(--control-shortcut-background-color);
+  box-shadow: inset 0 -1px 0 var(--control-shortcut-shadow-color);
+}
+
+#ecma-logo {
+  background: var(--figure-background);
 }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1255,7 +1255,7 @@ ${await utils.readFile(path.join(__dirname, '../js/multipage.js'))}
       }/styles/base16/solarized-light.min.css");
       @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/${
         (hljs as any).versionString
-      }/styles/base16/solarized-dark.min.css") (prefers-color-scheme: dark);
+      }/styles/a11y-dark.min.css") (prefers-color-scheme: dark);
     `;
     this.doc.head.appendChild(solarizedStyle);
   }

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1216,12 +1216,48 @@ ${await utils.readFile(path.join(__dirname, '../js/multipage.js'))}
       }
       this.doc.head.appendChild(printStyle);
     }
-    this.addStyle(
-      this.doc.head,
-      `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/${
+    const currentYearStyle = this.doc.createElement('style');
+    currentYearStyle.textContent = `
+    @media print {
+      @page :left {
+        @bottom-right {
+          content: '© Ecma International ${this.opts.date!.getFullYear()}';
+        }
+      }
+      @page :right {
+        @bottom-left {
+          content: '© Ecma International ${this.opts.date!.getFullYear()}';
+        }
+      }
+      @page :first {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+      @page :blank {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+    }
+    `;
+    this.doc.head.appendChild(currentYearStyle);
+    const solarizedStyle = this.doc.createElement('style');
+    solarizedStyle.textContent = `
+      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/${
         (hljs as any).versionString
-      }/styles/base16/solarized-light.min.css`,
-    );
+      }/styles/base16/solarized-light.min.css");
+      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/${
+        (hljs as any).versionString
+      }/styles/base16/solarized-dark.min.css") (prefers-color-scheme: dark);
+    `;
+    this.doc.head.appendChild(solarizedStyle);
   }
 
   private addStyle(head: HTMLHeadElement, href: string, media?: 'all' | 'print' | 'screen') {

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1688,7 +1688,7 @@ let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"se
 }
 
 @supports (color-scheme: dark) {
-  @media (prefers-color-scheme: dark) {
+  @media only screen and (prefers-color-scheme: dark) {
     :root {
       --foreground-color: #fcfcfc;
       --background-color: #171717;
@@ -1996,7 +1996,7 @@ var {
 }
 
 @supports (color-scheme: dark) {
-  @media (prefers-color-scheme: dark) {
+  @media only screen and (prefers-color-scheme: dark) {
     var {
       mix-blend-mode: normal;
     }

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -3172,7 +3172,7 @@ li.menu-search-result-term::before {
 
 emu-normative-optional::before {
   display: block;
-  color: #884400;
+  color: var(--attributes-tag-foreground-color);
   content: "NORMATIVE OPTIONAL";
 }
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1607,7 +1607,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 let sdoMap = JSON.parse(`{}`);
 let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"sec-intro","titleHTML":"Intro","number":""},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
-;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>:root {
+;let usesMultipage = false</script><style>:root {
   --foreground-color: #111;
   --background-color: #fff;
 
@@ -1669,6 +1669,8 @@ let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"se
   --control-input-background-color: #bbb;
   --control-input-border-color: #999;
 
+  --menu-header-background-color: #bbb;
+  --menu-revealed-link-foreground-color: #206ca7;
   --menu-unpin-hover-foreground-color: #bb1212;
 
   --menu-trace-list-foreground-color: #999;
@@ -1686,85 +1688,87 @@ let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"se
 }
 
 @supports (color-scheme: dark) {
-@media (prefers-color-scheme: dark) {
-:root {
-  --foreground-color: #fcfcfc;
-  --background-color: #171717;
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --foreground-color: #fcfcfc;
+      --background-color: #171717;
 
-  --link-foreground-color: #439de2;
-  --link-hover-foreground-color: #80cafb;
+      --link-foreground-color: #439de2;
+      --link-hover-foreground-color: #80cafb;
 
-  --user-code-foreground-color: brown;
+      --user-code-foreground-color: brown;
 
-  --var-foreground-color: #4fb6ab;
+      --var-foreground-color: #4fb6ab;
 
-  --referenced0-background-color: #9c9c1d;
-  --referenced1-background-color: #7e171c;
-  --referenced2-background-color: #1f6211;
-  --referenced3-background-color: #1a7a6b;
-  --referenced4-background-color: #7b4719;
-  --referenced5-background-color: #185870;
-  --referenced6-background-color: #731761;
+      --referenced0-background-color: #6d6d1e;
+      --referenced1-background-color: #7e171c;
+      --referenced2-background-color: #1f6211;
+      --referenced3-background-color: #1a7a6b;
+      --referenced4-background-color: #7b4719;
+      --referenced5-background-color: #185870;
+      --referenced6-background-color: #731761;
 
-  --note-background-color: #223c22;
-  --note-border-color: #31a331;
-  --note-editor-border-color: #801e1e;
+      --note-background-color: #1b2f1b;
+      --note-border-color: #31a331;
+      --note-editor-border-color: #801e1e;
 
-  --nt-link-foreground-color: #d0d0d0;
+      --nt-link-foreground-color: #d0d0d0;
 
-  --production-rhs-background-color: #4d4d4d;
-  --production-rhs-border-color: #888;
+      --production-rhs-background-color: #4d4d4d;
+      --production-rhs-border-color: #888;
 
-  --params-foreground-color: #57d0c7;
-  --opt-foreground-color: #d8b750;
+      --params-foreground-color: #57d0c7;
+      --opt-foreground-color: #d8b750;
 
-  --title-foreground-color: #f60;
+      --title-foreground-color: #f60;
 
-  --caption-foreground-color: #b0b0b0;
+      --caption-foreground-color: #b0b0b0;
 
-  --table-header-background-color: #404040;
+      --table-header-background-color: #303030;
 
-  --highlight-background-color-start: rgba(114, 105, 24, 1);
-  --highlight-background-color-end: rgba(114, 105, 24, 0);
+      --highlight-background-color-start: rgba(114, 105, 24, 1);
+      --highlight-background-color-end: rgba(114, 105, 24, 0);
 
-  --highlight-background-color: rgba(114, 105, 24, 1);
+      --highlight-background-color: rgba(114, 105, 24, 1);
 
-  --ins-background-color: #1e4a1e;
-  --ins-border-color: #61d89b;
+      --ins-background-color: #1e4a1e;
+      --ins-border-color: #61d89b;
 
-  --del-background-color: #4a1f1f;
+      --del-background-color: #4a1f1f;
 
-  --control-foreground-color: #101010;
-  --control-dimmed-foreground-color: #d0d0d0;
-  --control-background-color: #303030;
-  --control-dark-background-color: #505050;
-  --control-border-color: #505050;
-  --control-light-border-color: #606060;
-  --control-shortcut-background-color: #505050;
-  --control-shortcut-shadow-color: #000000;
-  --control-dialog-fade-color: rgba(0, 0, 0, 0.6);
+      --control-foreground-color: #101010;
+      --control-dimmed-foreground-color: #d0d0d0;
+      --control-background-color: #202020;
+      --control-dark-background-color: #303030;
+      --control-border-color: #505050;
+      --control-light-border-color: #606060;
+      --control-shortcut-background-color: #505050;
+      --control-shortcut-shadow-color: #000000;
+      --control-dialog-fade-color: rgba(0, 0, 0, 0.6);
 
-  --control-link-foreground-color: #7ebce9;
+      --control-link-foreground-color: #7ebce9;
 
-  --control-input-background-color: #606060;
-  --control-input-border-color: #a0a0a0;
+      --control-input-background-color: #606060;
+      --control-input-border-color: #a0a0a0;
 
-  --menu-unpin-hover-foreground-color: #e77373;
+      --menu-header-background-color: #404040;
+      --menu-revealed-link-foreground-color: #9bd0f7;
+      --menu-unpin-hover-foreground-color: #f29c9c;
 
-  --menu-trace-list-foreground-color: #222;
-  --menu-trace-list-background-color: #999;
+      --menu-trace-list-foreground-color: #222;
+      --menu-trace-list-background-color: #999;
 
-  --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
-  --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+      --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+      --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
 
-  --normative-optional-background-color: #352c24;
-  --normative-optional-border-color: #ff6600;
+      --normative-optional-background-color: #352c24;
+      --normative-optional-border-color: #ff6600;
 
-  --attributes-tag-foreground-color: #b9824b;
+      --attributes-tag-foreground-color: #e6a96d;
 
-  --figure-background: #fff;
-}
-}
+      --figure-background: #fff;
+    }
+  }
 }
 
 /* IBM Plex fonts (Latin subset) have been downloaded from Google Fonts and modified to add support back in for the `zero` substitution (slashed zeroes) */
@@ -1992,11 +1996,11 @@ var {
 }
 
 @supports (color-scheme: dark) {
-@media (prefers-color-scheme: dark) {
-var {
-  mix-blend-mode: normal;
-}
-}
+  @media (prefers-color-scheme: dark) {
+    var {
+      mix-blend-mode: normal;
+    }
+  }
 }
 
 var.field {
@@ -2005,7 +2009,7 @@ var.field {
 }
 /* suppress line break opportunities between `.` and `[[FieldName]]` */
 var.field::before {
-  content: '\2060'
+  content: '\2060';
 }
 
 var.referenced {
@@ -2587,7 +2591,7 @@ table.lightweight-table th {
     background-color: var(--highlight-background-color-start);
   }
   100% {
-    background-color: var(--highlight-background-color-end)
+    background-color: var(--highlight-background-color-end);
   }
 }
 #spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {
@@ -2841,7 +2845,7 @@ tr.del > td {
 }
 
 #menu-toc li.revealed-leaf > a {
-  color: var(--link-foreground-color);
+  color: var(--menu-revealed-link-foreground-color);
 }
 
 #menu-toc li.revealed > ol {
@@ -2858,7 +2862,7 @@ tr.del > td {
 
 .menu-pane-header {
   padding: 2px 8px;
-  background-color: var(--control-light-border-color);
+  background-color: var(--menu-header-background-color);
   font-weight: bold;
   letter-spacing: 1px;
   flex-grow: 0;
@@ -2883,6 +2887,10 @@ tr.del > td {
 
 .menu-pane-header emu-geq {
   margin-left: 0px;
+}
+
+.menu-pane-header a {
+  color: var(--control-link-foreground-color);
 }
 
 a.menu-pane-header-production {
@@ -3883,7 +3891,39 @@ h1.version {
   font-weight: normal;
 }
 
-}</style></head><body><div id="shortcuts-help">
+}</style><style>
+    @media print {
+      @page :left {
+        @bottom-right {
+          content: '© Ecma International 1997';
+        }
+      }
+      @page :right {
+        @bottom-left {
+          content: '© Ecma International 1997';
+        }
+      }
+      @page :first {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+      @page :blank {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+    }
+    </style><style>
+      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css");
+      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-dark.min.css") (prefers-color-scheme: dark);
+    </style></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1607,7 +1607,167 @@ document.addEventListener('DOMContentLoaded', () => {
 
 let sdoMap = JSON.parse(`{}`);
 let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"sec-intro","titleHTML":"Intro","number":""},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
-;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>/* IBM Plex fonts (Latin subset) have been downloaded from Google Fonts and modified to add support back in for the `zero` substitution (slashed zeroes) */
+;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>:root {
+  --foreground-color: #111;
+  --background-color: #fff;
+
+  --link-foreground-color: #206ca7;
+  --link-hover-foreground-color: #239dee;
+
+  --user-code-foreground-color: brown;
+
+  --var-foreground-color: #218379;
+
+  --referenced0-background-color: #ffff6c;
+  --referenced1-background-color: #ffa4a8;
+  --referenced2-background-color: #96e885;
+  --referenced3-background-color: #3eeed2;
+  --referenced4-background-color: #eacfb6;
+  --referenced5-background-color: #82ddff;
+  --referenced6-background-color: #ffbcf2;
+
+  --note-background-color: #e9fbe9;
+  --note-border-color: #52e052;
+  --note-editor-border-color: #faa;
+
+  --nt-link-foreground-color: #333;
+
+  --production-rhs-background-color: #f0f0f0;
+  --production-rhs-border-color: #888;
+
+  --params-foreground-color: #2aa198;
+  --opt-foreground-color: #b58900;
+
+  --title-foreground-color: #f60;
+
+  --caption-foreground-color: #555555;
+
+  --table-header-background-color: #eeeeee;
+
+  --highlight-background-color-start: rgba(249, 241, 172, 1);
+  --highlight-background-color-end: rgba(249, 241, 172, 0);
+
+  --highlight-background-color: rgba(249, 241, 172, 1);
+
+  --ins-background-color: #e0f8e0;
+  --ins-border-color: #396;
+
+  --del-background-color: #fee;
+
+  --control-foreground-color: #eee;
+  --control-dimmed-foreground-color: #666;
+  --control-background-color: #ddd;
+  --control-dark-background-color: #ccc;
+  --control-border-color: #aaa;
+  --control-light-border-color: #bbb;
+  --control-shortcut-background-color: #eee;
+  --control-shortcut-shadow-color: #ccc;
+  --control-dialog-fade-color: rgba(255, 255, 255, 0.6);
+
+  --control-link-foreground-color: #1567a2;
+
+  --control-input-background-color: #bbb;
+  --control-input-border-color: #999;
+
+  --menu-unpin-hover-foreground-color: #bb1212;
+
+  --menu-trace-list-foreground-color: #999;
+  --menu-trace-list-background-color: #222;
+
+  --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+  --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+
+  --normative-optional-background-color: #ffeedd;
+  --normative-optional-border-color: #ff6600;
+
+  --attributes-tag-foreground-color: #884400;
+
+  --figure-background: #fff;
+}
+
+@supports (color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
+:root {
+  --foreground-color: #fcfcfc;
+  --background-color: #171717;
+
+  --link-foreground-color: #439de2;
+  --link-hover-foreground-color: #80cafb;
+
+  --user-code-foreground-color: brown;
+
+  --var-foreground-color: #4fb6ab;
+
+  --referenced0-background-color: #9c9c1d;
+  --referenced1-background-color: #7e171c;
+  --referenced2-background-color: #1f6211;
+  --referenced3-background-color: #1a7a6b;
+  --referenced4-background-color: #7b4719;
+  --referenced5-background-color: #185870;
+  --referenced6-background-color: #731761;
+
+  --note-background-color: #223c22;
+  --note-border-color: #31a331;
+  --note-editor-border-color: #801e1e;
+
+  --nt-link-foreground-color: #d0d0d0;
+
+  --production-rhs-background-color: #4d4d4d;
+  --production-rhs-border-color: #888;
+
+  --params-foreground-color: #57d0c7;
+  --opt-foreground-color: #d8b750;
+
+  --title-foreground-color: #f60;
+
+  --caption-foreground-color: #b0b0b0;
+
+  --table-header-background-color: #404040;
+
+  --highlight-background-color-start: rgba(114, 105, 24, 1);
+  --highlight-background-color-end: rgba(114, 105, 24, 0);
+
+  --highlight-background-color: rgba(114, 105, 24, 1);
+
+  --ins-background-color: #1e4a1e;
+  --ins-border-color: #61d89b;
+
+  --del-background-color: #4a1f1f;
+
+  --control-foreground-color: #101010;
+  --control-dimmed-foreground-color: #d0d0d0;
+  --control-background-color: #303030;
+  --control-dark-background-color: #505050;
+  --control-border-color: #505050;
+  --control-light-border-color: #606060;
+  --control-shortcut-background-color: #505050;
+  --control-shortcut-shadow-color: #000000;
+  --control-dialog-fade-color: rgba(0, 0, 0, 0.6);
+
+  --control-link-foreground-color: #7ebce9;
+
+  --control-input-background-color: #606060;
+  --control-input-border-color: #a0a0a0;
+
+  --menu-unpin-hover-foreground-color: #e77373;
+
+  --menu-trace-list-foreground-color: #222;
+  --menu-trace-list-background-color: #999;
+
+  --toolbox-tail-background-outside-color: rgba(0, 0, 0, 0);
+  --toolbox-tail-border-outside-color: rgba(204, 204, 204, 0);
+
+  --normative-optional-background-color: #352c24;
+  --normative-optional-border-color: #ff6600;
+
+  --attributes-tag-foreground-color: #b9824b;
+
+  --figure-background: #fff;
+}
+}
+}
+
+/* IBM Plex fonts (Latin subset) have been downloaded from Google Fonts and modified to add support back in for the `zero` substitution (slashed zeroes) */
 
 /* https://fonts.googleapis.com/css2?family=IBM%20Plex%20Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap */
 @font-face {
@@ -1700,7 +1860,7 @@ let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"se
 }
 
 html {
-  background-color: #fff;
+  background-color: var(--background-color);
 }
 
 body {
@@ -1714,7 +1874,7 @@ body {
   font-variant-numeric: slashed-zero;
   padding: 0;
   margin: 0;
-  color: #111;
+  color: var(--foreground-color);
 }
 
 #spec-container {
@@ -1741,16 +1901,16 @@ span[aria-hidden='true'] {
 
 a {
   text-decoration: none;
-  color: #206ca7;
+  color: var(--link-foreground-color);
 }
 
 a:visited {
-  color: #206ca7;
+  color: var(--link-foreground-color);
 }
 
 a:hover {
   text-decoration: underline;
-  color: #239dee;
+  color: var(--link-hover-foreground-color);
 }
 
 a.e-user-code,
@@ -1761,9 +1921,9 @@ span.e-user-code {
 a.e-user-code::before,
 span.e-user-code::before {
   display: none;
-  color: brown;
-  background-color: white;
-  border: 2pt solid brown;
+  color: var(--user-code-foreground-color);
+  background-color: var(--background-color);
+  border: 2pt solid var(--user-code-foreground-color);
   padding: 0.3ex;
   margin: 0 0.25em 0 0;
   line-height: normal;
@@ -1778,8 +1938,8 @@ span.e-user-code::before {
 
 a.e-user-code:hover::before,
 span.e-user-code:hover::before {
-  background-color: brown;
-  color: white;
+  background-color: var(--user-code-foreground-color);
+  color: var(--background-color);
 }
 
 html.show-ao-annotations a.e-user-code::before,
@@ -1806,7 +1966,7 @@ pre code {
 }
 
 pre code.hljs {
-  background-color: #fff;
+  background-color: var(--background-color);
   margin: 0;
   padding: 0;
 }
@@ -1823,13 +1983,22 @@ ol.toc ol.toc {
 
 var {
   border-radius: 5px;
-  color: #218379;
+  color: var(--var-foreground-color);
   transition: all 0.25s ease-out;
   cursor: pointer;
   padding: 0 4px;
   margin: 0 -4px;
   mix-blend-mode: multiply;
 }
+
+@supports (color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
+var {
+  mix-blend-mode: normal;
+}
+}
+}
+
 var.field {
   font: inherit;
   color: inherit;
@@ -1844,25 +2013,25 @@ var.referenced {
 }
 
 var.referenced0 {
-  background-color: #ffff6c;
+  background-color: var(--referenced0-background-color);
 }
 var.referenced1 {
-  background-color: #ffa4a8;
+  background-color: var(--referenced1-background-color);
 }
 var.referenced2 {
-  background-color: #96e885;
+  background-color: var(--referenced2-background-color);
 }
 var.referenced3 {
-  background-color: #3eeed2;
+  background-color: var(--referenced3-background-color);
 }
 var.referenced4 {
-  background-color: #eacfb6;
+  background-color: var(--referenced4-background-color);
 }
 var.referenced5 {
-  background-color: #82ddff;
+  background-color: var(--referenced5-background-color);
 }
 var.referenced6 {
-  background-color: #ffbcf2;
+  background-color: var(--referenced6-background-color);
 }
 
 emu-const {
@@ -1935,8 +2104,8 @@ emu-note {
   gap: 1em;
   flex-direction: row;
   color: inherit;
-  border-left: 5px solid #52e052;
-  background: #e9fbe9;
+  border-left: 5px solid var(--note-border-color);
+  background: var(--note-background-color);
   padding: 10px 10px 10px 0;
   overflow-x: auto;
 }
@@ -1950,7 +2119,7 @@ emu-note > span.note {
 }
 
 emu-note[type='editor'] {
-  border-left-color: #faa;
+  border-left-color: var(--note-editor-border-color);
 }
 
 emu-note > div.note-contents {
@@ -2059,7 +2228,7 @@ emu-nt {
 
 emu-nt a,
 emu-nt a:visited {
-  color: #333;
+  color: var(--nt-link-foreground-color);
 }
 
 emu-rhs emu-nt {
@@ -2091,8 +2260,8 @@ emu-production:not([collapsed]) emu-rhs {
 }
 
 emu-production:not([collapsed]) emu-rhs:hover {
-  border-color: #888;
-  background-color: #f0f0f0;
+  border-color: var(--production-rhs-border-color);
+  background-color: var(--production-rhs-background-color);
 }
 
 emu-mods {
@@ -2112,11 +2281,11 @@ emu-opt {
 
 emu-params,
 emu-constraints {
-  color: #2aa198;
+  color: var(--params-foreground-color);
 }
 
 emu-opt {
-  color: #b58900;
+  color: var(--opt-foreground-color);
 }
 
 emu-gprose {
@@ -2131,18 +2300,18 @@ emu-production emu-gprose {
 }
 
 h1.shortname {
-  color: #f60;
+  color: var(--title-foreground-color);
   font-size: 1.5em;
   margin: 0;
 }
 
 h1.version {
-  color: #f60;
+  color: var(--title-foreground-color);
   font-size: 1.5em;
 }
 
 h1.title {
-  color: #f60;
+  color: var(--title-foreground-color);
 }
 
 h1,
@@ -2359,9 +2528,12 @@ figure table.real-table {
 }
 figure figcaption {
   display: block;
-  color: #555555;
+  color: var(--caption-foreground-color);
   font-weight: bold;
   text-align: center;
+}
+figure img {
+  background: var(--figure-background);
 }
 
 emu-table table {
@@ -2377,18 +2549,18 @@ emu-table td,
 emu-table th,
 table.real-table td,
 table.real-table th {
-  border: 1px solid black;
+  border: 1px solid var(--foreground-color);
   padding: 0.4em;
   vertical-align: baseline;
 }
 emu-table th,
 emu-table thead td,
 table.real-table th {
-  background-color: #eeeeee;
+  background-color: var(--table-header-background-color);
 }
 
 emu-table td {
-  background: #fff;
+  background: var(--background-color);
 }
 
 td[colspan]:not([colspan="1"]), th[colspan]:not([colspan="1"]) {
@@ -2412,10 +2584,10 @@ table.lightweight-table th {
    and a persistent focus-associated highlight */
 @keyframes highlight-target-bg {
   0% {
-    background-color: rgba(249, 241, 172, 1);
+    background-color: var(--highlight-background-color-start);
   }
   100% {
-    background-color: rgba(249, 241, 172, 0);
+    background-color: var(--highlight-background-color-end)
   }
 }
 #spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {
@@ -2423,18 +2595,18 @@ table.lightweight-table th {
 }
 #spec-container :target:focus-within:not(:has(:not(a))) {
   animation: none;
-  background-color: rgba(249, 241, 172, 1);
+  background-color: var(--highlight-background-color);
 }
 
 /* diff styles */
 ins {
-  background-color: #e0f8e0;
+  background-color: var(--ins-background-color);
   text-decoration: none;
-  border-bottom: 1px solid #396;
+  border-bottom: 1px solid var(--ins-border-color);
 }
 
 del {
-  background-color: #fee;
+  background-color: var(--del-background-color);
 }
 
 ins.block,
@@ -2455,11 +2627,11 @@ tr.ins > td > ins {
 }
 
 tr.ins > td {
-  background-color: #e0f8e0;
+  background-color: var(--ins-background-color);
 }
 
 tr.del > td {
-  background-color: #fee;
+  background-color: var(--del-background-color);
 }
 
 /* Menu Styles */
@@ -2473,8 +2645,8 @@ tr.del > td {
   height: 1.5em;
   z-index: 3;
   visibility: hidden;
-  color: #1567a2;
-  background-color: #fff;
+  color: var(--control-link-foreground-color);
+  background-color: var(--background-color);
 
   line-height: 1.5em;
   text-align: center;
@@ -2495,14 +2667,14 @@ tr.del > td {
   height: 100vh;
   max-width: 500px;
   box-sizing: border-box;
-  background-color: #ddd;
+  background-color: var(--control-background-color);
   overflow: hidden;
   transition: opacity 0.1s linear;
   padding: 0 5px;
   position: fixed;
   left: 0;
   top: 0;
-  border-right: 2px solid #bbb;
+  border-right: 2px solid var(--control-light-border-color);
 
   z-index: 2;
 }
@@ -2515,7 +2687,7 @@ tr.del > td {
 }
 
 #menu a {
-  color: #1567a2;
+  color: var(--control-link-foreground-color);
 }
 
 #menu.active {
@@ -2535,7 +2707,7 @@ tr.del > td {
 
 #menu-pins .unpin-all {
   border: none;
-  background: #ccc;
+  background: var(--control-dark-background-color);
   border-radius: 4px;
   height: 18px;
   font-size: 12px;
@@ -2543,7 +2715,7 @@ tr.del > td {
   font-family: 'IBM Plex Sans', sans-serif;
 }
 #menu-pins .unpin-all:hover {
-  background: #ddd;
+  background: var(--control-background-color);
 }
 
 #menu-pins-list {
@@ -2577,16 +2749,17 @@ tr.del > td {
 }
 #menu-pins-list > li::before,
 #menu-pins-list > li > .unpin:hover {
-  background: #ccc;
+  background: var(--control-dark-background-color);
 }
 
 #menu-pins-list > li > .unpin,
 #menu-pins .unpin-all {
   cursor: pointer;
+  color: var(--foreground-color);
 }
 #menu-pins-list > li > .unpin:hover,
 #menu-pins .unpin-all:hover {
-  color: #bb1212;
+  color: var(--menu-unpin-hover-foreground-color);
 }
 
 #menu-pins-list > li::before {
@@ -2663,12 +2836,12 @@ tr.del > td {
 }
 
 #menu-toc li.revealed > a {
-  background-color: #ccc;
+  background-color: var(--control-dark-background-color);
   font-weight: bold;
 }
 
 #menu-toc li.revealed-leaf > a {
-  color: #206ca7;
+  color: var(--link-foreground-color);
 }
 
 #menu-toc li.revealed > ol {
@@ -2685,7 +2858,7 @@ tr.del > td {
 
 .menu-pane-header {
   padding: 2px 8px;
-  background-color: #bbb;
+  background-color: var(--control-light-border-color);
   font-weight: bold;
   letter-spacing: 1px;
   flex-grow: 0;
@@ -2758,8 +2931,9 @@ a.menu-pane-header-production {
   margin: 5px 0 0 0;
   font-size: 1em;
   padding: 2px;
-  background-color: #bbb;
-  border: 1px solid #999;
+  color: var(--foreground-color);
+  background-color: var(--control-input-background-color);
+  border: 1px solid var(--control-input-border-color);
 }
 
 #menu-search-results {
@@ -2773,7 +2947,7 @@ li.menu-search-result-clause::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 li.menu-search-result-op::before {
@@ -2782,7 +2956,7 @@ li.menu-search-result-op::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 
@@ -2792,7 +2966,7 @@ li.menu-search-result-prod::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 
@@ -2802,7 +2976,7 @@ li.menu-search-result-term::before {
   display: inline-block;
   text-align: right;
   padding-right: 1ex;
-  color: #666;
+  color: var(--control-dimmed-foreground-color);
   font-size: 75%;
 }
 
@@ -2831,9 +3005,9 @@ li.menu-search-result-term::before {
 }
 #menu-trace-list li::before {
   content: counter(item) ' ';
-  background-color: #222;
+  background-color: var(--menu-trace-list-background-color);
   counter-increment: item;
-  color: #999;
+  color: var(--menu-trace-list-foreground-color);
   width: 20px;
   height: 20px;
   line-height: 20px;
@@ -2899,9 +3073,9 @@ li.menu-search-result-term::before {
 
 .toolbox {
   position: relative;
-  background: #ddd;
-  border: 1px solid #aaa;
-  color: #eee;
+  background: var(--control-background-color);
+  border: 1px solid var(--control-border-color);
+  color: var(--control-foreground-color);
   padding: 5px 7px;
   border-radius: 3px;
 }
@@ -2929,14 +3103,14 @@ li.menu-search-result-term::before {
 }
 
 .toolbox::after {
-  border-color: rgba(0, 0, 0, 0);
-  border-top-color: #ddd;
+  border-color: var(--toolbox-tail-background-outside-color);
+  border-top-color: var(--control-background-color);
   border-width: 10px;
   margin-left: -10px;
 }
 .toolbox::before {
-  border-color: rgba(204, 204, 204, 0);
-  border-top-color: #aaa;
+  border-color: var(--toolbox-tail-border-outside-color);
+  border-top-color: var(--control-border-color);
   border-width: 12px;
   margin-left: -12px;
 }
@@ -2947,7 +3121,7 @@ li.menu-search-result-term::before {
   left: 0;
   right: 0;
   display: none;
-  background-color: #ddd;
+  background-color: var(--control-background-color);
   z-index: 1;
 }
 
@@ -2998,19 +3172,19 @@ emu-normative-optional,
 [normative-optional],
 [deprecated],
 [legacy] {
-  border-left: 5px solid #ff6600;
+  border-left: 5px solid var(--normative-optional-border-color);
   display: block;
   padding: 0.5em;
-  background: #ffeedd;
+  background: var(--normative-optional-background-color);
 }
 
 .attributes-tag {
   text-transform: uppercase;
-  color: #884400;
+  color: var(--attributes-tag-foreground-color);
 }
 
 .attributes-tag a {
-  color: #884400;
+  color: var(--attributes-tag-foreground-color);
 }
 
 /* Shortcuts help dialog */
@@ -3025,10 +3199,10 @@ emu-normative-optional,
   top: calc(5vw + 5vh);
   padding: 30px 90px;
   max-width: 500px;
-  outline: solid 10000px rgba(255, 255, 255, 0.6);
+  outline: solid 10000px var(--control-dialog-fade-color);
   border-radius: 5px;
   border-width: 1px 1px 0 1px;
-  background-color: #ddd;
+  background-color: var(--control-background-color);
   display: none;
 }
 
@@ -3049,9 +3223,13 @@ emu-normative-optional,
   padding: 3px 10px;
   border-radius: 3px;
   border-width: 1px 1px 0 1px;
-  border-color: #bbb;
-  background-color: #eee;
-  box-shadow: inset 0 -1px 0 #ccc;
+  border-color: var(--control-light-border-color);
+  background-color: var(--control-shortcut-background-color);
+  box-shadow: inset 0 -1px 0 var(--control-shortcut-shadow-color);
+}
+
+#ecma-logo {
+  background: var(--figure-background);
 }
 </style><style>@media print {
 @font-face {

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -3922,7 +3922,7 @@ h1.version {
     }
     </style><style>
       @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css");
-      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-dark.min.css") (prefers-color-scheme: dark);
+      @import url("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/a11y-dark.min.css") (prefers-color-scheme: dark);
     </style></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>


### PR DESCRIPTION
This adds dark mode for the spec.

The colors and the variable names are chosen without much consideration, and I'm open to any changes.

There are some issue with the transparent images, such as the ECMA logo.
If there's dark-mode logo or any other solution, let me know.
For other images in figure, I've added always-#fff background color.

<img width="1430" alt="dark" src="https://github.com/user-attachments/assets/4e59a1d4-8c0f-4a65-a9ee-87a4aae7af78" />
