### PR TITLE
Some fixes to maintain compliance to the styleguide

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -3,21 +3,42 @@
 ## Required frontmatter
 
 - In order to produce a PDF, the front matter `title`, `shortname`, and `status` are **mandatory**.
-- If using the alternative copyright, `location` is also mandatory.
-- If generating a version for submission to the GA, `version` and `date` are mandatory. `date` should reflect the date of the Ecma GA which will ratify the Standard. For example:
 
+```yaml
+title: Temporal proposal
+shortname: Temporal
+status: proposal
+stage: 3
 ```
-title: ECMAScript® 2024 Language Specification
+
+- If using the alternative copyright for a standard publication, `location` is also mandatory. For example:
+
+```yaml
+title: ECMAScript® Language Specification
 shortname: ECMA-262
-version: 15<sup>th</sup> Edition
-date: 2024-06-25
+status: draft
+boilerplate:
+  copyright: alternative
+```
+
+- If generating a version for submission to the GA, `version` and `date` are mandatory. `date` should reflect the date of the Ecma GA which will ratify the Standard.
+
+```yaml
+title: ECMAScript® 2025 Language Specification
+shortname: ECMA-262
+version: 16<sup>th</sup> Edition
+date: 2025-06-25
+status: standard
+boilerplate:
+  copyright: alternative
+location: https://262.ecma-international.org/16.0/
 ```
 
 To generate markup for use in PDF conversion, make sure to include the options `--assets`, `--assets-dir`, and `--printable`. If you have images and styles to include, make sure to move them into your assets directory before running `ecmarkup`. For example:
 
 ```shell
-mkdir -p out &&
-cp -R images out &&
+mkdir -p out && \
+cp -R images out && \
 ecmarkup --assets external --assets-dir out --printable spec.html out/index.html
 ```
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,10 @@
 # Generating a PDF from ecmarkup
 
-In order to produce a PDF, the front matter `title`, `shortname`, and `status` are **mandatory**. If generating a version for submission to the GA, `version` and `date` are mandatory. `date` should reflect the date of the Ecma GA which will ratify the Standard. For example:
+## Required frontmatter
+
+- In order to produce a PDF, the front matter `title`, `shortname`, and `status` are **mandatory**.
+- If using the alternative copyright, `location` is also mandatory.
+- If generating a version for submission to the GA, `version` and `date` are mandatory. `date` should reflect the date of the Ecma GA which will ratify the Standard. For example:
 
 ```
 title: ECMAScript® 2024 Language Specification
@@ -21,7 +25,7 @@ Then, from your spec's working directory, run [`prince-books`](https://www.princ
 
 ```shell
 cd path/to/spec
-prince --script ./node_modules/ecmarkup/js/print.js out/index.html -o path/to/output.pdf
+prince-books --script ./node_modules/ecmarkup/js/print.js out/index.html -o path/to/output.pdf
 ```
 
 This has been extensively tested with Prince 15. Earlier and later editions not guaranteed.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Generating a PDF from ecmarkup
 
-In order to produce a PDF, the front matter `title`, `shortname`, `version`, and `date` are **mandatory**. If generating a final annual edition, date should reflect the date of the Ecma GA which will ratify the Standard. For example:
+In order to produce a PDF, the front matter `title`, `shortname`, and `status` are **mandatory**. If generating a version for submission to the GA, `version` and `date` are mandatory. `date` should reflect the date of the Ecma GA which will ratify the Standard. For example:
 
 ```
 title: ECMAScript® 2024 Language Specification
@@ -17,7 +17,7 @@ cp -R images out &&
 ecmarkup --assets external --assets-dir out --printable spec.html out/index.html
 ```
 
-Then, from your spec's working directory, run [`prince`](https://www.princexml.com/) to generate your PDF.
+Then, from your spec's working directory, run [`prince-books`](https://www.princexml.com/) to generate your PDF.
 
 ```shell
 cd path/to/spec

--- a/boilerplate/alternative-copyright.html
+++ b/boilerplate/alternative-copyright.html
@@ -1,0 +1,57 @@
+<div class="alternative-copyright">
+  <p>ALTERNATIVE COPYRIGHT NOTICE AND COPYRIGHT LICENSE</p>
+
+  <p>&copy; !YEAR! Ecma International</p>
+
+  <p>
+    By obtaining and/or copying this work, you (the licensee) agree that you
+    have read, understood, and will comply with the following terms and
+    conditions.
+  </p>
+
+  <p>
+    Permission under Ecma’s copyright to copy, modify, prepare derivative works
+    of, and distribute this work, with or without modification, for any purpose
+    and without fee or royalty is hereby granted, provided that you include the
+    following on ALL copies of the work or portions thereof, including
+    modifications:
+  </p>
+
+  <p>
+    (i) The full text of this COPYRIGHT NOTICE AND COPYRIGHT LICENSE in a location
+    viewable to users of the redistributed or derivative work.
+  </p>
+  <p>
+    (ii) Any pre-existing intellectual property disclaimers, notices, or terms and
+    conditions. If none exist, the Ecma alternative copyright notice should be
+    included.
+  </p>
+  <p>
+    (iii) Notice of any changes or modifications, through a copyright statement on
+    the document such as “This document includes material copied from or
+    derived from !DOCUMENT!.<br />
+    Copyright &copy; Ecma International.”
+  </p>
+
+  <p><strong>Disclaimers</strong></p>
+
+  <p>
+    THIS WORK IS PROVIDED “AS IS,” AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS
+    OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES
+    OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF
+    THE DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+    TRADEMARKS OR OTHER RIGHTS.
+  </p>
+
+  <p>
+    COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+    CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT.
+  </p>
+
+  <p>
+    The name and trademarks of copyright holders may NOT be used in advertising
+    or publicity pertaining to the work without specific, written prior
+    permission. Title to copyright in this work will at all times remain with
+    copyright holders.
+  </p>
+</div>

