### PR TITLE
Fix 'oneof' in syntax-directed operations

### DIFF
--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -75,6 +75,9 @@ export function rhsMatches(a: RightHandSide | OneOfList, b: RightHandSide | OneO
     }
     case SyntaxKind.OneOfList:
       return oneOfListMatches(a, b as OneOfList);
+    default:
+      // @ts-expect-error: Callers might pass other kinds of nodes.
+      throw new Error('unknown rhs type ' + a.constructor.name);
   }
 }
 

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -175,10 +175,8 @@ function oneOfListMatches(a: OneOfList, b: OneOfList) {
   if (a.terminals === undefined || b.terminals === undefined) {
     throw new Error('OneOfList must have terminals');
   }
-  return (
-    a.terminals.length === b.terminals.length &&
-    a.terminals.every((ae, i) => ae.text === b.terminals![i].text)
-  );
+  // The terminals in a must be a subset of the terminals in b.
+  return a.terminals.every(ae => b.terminals!.find(be => ae.text === be.text));
 }
 
 // this is only for use with single-file grammars

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -73,8 +73,8 @@ export function rhsMatches(a: RightHandSide | OneOfList, b: RightHandSide | OneO
       }
       return symbolSpanMatches(aHead, bHead);
     }
-    default:
-      throw new Error('unknown rhs type ' + a.constructor.name);
+    case SyntaxKind.OneOfList:
+      return oneOfListMatches(a, b as OneOfList);
   }
 }
 
@@ -168,6 +168,16 @@ function argumentListMatches(a: ArgumentList, b: ArgumentList) {
       }
       return ae.operatorToken.kind === be.operatorToken.kind && ae.name.text === be.name.text;
     })
+  );
+}
+
+function oneOfListMatches(a: OneOfList, b: OneOfList) {
+  if (a.terminals === undefined || b.terminals === undefined) {
+    throw new Error('OneOfList must have terminals');
+  }
+  return (
+    a.terminals.length === b.terminals.length &&
+    a.terminals.every((ae, i) => ae.text === b.terminals![i].text)
   );
 }
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -1117,7 +1117,7 @@ ${M}      </pre>
         <h1>Static Semantics: Example</h1>
         <dl class='header'></dl>
           <emu-grammar>
-            Foo :: ${M}one of \`d\`
+            Foo :: ${M}one of \`d\` \`e\`
           </emu-grammar>
           <emu-alg>
             1. Return *true*.
@@ -1126,7 +1126,7 @@ ${M}      </pre>
         {
           ruleId: 'grammar-shape',
           nodeType: 'emu-grammar',
-          message: 'could not find definition for rhs "d"',
+          message: 'could not find definition for rhs "d e"',
         },
       );
     });
@@ -1215,20 +1215,20 @@ ${M}      </pre>
     it('negative: oneof (subset)', async () => {
       await assertErrorFree(`
         <emu-grammar type="definition">
-          Foo :: one of \`a\` \`b\` \`c\`
+          Foo :: one of \`a\` \`b\` \`c\` \`d\`
         </emu-grammar>
 
         <emu-clause id="sec-example" type="sdo">
         <h1>Static Semantics: Example</h1>
         <dl class='header'></dl>
           <emu-grammar>
-            Foo :: one of \`a\`
+            Foo :: one of \`a\` \`b\`
           </emu-grammar>
           <emu-alg>
             1. Return *true*.
           </emu-alg>
           <emu-grammar>
-            Foo :: one of \`b\`
+            Foo :: one of \`c\` \`d\`
           </emu-grammar>
           <emu-alg>
             1. Return *false*.

--- a/test/errors.js
+++ b/test/errors.js
@@ -1106,6 +1106,31 @@ ${M}      </pre>
       );
     });
 
+    it('unknown oneof', async () => {
+      await assertError(
+        positioned`
+        <emu-grammar type="definition">
+          Foo :: one of \`a\` \`b\` \`c\`
+        </emu-grammar>
+
+        <emu-clause id="sec-example" type="sdo">
+        <h1>Static Semantics: Example</h1>
+        <dl class='header'></dl>
+          <emu-grammar>
+            Foo :: ${M}one of \`a\`
+          </emu-grammar>
+          <emu-alg>
+            1. Return *true*.
+          </emu-alg>
+        </emu-clause>`,
+        {
+          ruleId: 'grammar-shape',
+          nodeType: 'emu-grammar',
+          message: 'could not find definition for rhs "a"',
+        },
+      );
+    });
+
     it('negative', async () => {
       await assertErrorFree(`
         <emu-grammar type="definition">
@@ -1166,6 +1191,25 @@ ${M}      </pre>
           extraBiblios: [upstream],
         },
       );
+    });
+
+    it('negative: oneof', async () => {
+      await assertErrorFree(`
+        <emu-grammar type="definition">
+          Foo :: one of \`a\` \`b\` \`c\`
+        </emu-grammar>
+
+        <emu-clause id="sec-example" type="sdo">
+        <h1>Static Semantics: Example</h1>
+        <dl class='header'></dl>
+          <emu-grammar>
+            Foo :: one of \`a\` \`b\` \`c\`
+          </emu-grammar>
+          <emu-alg>
+            1. Return *true*.
+          </emu-alg>
+        </emu-clause>
+      `);
     });
   });
 });

--- a/test/errors.js
+++ b/test/errors.js
@@ -1117,7 +1117,7 @@ ${M}      </pre>
         <h1>Static Semantics: Example</h1>
         <dl class='header'></dl>
           <emu-grammar>
-            Foo :: ${M}one of \`a\`
+            Foo :: ${M}one of \`d\`
           </emu-grammar>
           <emu-alg>
             1. Return *true*.
@@ -1126,7 +1126,7 @@ ${M}      </pre>
         {
           ruleId: 'grammar-shape',
           nodeType: 'emu-grammar',
-          message: 'could not find definition for rhs "a"',
+          message: 'could not find definition for rhs "d"',
         },
       );
     });
@@ -1207,6 +1207,31 @@ ${M}      </pre>
           </emu-grammar>
           <emu-alg>
             1. Return *true*.
+          </emu-alg>
+        </emu-clause>
+      `);
+    });
+
+    it('negative: oneof (subset)', async () => {
+      await assertErrorFree(`
+        <emu-grammar type="definition">
+          Foo :: one of \`a\` \`b\` \`c\`
+        </emu-grammar>
+
+        <emu-clause id="sec-example" type="sdo">
+        <h1>Static Semantics: Example</h1>
+        <dl class='header'></dl>
+          <emu-grammar>
+            Foo :: one of \`a\`
+          </emu-grammar>
+          <emu-alg>
+            1. Return *true*.
+          </emu-alg>
+          <emu-grammar>
+            Foo :: one of \`b\`
+          </emu-grammar>
+          <emu-alg>
+            1. Return *false*.
           </emu-alg>
         </emu-clause>
       `);


### PR DESCRIPTION
In the source map spec we have the use-case of declaring an SDO over a lexical production (for VLQ decoding).

This PR adds the missing implementation.