--- a/boilerplate/standard-copyright.html
+++ b/boilerplate/standard-copyright.html
@@ -1,18 +1,23 @@
-<p>© !YEAR! Ecma International</p>
+<p>COPYRIGHT NOTICE</p>
+
+<p>&copy; !YEAR! Ecma International</p>
+
 <p>By obtaining and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.</p>
 
-<p>Permission under Ecma’s copyright to copy, modify, prepare derivative works of, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work or portions thereof, including modifications:</p>
+<p>This document may be copied, published and distributed to others, and certain derivative works of it may be prepared, copied, published, and distributed, in whole or in part, provided that the above copyright notice and this Copyright License and Disclaimer are included on all such copies and derivative works. The only derivative works that are permissible under this Copyright License and Disclaimer are:</p>
 
-<ol>
-  <li>(i) The full text of this COPYRIGHT NOTICE AND COPYRIGHT LICENSE in a location viewable to users of the redistributed or derivative work.</li>
-  <li>(ii) Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the Ecma alternative copyright notice should be included.</li>
-  <li>(iii) Notice of any changes or modifications, through a copyright statement on the document such as “This document includes material copied from or derived from [title and URI of the Ecma  document].  Copyright © Ecma International.”</li>
-</ol>
+<p>(i) works which incorporate all or portion of this document for the purpose of providing commentary or explanation (such as an annotated version of the document),</p>
 
-<p>Disclaimers</p>
+<p>(ii) works which incorporate all or portion of this document for the purpose of incorporating features that provide accessibility,</p>
 
-<p>THIS WORK IS PROVIDED “AS IS,” AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.</p>
+<p>(iii) translations of this document into languages other than English and into different formats and</p>
 
-<p>COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT.</p>
+<p>(iv) works by making use of this specification in standard conformant products by implementing (e.g. by copy and paste wholly or partly) the functionality therein.</p>
 
-<p>The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the work without specific, written prior permission. Title to copyright in this work will at all times remain with copyright holders.</p>
+<p>However, the content of this document itself may not be modified in any way, including by removing the copyright notice or references to Ecma International, except as required to translate it into languages other than English or into a different format.</p>
+
+<p>The official version of an Ecma International document is the English language version on the Ecma International website. In the event of discrepancies between a translated version and the official version, the official version shall govern.</p>
+
+<p>The limited permissions granted above are perpetual and will not be revoked by Ecma International or its successors or assigns.</p>
+
+<p>This document and the information contained herein is provided on an “AS IS” basis and ECMA INTERNATIONAL DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.</p>

--- a/css/print.css
+++ b/css/print.css
@@ -560,18 +560,13 @@ emu-annex > h1 .secnum {
   margin: 0 0 1lh;
 }
 
-.copyright-notice {
-  /* ecma mandated */
+.copyright-notice { /* ecma mandated */
   font-style: italic;
   border: 1px solid black;
   padding: 1em;
   page: copyright;
   page-break-before: always;
   page-break-after: always;
-}
-
-.full-page-svg {
-  color: rgba(255, 255, 255, 0);
 }
 
 .secnum {

--- a/css/print.css
+++ b/css/print.css
@@ -496,7 +496,7 @@ emu-figure img {
 }
 
 #toc a[href]::after {
-  content: leader(dotted)  target-counter(attr(href), page);
+  content: leader(dotted) target-counter(attr(href), page);
 }
 
 #toc > ol.toc {
@@ -548,11 +548,20 @@ a[data-print-href]::after {
   width: auto;
 }
 
-.annex-title {
+emu-annex > h1 {
   text-align: center;
 }
 
-.copyright-notice { /* ecma mandated */
+emu-annex > h1 span {
+  display: block;
+}
+
+emu-annex > h1 .secnum {
+  margin: 0 0 1lh;
+}
+
+.copyright-notice {
+  /* ecma mandated */
   font-style: italic;
   border: 1px solid black;
   padding: 1em;
@@ -613,6 +622,7 @@ h1.version {
 }
 
 #front-cover h1.title {
+  display: block;
   font-weight: bold;
   font-size: 20pt;
   line-height: 1.2;
@@ -624,15 +634,6 @@ h1.version {
 
 #inside-cover {
   page: inside-cover;
-}
-
-#inside-cover address {
-  color: black;
-  font-size: 12pt;
-  font-style: normal;
-  position: relative;
-  left: 72mm;
-  top: 82mm;
 }
 
 #toc {
@@ -647,4 +648,8 @@ h1.version {
 
 .annex-kind {
   font-weight: normal;
+}
+
+p.ECMAaddress {
+  margin: 0;
 }

--- a/js/print.js
+++ b/js/print.js
@@ -10,9 +10,8 @@
 
 // Prince.trackBoxes = true;
 
-const specContainer = document.getElementById('spec-container');
-const shortname = specContainer.querySelector('h1.shortname');
-const version = specContainer.querySelector('h1.version');
+const shortname = document.querySelector('h1.shortname');
+const version = document.querySelector('h1.version');
 
 rearrangeTables();
 
@@ -21,7 +20,7 @@ PDF.pageMode = 'show-bookmarks';
 PDF.duplex = 'duplex-flip-long-edge';
 PDF.title = document.title;
 PDF.author = 'Ecma International';
-PDF.subject = shortname.innerHTML + ', ' + version.innerHTML;
+PDF.subject = shortname.innerHTML + (version ? ', ' + version.innerHTML : '');
 
 /**
  * Sets up table captions and figcaptions for tables, which provides for

--- a/spec/index.html
+++ b/spec/index.html
@@ -77,7 +77,7 @@ markEffects: true
       <tr><td>`--no-toc`</td><td>`toc`</td><td>Emit table of contents. Boolean, default true.</td></tr>
       <tr><td>`--printable`</td><td>`printable`</td><td>Make the output suitable for printing. Boolean, default false.</td></tr>
       <tr><td>`--load-biblio`</td><td>`extraBiblios`</td><td>Extra biblio.json file(s) to load. This should contain either an object as exported by `--write-biblio` or an array of such objects.</td></tr>
-      <tr><td></td><td>`boilerplate`</td><td>An object with `address` and/or `copyright` and/or `license` fields containing paths to files containing the corresponding content for populating an element with class "copyright-and-software-license" (or if not found, an appended <emu-xref href="#emu-annex" title></emu-xref> with that id) when `copyright` is true. Absent fields are assumed to reference files in a "boilerplate" directory sibling of the directory containing the ecmarkup executable.</td></tr>
+      <tr><td></td><td>`boilerplate`</td><td>An object with `address` and/or `copyright` and/or `license` fields containing paths to files containing the corresponding content for populating an element with class "copyright-and-software-license" (or if not found, an appended <emu-xref href="#emu-annex" title></emu-xref> with that id) when `copyright` is true or set to `alternative`. Absent fields are assumed to reference files in a "boilerplate" directory sibling of the directory containing the ecmarkup executable.</td></tr>
       <tr><td>`--mark-effects`</td><td>`markEffects`</td><td>Propagate and render <a href="#effects">effects</a> like "user code".</td></tr>
     </table>
   </emu-table>

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1508,12 +1508,18 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
 
     // version string, e.g. "6th Edition July 2016" or "Draft 10 / September 26, 2015"
     let versionText = '';
+    let omitShortname = false;
     if (version) {
       versionText += version + ' / ';
     } else if (status === 'proposal' && stage) {
       versionText += 'Stage ' + stage + ' Draft / ';
-    } else if (status === 'draft' && shortname) {
-      versionText += 'Draft / ';
+    } else if (status === 'draft') {
+      if (this.opts.printable) {
+        versionText += 'Draft / ';
+      } else if (shortname) {
+        versionText += 'Draft ' + shortname + ' / ';
+        omitShortname = true;
+      }
     } else {
       return;
     }
@@ -1538,7 +1544,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
     }
 
     // shortname and status, like 'Draft ECMA-262'
-    if (shortname) {
+    if (shortname && !omitShortname) {
       // for proposals, link shortname to location
       const shortnameLinkHtml =
         status === 'proposal' && location ? `<a href="${location}">${shortname}</a>` : shortname;

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -597,10 +597,6 @@ export default class Spec {
       if (metadataEle) {
         this.doc.querySelector('emu-intro')!.appendChild(metadataEle);
       }
-      const scopeEle = document.getElementById('scope') ?? document.getElementById('sec-scope');
-      if (scopeEle) {
-        scopeEle.before(this.doc.querySelector('h1.title')!.cloneNode(true));
-      }
 
       // front cover
       const frontCover = document.createElement('div');
@@ -608,16 +604,13 @@ export default class Spec {
       frontCover.classList.add('full-page-svg');
       frontCover.setAttribute('id', 'front-cover');
 
-      const shortNameNode = this.doc.querySelector('h1.shortname');
-      if (shortNameNode != null) {
-        frontCover.appendChild(shortNameNode.cloneNode(true));
-      }
       const versionNode = this.doc.querySelector('h1.version');
       if (versionNode != null) {
-        frontCover.appendChild(versionNode.cloneNode(true));
+        frontCover.append(versionNode);
       }
-      // we know title exists because we enforce it in the constructor when using --printable
-      frontCover.appendChild(this.doc.querySelector('title')!.cloneNode(true));
+      // we know title & shortname exist because we enforce it in the constructor when using --printable
+      frontCover.append(this.doc.querySelector('h1.title') ?? '');
+      frontCover.append(this.doc.querySelector('h1.shortname') ?? '');
       wrapper.before(frontCover);
 
       // inside cover
@@ -625,8 +618,6 @@ export default class Spec {
 
       insideCover.classList.add('full-page-svg');
       insideCover.setAttribute('id', 'inside-cover');
-      insideCover.innerHTML =
-        '<p>Ecma International<br />Rue du Rhone 114 CH-1204 Geneva<br/>Tel: +41 22 849 6000<br/>Fax: +41 22 849 6001<br/>Web: https://www.ecma-international.org<br/>Ecma is the registered trademark of Ecma International.</p>';
 
       frontCover.after(insideCover);
     }
@@ -646,7 +637,18 @@ export default class Spec {
     if (this.opts.printable) {
       this.log('Applying tweaks for printable document...');
       // The logo is present in ecma-262. We could consider removing it from the document instead of having this tweak.
-      document.getElementById('ecma-logo')?.remove();
+      const logo = document.getElementById('ecma-logo');
+      if (logo) {
+        if (logo.parentElement && logo.parentElement.tagName === 'P') {
+          logo.parentElement.remove();
+        } else {
+          logo.remove();
+        }
+      }
+
+      this.doc
+        .querySelector('#spec-container > emu-clause:first-of-type')
+        ?.before(this.doc.querySelector('h1.title')!.cloneNode(true));
     } else {
       // apparently including this confuses Prince, even when it's `display: none`
       this.log('Building shortcuts help dialog...');
@@ -1461,28 +1463,30 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
             'contributors not specified, skipping copyright boilerplate. specify contributors in your frontmatter metadata',
         });
       } else {
-        const copyrightClause = this.buildCopyrightBoilerplate();
+        // copyright goes near the front of the printed document, instead of the last annex
         if (this.opts.printable) {
           const intro = this.doc.querySelector('emu-intro');
           if (!intro) {
             throw new Error('--printable requires an emu-intro');
           }
+          const copyrightClause = this.buildCopyrightBoilerplate();
           intro.after(copyrightClause);
-        } else {
-          let last: HTMLElement | undefined;
-          utils.domWalkBackward(this.doc.body, node => {
-            if (last) return false;
-            if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-ANNEX') {
-              last = node as HTMLElement;
-              return false;
-            }
-          });
+        }
 
-          if (last && last.parentNode) {
-            last.parentNode.insertBefore(copyrightClause, last.nextSibling);
-          } else {
-            this.doc.body.appendChild(copyrightClause);
+        const licenseClause = this.buildLicenseBoilerplate();
+        let last: HTMLElement | undefined;
+        utils.domWalkBackward(this.doc.body, node => {
+          if (last) return false;
+          if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-ANNEX') {
+            last = node as HTMLElement;
+            return false;
           }
+        });
+
+        if (last && last.parentNode) {
+          last.parentNode.insertBefore(licenseClause, last.nextSibling);
+        } else {
+          this.doc.body.appendChild(licenseClause);
         }
       }
     }
@@ -1504,14 +1508,12 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
 
     // version string, e.g. "6th Edition July 2016" or "Draft 10 / September 26, 2015"
     let versionText = '';
-    let omitShortname = false;
     if (version) {
       versionText += version + ' / ';
     } else if (status === 'proposal' && stage) {
       versionText += 'Stage ' + stage + ' Draft / ';
     } else if (status === 'draft' && shortname) {
-      versionText += 'Draft ' + shortname + ' / ';
-      omitShortname = true;
+      versionText += 'Draft / ';
     } else {
       return;
     }
@@ -1536,7 +1538,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
     }
 
     // shortname and status, like 'Draft ECMA-262'
-    if (shortname && !omitShortname) {
+    if (shortname) {
       // for proposals, link shortname to location
       const shortnameLinkHtml =
         status === 'proposal' && location ? `<a href="${location}">${shortname}</a>` : shortname;
@@ -1594,16 +1596,47 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
   }
 
   private buildCopyrightBoilerplate() {
-    let addressFile: string | undefined;
     let copyrightFile: string | undefined;
+
+    if (this.opts.boilerplate) {
+      if (this.opts.boilerplate.copyright == 'alternative') {
+        copyrightFile = 'alternative-copyright';
+      } else if (this.opts.boilerplate.copyright) {
+        copyrightFile = path.join(process.cwd(), this.opts.boilerplate.copyright);
+      }
+    }
+
+    let copyright = getBoilerplate(copyrightFile || `${this.opts.status}-copyright`);
+    const copyrightElement = this.doc.createElement('div');
+
+    copyrightElement.classList.add('copyright-notice');
+    copyrightElement.id = 'copyright-notice';
+
+    if (this.opts.contributors) {
+      copyright = copyright.replace('!CONTRIBUTORS!', this.opts.contributors);
+    }
+
+    copyright = copyright
+      .replace('!YEAR!', '' + this.opts.date!.getFullYear())
+      .replace('!DOCUMENT!', `${this.opts.title} ${this.opts.location}`);
+
+    if (this.opts.printable) {
+      copyrightElement.innerHTML = copyright;
+    } else {
+      copyrightElement.innerHTML = `<h2>Copyright Notice</h2>
+${copyright}`;
+    }
+
+    return copyrightElement;
+  }
+
+  private buildLicenseBoilerplate() {
+    let addressFile: string | undefined;
     let licenseFile: string | undefined;
 
     if (this.opts.boilerplate) {
       if (this.opts.boilerplate.address) {
         addressFile = path.join(process.cwd(), this.opts.boilerplate.address);
-      }
-      if (this.opts.boilerplate.copyright) {
-        copyrightFile = path.join(process.cwd(), this.opts.boilerplate.copyright);
       }
       if (this.opts.boilerplate.license) {
         licenseFile = path.join(process.cwd(), this.opts.boilerplate.license);
@@ -1612,42 +1645,43 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
 
     // Get content from files
     let address = getBoilerplate(addressFile || 'address');
-    let copyright = getBoilerplate(copyrightFile || `${this.opts.status}-copyright`);
     const license = getBoilerplate(licenseFile || 'software-license');
 
     if (this.opts.status === 'proposal') {
       address = '';
     }
 
-    // Operate on content
-    copyright = copyright.replace(/!YEAR!/g, '' + this.opts.date!.getFullYear());
+    let licenseClause = this.doc.querySelector('.copyright-and-software-license');
 
-    if (this.opts.contributors) {
-      copyright = copyright.replace(/!CONTRIBUTORS!/g, this.opts.contributors);
-    }
-
-    let copyrightClause = this.doc.querySelector('.copyright-and-software-license');
-    if (!copyrightClause) {
-      copyrightClause = this.doc.createElement(this.opts.printable ? 'div' : 'emu-annex');
-      copyrightClause.setAttribute('id', 'sec-copyright-and-software-license');
-      copyrightClause.classList.add('copyright-notice');
+    if (!licenseClause) {
+      licenseClause = this.doc.createElement('emu-annex');
+      licenseClause.setAttribute('id', 'sec-copyright-and-software-license');
     } else if (this.opts.printable) {
       throw new Error(
         'ecmarkup currently generates its own copyright for printed documents; if you need this open an issue',
       );
     }
-    copyrightClause.setAttribute('back-matter', '');
 
-    copyrightClause.innerHTML = `
-      <h1>Copyright &amp; Software License</h1>
+    licenseClause.setAttribute('back-matter', '');
+
+    // Printed document has "Software license" as last section, web version has "Copyright and Software license"
+    if (this.opts.printable) {
+      licenseClause.innerHTML = `
+      <h1>Software License</h1>
       ${address}
-      <h2>Copyright Notice</h2>
-      ${copyright.replace('!YEAR!', '' + this.opts.date!.getFullYear())}
-      <h2>Software License</h2>
       ${license}
-    `;
+      `;
+    } else {
+      licenseClause.innerHTML = `
+        <h1>Copyright &amp; Software License</h1>
+        ${address}
+        ${this.buildCopyrightBoilerplate().outerHTML}
+        <h2>Software License</h2>
+        ${license}
+      `;
+    }
 
-    return copyrightClause;
+    return licenseClause;
   }
 
   private generateSDOMap() {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1513,10 +1513,10 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
       versionText += version + ' / ';
     } else if (status === 'proposal' && stage) {
       versionText += 'Stage ' + stage + ' Draft / ';
-    } else if (status === 'draft') {
+    } else if (status === 'draft' && shortname) {
       if (this.opts.printable) {
         versionText += 'Draft / ';
-      } else if (shortname) {
+      } else {
         versionText += 'Draft ' + shortname + ' / ';
         omitShortname = true;
       }

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -3738,7 +3738,7 @@ emu-figure img {
 }
 
 #toc a[href]::after {
-  content: leader(dotted)  target-counter(attr(href), page);
+  content: leader(dotted) target-counter(attr(href), page);
 }
 
 #toc > ol.toc {
@@ -3790,8 +3790,16 @@ a[data-print-href]::after {
   width: auto;
 }
 
-.annex-title {
+emu-annex > h1 {
   text-align: center;
+}
+
+emu-annex > h1 span {
+  display: block;
+}
+
+emu-annex > h1 .secnum {
+  margin: 0 0 1lh;
 }
 
 .copyright-notice { /* ecma mandated */
@@ -3801,10 +3809,6 @@ a[data-print-href]::after {
   page: copyright;
   page-break-before: always;
   page-break-after: always;
-}
-
-.full-page-svg {
-  color: rgba(255, 255, 255, 0);
 }
 
 .secnum {
@@ -3855,6 +3859,7 @@ h1.version {
 }
 
 #front-cover h1.title {
+  display: block;
   font-weight: bold;
   font-size: 20pt;
   line-height: 1.2;
@@ -3866,15 +3871,6 @@ h1.version {
 
 #inside-cover {
   page: inside-cover;
-}
-
-#inside-cover address {
-  color: black;
-  font-size: 12pt;
-  font-style: normal;
-  position: relative;
-  left: 72mm;
-  top: 82mm;
 }
 
 #toc {
@@ -3889,6 +3885,10 @@ h1.version {
 
 .annex-kind {
   font-weight: normal;
+}
+
+p.ECMAaddress {
+  margin: 0;
 }
 
 }</style><style>
@@ -3939,14 +3939,14 @@ h1.version {
     <h1>Intro</h1>
     <p>This is a section.</p>
 </emu-intro>
-<emu-annex id="sec-copyright-and-software-license" class="copyright-notice" back-matter="">
-      <h1>Copyright &amp; Software License</h1>
-      
-      <h2>Copyright Notice</h2>
-      <p>© 1997 Ecma</p>
-
-      <h2>Software License</h2>
-      <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+<emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 1997 Ecma</p>
+</div>
+        <h2>Software License</h2>
+        <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
 
 <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 
@@ -3958,4 +3958,4 @@ h1.version {
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex></div></body>
+      </emu-annex></div></body>

--- a/test/baselines/generated-reference/boilerplate-address.html
+++ b/test/baselines/generated-reference/boilerplate-address.html
@@ -9,17 +9,17 @@
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
 </ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
-<emu-annex id="sec-copyright-and-software-license" class="copyright-notice" back-matter="">
-      <h1>Copyright &amp; Software License</h1>
-      <p class="ECMAaddress">Tet Corporation</p>
+<emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        <p class="ECMAaddress">Tet Corporation</p>
 <p class="ECMAaddress">2 Hammarskjöld Plaza</p>
 <p class="ECMAaddress">New York City, New York</p>
 <p class="ECMAaddress">Tel: 123-456-7890</p>
 <p class="ECMAaddress">Fax: 123-456-7890</p>
 <p class="ECMAaddress">Web: <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
 
-      <h2>Copyright Notice</h2>
-      <p>© 2018 Ecma International</p>
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 2018 Ecma International</p>
 
 <p>This draft document may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published, and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this section are included on all such copies and derivative works. However, this document itself may not be modified in any way, including by removing the copyright notice or references to Ecma International, except as needed for the purpose of developing any document or deliverable produced by Ecma International.</p>
 
@@ -28,9 +28,9 @@
 <p>The limited permissions are granted through the standardization phase and will not be revoked by Ecma International or its successors or assigns during this time.</p>
 
 <p>This document and the information contained herein is provided on an "AS IS" basis and ECMA INTERNATIONAL DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.</p>
-
-      <h2>Software License</h2>
-      <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+</div>
+        <h2>Software License</h2>
+        <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
 
 <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 
@@ -42,4 +42,4 @@
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex></div></body>
+      </emu-annex></div></body>

--- a/test/baselines/generated-reference/boilerplate-address.html
+++ b/test/baselines/generated-reference/boilerplate-address.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-address.html
+++ b/test/baselines/generated-reference/boilerplate-address.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-all.html
+++ b/test/baselines/generated-reference/boilerplate-all.html
@@ -9,23 +9,23 @@
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
 </ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
-<emu-annex id="sec-copyright-and-software-license" class="copyright-notice" back-matter="">
-      <h1>Copyright &amp; Software License</h1>
-      <p class="ECMAaddress">Tet Corporation</p>
+<emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        <p class="ECMAaddress">Tet Corporation</p>
 <p class="ECMAaddress">2 Hammarskjöld Plaza</p>
 <p class="ECMAaddress">New York City, New York</p>
 <p class="ECMAaddress">Tel: 123-456-7890</p>
 <p class="ECMAaddress">Fax: 123-456-7890</p>
 <p class="ECMAaddress">Web: <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
 
-      <h2>Copyright Notice</h2>
-      <p>© 2018 Rick Waldron, Mid-World</p>
-
-      <h2>Software License</h2>
-      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 2018 Rick Waldron, Mid-World</p>
+</div>
+        <h2>Software License</h2>
+        <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
 
 <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
 
 <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 
-    </emu-annex></div></body>
+      </emu-annex></div></body>

--- a/test/baselines/generated-reference/boilerplate-all.html
+++ b/test/baselines/generated-reference/boilerplate-all.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-all.html
+++ b/test/baselines/generated-reference/boilerplate-all.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-copyright.html
+++ b/test/baselines/generated-reference/boilerplate-copyright.html
@@ -9,20 +9,20 @@
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
 </ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
-<emu-annex id="sec-copyright-and-software-license" class="copyright-notice" back-matter="">
-      <h1>Copyright &amp; Software License</h1>
-      <p class="ECMAaddress">Ecma International</p>
+<emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        <p class="ECMAaddress">Ecma International</p>
 <p class="ECMAaddress">Rue du Rhone 114</p>
 <p class="ECMAaddress">CH-1204 Geneva</p>
 <p class="ECMAaddress">Tel: +41 22 849 6000</p>
 <p class="ECMAaddress">Fax: +41 22 849 6001</p>
 <p class="ECMAaddress">Web: <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
 
-      <h2>Copyright Notice</h2>
-      <p>© 2018 Rick Waldron, Mid-World</p>
-
-      <h2>Software License</h2>
-      <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 2018 Rick Waldron, Mid-World</p>
+</div>
+        <h2>Software License</h2>
+        <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
 
 <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 
@@ -34,4 +34,4 @@
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex></div></body>
+      </emu-annex></div></body>

--- a/test/baselines/generated-reference/boilerplate-copyright.html
+++ b/test/baselines/generated-reference/boilerplate-copyright.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-copyright.html
+++ b/test/baselines/generated-reference/boilerplate-copyright.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-license.html
+++ b/test/baselines/generated-reference/boilerplate-license.html
@@ -9,17 +9,17 @@
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
 </ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
-<emu-annex id="sec-copyright-and-software-license" class="copyright-notice" back-matter="">
-      <h1>Copyright &amp; Software License</h1>
-      <p class="ECMAaddress">Ecma International</p>
+<emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        <p class="ECMAaddress">Ecma International</p>
 <p class="ECMAaddress">Rue du Rhone 114</p>
 <p class="ECMAaddress">CH-1204 Geneva</p>
 <p class="ECMAaddress">Tel: +41 22 849 6000</p>
 <p class="ECMAaddress">Fax: +41 22 849 6001</p>
 <p class="ECMAaddress">Web: <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
 
-      <h2>Copyright Notice</h2>
-      <p>© 2018 Ecma International</p>
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 2018 Ecma International</p>
 
 <p>This draft document may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published, and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this section are included on all such copies and derivative works. However, this document itself may not be modified in any way, including by removing the copyright notice or references to Ecma International, except as needed for the purpose of developing any document or deliverable produced by Ecma International.</p>
 
@@ -28,12 +28,12 @@
 <p>The limited permissions are granted through the standardization phase and will not be revoked by Ecma International or its successors or assigns during this time.</p>
 
 <p>This document and the information contained herein is provided on an "AS IS" basis and ECMA INTERNATIONAL DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.</p>
-
-      <h2>Software License</h2>
-      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+</div>
+        <h2>Software License</h2>
+        <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
 
 <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
 
 <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 
-    </emu-annex></div></body>
+      </emu-annex></div></body>

--- a/test/baselines/generated-reference/boilerplate-license.html
+++ b/test/baselines/generated-reference/boilerplate-license.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-license.html
+++ b/test/baselines/generated-reference/boilerplate-license.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><meta property="og:image" content="https://tc39.es/ecmarkup/ecma-logo.png"><meta property="og:title" content="test title!"><title>test title!</title></head><body><div id="shortcuts-help">
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -7,7 +7,7 @@
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="spec-container"><h1 class="version">April 2, 2018</h1><h1 class="title">test title!</h1>
+</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/clauses.html
+++ b/test/baselines/generated-reference/clauses.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<head><meta charset="utf-8"><title>Test Doc</title></head><body class=" oldtoc"><div class="full-page-svg" id="front-cover"><title>Test Doc</title></div><div class="full-page-svg" id="inside-cover"><p>Ecma International<br>Rue du Rhone 114 CH-1204 Geneva<br>Tel: +41 22 849 6000<br>Fax: +41 22 849 6001<br>Web: https://www.ecma-international.org<br>Ecma is the registered trademark of Ecma International.</p></div><div id="spec-container"><h1 class="title">Test Doc</h1>
+<head><meta charset="utf-8"><title>Test Doc</title></head><body class=" oldtoc"><div class="full-page-svg" id="front-cover"><h1 class="title">Test Doc</h1></div><div class="full-page-svg" id="inside-cover"></div><div id="spec-container">
 <div id="toc"><h2>Contents</h2><ol class="toc"><li><a href="#sec-intro" title="Intro">Intro</a><ol class="toc"><li><a href="#sec-intro2" title="Sub Intro">Sub Intro</a></li></ol></li><li><a href="#sec-clause" title="Clause Foo(a, b)"><span class="secnum">1</span> Clause Foo(<var>a</var>, <var>b</var>)</a><ol class="toc"><li><a href="#Foo" title="Sub Clause"><span class="secnum">1.1</span> Sub Clause</a></li></ol></li><li><a href="#sec-number" title="Explicit number"><span class="secnum">7</span> Explicit number</a><ol class="toc"><li><a href="#sec-number1" title="Automatic number inside explicit number"><span class="secnum">7.1</span> Automatic number inside explicit number</a></li><li><a href="#sec-number2" title="Nested explicit number"><span class="secnum">7.4</span> Nested explicit number</a></li><li><a href="#sec-number3" title="Automatic number after explicit number"><span class="secnum">7.5</span> Automatic number after explicit number</a></li><li><a href="#sec-number-nested" title="Multi-step explicit numbers"><span class="secnum">7.6</span> Multi-step explicit numbers</a></li></ol></li><li><a href="#sec-annex" title="Annex"><span class="secnum">Annex A <span class="annex-kind">(informative)</span></span> Annex</a><ol class="toc"><li><a href="#sec-annex2" title="Sub-annex"><span class="secnum">A.1</span> Sub-annex</a></li></ol></li></ol></div><emu-intro id="sec-intro">
   <h1>Intro</h1>
   <emu-intro id="sec-intro2">
@@ -7,7 +7,7 @@
   </emu-intro>
 </emu-intro>
 
-<emu-clause id="sec-clause">
+<h1 class="title">Test Doc</h1><emu-clause id="sec-clause">
   <!-- check for emd in headers and toc -->
   <h1><span class="secnum">1</span> Clause Foo(<var>a</var>, <var>b</var>)</h1>
 

--- a/test/baselines/generated-reference/copyright.html
+++ b/test/baselines/generated-reference/copyright.html
@@ -10,17 +10,17 @@
 </ul></div><div id="spec-container"><h1 class="version">Draft 1 / September 26, 2014</h1><h1 class="title">test title!</h1>
 <emu-clause id="sec-clause">
   <h1><span class="secnum">1</span> Test Clause</h1>
-</emu-clause><emu-annex id="sec-copyright-and-software-license" class="copyright-notice" back-matter="">
-      <h1>Copyright &amp; Software License</h1>
-      <p class="ECMAaddress">Ecma International</p>
+</emu-clause><emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        <p class="ECMAaddress">Ecma International</p>
 <p class="ECMAaddress">Rue du Rhone 114</p>
 <p class="ECMAaddress">CH-1204 Geneva</p>
 <p class="ECMAaddress">Tel: +41 22 849 6000</p>
 <p class="ECMAaddress">Fax: +41 22 849 6001</p>
 <p class="ECMAaddress">Web: <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
 
-      <h2>Copyright Notice</h2>
-      <p>© 2014 Ecma International</p>
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 2014 Ecma International</p>
 
 <p>This draft document may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published, and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this section are included on all such copies and derivative works. However, this document itself may not be modified in any way, including by removing the copyright notice or references to Ecma International, except as needed for the purpose of developing any document or deliverable produced by Ecma International.</p>
 
@@ -29,9 +29,9 @@
 <p>The limited permissions are granted through the standardization phase and will not be revoked by Ecma International or its successors or assigns during this time.</p>
 
 <p>This document and the information contained herein is provided on an "AS IS" basis and ECMA INTERNATIONAL DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.</p>
-
-      <h2>Software License</h2>
-      <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+</div>
+        <h2>Software License</h2>
+        <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
 
 <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 
@@ -43,5 +43,5 @@
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex>
+      </emu-annex>
 </div></body>

--- a/test/baselines/generated-reference/proposal-copyright.html
+++ b/test/baselines/generated-reference/proposal-copyright.html
@@ -9,14 +9,14 @@
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
 </ul></div><div id="spec-container"><h1 class="version">Stage 0 Draft / September 26, 2014</h1><h1 class="title">test title!</h1>
 
-<emu-annex id="sec-copyright-and-software-license" class="copyright-notice" back-matter="">
-      <h1>Copyright &amp; Software License</h1>
-      
-      <h2>Copyright Notice</h2>
-      <p>© 2014 Brian Terlson, Ecma International</p>
-
-      <h2>Software License</h2>
-      <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+<emu-annex id="sec-copyright-and-software-license" back-matter="">
+        <h1>Copyright &amp; Software License</h1>
+        
+        <div class="copyright-notice" id="copyright-notice"><h2>Copyright Notice</h2>
+<p>© 2014 Brian Terlson, Ecma International</p>
+</div>
+        <h2>Software License</h2>
+        <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT <a href="https://ecma-international.org/memento/codeofconduct.htm">https://ecma-international.org/memento/codeofconduct.htm</a> FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
 
 <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 
@@ -28,4 +28,4 @@
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex></div></body>
+      </emu-annex></div></body>


### PR DESCRIPTION
More TCs and TGs are expressing an interest in Ecmarkup, so I want to make sure we can produce the mandatory documents for them at standardization time.

Man I really hate the logic I came up with for the copyright page. Alternative: make sure it gets an easy-to-reference ID and move that back into the print.js DOM manipulation.

~~This is a draft because I’ve only glossed over the multipage output, haven’t given it a good look yet.~~

This has all been checked on printable & multi-page ECMA-262 & ECMA-402 builds. I noticed no changes on multipage builds.

## fixed

- no longer failing on draft status due to code removing shortname after checking for its presence

<details>
<summary>replaced blank cover</summary>

![2503_s9qwa](https://github.com/user-attachments/assets/9f33d05a-93dc-4ee7-82b2-ff08565fe504)

</details>

<details>
<summary>removed unexpected title page</summary>

![2503_luqn0](https://github.com/user-attachments/assets/1f8f3283-5b78-468a-8345-76a09ea0c730)

</details>

- removed extraneous address addition to inside cover (and its associated style)
- added missing license page from ToC (it should be listed the same way the bibliography or colophon are)

<details><summary>replaced incorrectly formatted copyright notice—should match template</summary>

![2503_c2xwo](https://github.com/user-attachments/assets/3e34fb22-2547-4c45-b2e5-c2c7d3b62407)

</details>

- software license in wrong spot for printed standards moved to end
- added correct copyright notice for certain standards ([Ecma “alternative” copyright notice](https://ecma-international.org/policies/by-ipr/ecma-text-copyright-policy/#alternative-copyright-notice))
  - `alternative` option added to `boilerplate.copyright` for documents which use Ecma’s alternative copyright

<details><summary>formatted Annex titles as expected by template</summary>

![2503_iu5qm](https://github.com/user-attachments/assets/54ffa972-aca5-4caa-8aa5-68d4fd58e7ff)

</details>

## needs extra scrutiny

I removed the code that moves the “scope” section to the beginning when printable option is passed. I didn’t see a spec that had the scope anywhere else, nor would I expect it. Maybe left over from when I was doing more manipulation on the prince side? Need a gut check that it’s good to go.

<details>

<summary>I changed the special treatment that the shortname gets when there’s a draft, as it breaks anything relying on the shortname being present. It shouldn’t impact multipage builds at all, but I suppose I could imagine a corner case where before changes to after</summary>

Before:

<img width="299" alt="2503_3t3f1" src="https://github.com/user-attachments/assets/2bf46fb5-8694-470e-81f9-4949be6319c9" />

After: 

<img width="292" alt="2503_v0nly" src="https://github.com/user-attachments/assets/f9dfa969-8c60-4d19-ad84-50e10025c75b" />

</details>

The generated references are meaningfully different because of 👆🏻.  Seeking an opinion on whether or not they should not be.