### PR TITLE
deps: Migrate to `@esfx/canceltoken`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "21.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"@esfx/canceltoken": "^1.0.0",
 				"chalk": "^4.1.2",
 				"command-line-args": "^5.2.0",
 				"command-line-usage": "^6.1.1",
@@ -23,7 +24,6 @@
 				"jsdom": "^25.0.1",
 				"nwsapi": "2.2.0",
 				"parse5": "^6.0.1",
-				"prex": "^0.4.7",
 				"promise-debounce": "^1.0.1"
 			},
 			"bin": {
@@ -125,96 +125,42 @@
 			}
 		},
 		"node_modules/@esfx/async-canceltoken": {
-			"version": "1.0.0-pre.30",
-			"resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.30.tgz",
-			"integrity": "sha512-4he0W+ZKH4OO4RvGfmATIibO5JzGLQqwm4Dp3X15bWnguDTmmOFt3Qt169Doij/gXxn2aPpZvxUaYIEebi8Xig==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0.tgz",
+			"integrity": "sha512-3Ps/4NPd7qFltmHL+CYXCjZtNXcQGV9BZmpzu8Rt3/0SZMtbQve0gtX0uJDJGvAWa6w3IB4HrKVP12VPoFONmA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@esfx/cancelable": "^1.0.0-pre.30",
-				"@esfx/collections-linkedlist": "^1.0.0-pre.24",
-				"@esfx/disposable": "^1.0.0-pre.30",
-				"@esfx/internal-guards": "^1.0.0-pre.23",
-				"@esfx/internal-tag": "^1.0.0-pre.19",
-				"tslib": "^2.1.0"
+				"@esfx/cancelable": "^1.0.0",
+				"@esfx/canceltoken": "^1.0.0",
+				"@esfx/disposable": "^1.0.0",
+				"tslib": "^2.4.0"
 			}
-		},
-		"node_modules/@esfx/async-canceltoken/node_modules/@esfx/cancelable": {
-			"version": "1.0.0-pre.30",
-			"resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.30.tgz",
-			"integrity": "sha512-fo0+/D3tEcSOHdZ8HiCR7qOKl5Tkk6Nw6QJNNXSQ0ejlpP3HU4S2i0rb/tjHQ1EkUcWZfB3g2jzfL0ioQSEgGg==",
-			"dependencies": {
-				"@esfx/disposable": "^1.0.0-pre.30",
-				"@esfx/internal-deprecate": "^1.0.0-pre.24",
-				"@esfx/internal-guards": "^1.0.0-pre.23",
-				"@esfx/internal-tag": "^1.0.0-pre.19"
-			}
-		},
-		"node_modules/@esfx/async-canceltoken/node_modules/@esfx/disposable": {
-			"version": "1.0.0-pre.30",
-			"resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.30.tgz",
-			"integrity": "sha512-njBGIQO+HW+lMqqMjURC+MWn+55ufulgebPLXzlxbwVSz5hZkoCsv6n9sIBQbnvg/PYQmWK5Dk6gDSmFfihTUg=="
 		},
 		"node_modules/@esfx/cancelable": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.24.tgz",
-			"integrity": "sha512-4xDsmBKAK0rSMwO/5PvrHdzHuJksZAwNCeUVi88IX1TwvcFtXbGh496oPMoHoDSEhRqWAg94cO5Whvz+h4Kq1Q==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0.tgz",
+			"integrity": "sha512-2dry/TuOT9ydpw86f396v09cyi/gLeGPIZSH4Gx+V/qKQaS/OXCRurCY+Cn8zkBfTAgFsjk9NE15d+LPo2kt9A==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@esfx/disposable": "^1.0.0-pre.19",
-				"@esfx/internal-deprecate": "^1.0.0-pre.24",
-				"@esfx/internal-guards": "^1.0.0-pre.23",
-				"@esfx/internal-tag": "^1.0.0-pre.19"
+				"@esfx/disposable": "^1.0.0"
 			}
 		},
-		"node_modules/@esfx/collection-core": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.24.tgz",
-			"integrity": "sha512-OIgMS91JmjSoRWD7u/DfnDzo8vDggeTeUPRi1p5WhyboY0+IwmetEqgeHZb8bpka/SsmtYX5qxqEjeqNXqh+pA==",
+		"node_modules/@esfx/canceltoken": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/canceltoken/-/canceltoken-1.0.0.tgz",
+			"integrity": "sha512-/TgdzC5O89w5v0TgwE2wcdtampWNAFOxzurCtb4RxYVr3m72yk3Bg82vMdznx+H9nnf28zVDR0PtpZO9FxmOkw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@esfx/internal-deprecate": "^1.0.0-pre.24",
-				"@esfx/internal-guards": "^1.0.0-pre.23"
-			}
-		},
-		"node_modules/@esfx/collections-linkedlist": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.24.tgz",
-			"integrity": "sha512-Maya8jXH0xvzyfeSH88/j2b5gavO/mluslgIC2Ttdz8rh6+3o8/pVYriceH/Jinn4pgTEzDhO6Rn/aruZG0+Ug==",
-			"dependencies": {
-				"@esfx/collection-core": "^1.0.0-pre.24",
-				"@esfx/equatable": "^1.0.0-pre.19",
-				"@esfx/internal-guards": "^1.0.0-pre.23"
+				"@esfx/cancelable": "^1.0.0",
+				"@esfx/disposable": "^1.0.0",
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esfx/disposable": {
-			"version": "1.0.0-pre.19",
-			"resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.19.tgz",
-			"integrity": "sha512-xNrDOKBzx49yXfQuAbWv5IN7dL1qL7DhLxmh9U6oC4uN0mLdlUHByMpyKonkHG98rEF43Q1xwuOAgEJd7C4eyw=="
-		},
-		"node_modules/@esfx/equatable": {
-			"version": "1.0.0-pre.19",
-			"resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.19.tgz",
-			"integrity": "sha512-+f6Xm6GOigyGx7t0D0IyG9Z0AuYDhNWjwV49vs5uNG/+0VQAOSYjmnpSzTZRYcYwxW52DmWJWFYNY8bvCDD2ag=="
-		},
-		"node_modules/@esfx/internal-deprecate": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.24.tgz",
-			"integrity": "sha512-TSU5k04+nuVQdyfYhaVXxyskdiwYQHgwN20J3cbyRrm/YFi2dOoFSLFvkMNh7LNOPGWSOg6pfAm3kd23ISR3Ow=="
-		},
-		"node_modules/@esfx/internal-guards": {
-			"version": "1.0.0-pre.23",
-			"resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.23.tgz",
-			"integrity": "sha512-y2svuwRERA2eKF1T/Stq+O8kPjicFQcUTob5je3L6iloOHnOD0sX6aQLvheWmTXXS7hAnjlyMeSN/ec84BRyHg==",
-			"dependencies": {
-				"@esfx/type-model": "^1.0.0-pre.23"
-			}
-		},
-		"node_modules/@esfx/internal-tag": {
-			"version": "1.0.0-pre.19",
-			"resolved": "https://registry.npmjs.org/@esfx/internal-tag/-/internal-tag-1.0.0-pre.19.tgz",
-			"integrity": "sha512-/v1D5LfvBnbvHzL22Vh6yobrOTVCBhsW/l9M+/GRA51eqCN27yTmWGaYUSd1QXp2vxHwNr0sfckVoNtTzeaIqQ=="
-		},
-		"node_modules/@esfx/type-model": {
-			"version": "1.0.0-pre.23",
-			"resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.23.tgz",
-			"integrity": "sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0.tgz",
+			"integrity": "sha512-hu7EI+YxlEWEKrb2himbS13HNaq5mlUePASf99KeQqkiNeqiAZbKqG4w59uDcLZs8JrV3qJqS/NYib5ZMhbfTQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
@@ -2579,15 +2525,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/prex": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/prex/-/prex-0.4.7.tgz",
-			"integrity": "sha512-ulhl3iyjmAW/GroRQJN4CG+pC6KJ+W+deNRBkEShQwe16wLP9k92+x6RmLJuLiVSGkbxhnAqHpGdJJCh3bRpUQ==",
-			"dependencies": {
-				"@esfx/cancelable": "^1.0.0-pre.13",
-				"@esfx/disposable": "^1.0.0-pre.13"
-			}
-		},
 		"node_modules/promise-debounce": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-debounce/-/promise-debounce-1.0.1.tgz",
@@ -3443,98 +3380,38 @@
 			}
 		},
 		"@esfx/async-canceltoken": {
-			"version": "1.0.0-pre.30",
-			"resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.30.tgz",
-			"integrity": "sha512-4he0W+ZKH4OO4RvGfmATIibO5JzGLQqwm4Dp3X15bWnguDTmmOFt3Qt169Doij/gXxn2aPpZvxUaYIEebi8Xig==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0.tgz",
+			"integrity": "sha512-3Ps/4NPd7qFltmHL+CYXCjZtNXcQGV9BZmpzu8Rt3/0SZMtbQve0gtX0uJDJGvAWa6w3IB4HrKVP12VPoFONmA==",
 			"requires": {
-				"@esfx/cancelable": "^1.0.0-pre.30",
-				"@esfx/collections-linkedlist": "^1.0.0-pre.24",
-				"@esfx/disposable": "^1.0.0-pre.30",
-				"@esfx/internal-guards": "^1.0.0-pre.23",
-				"@esfx/internal-tag": "^1.0.0-pre.19",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"@esfx/cancelable": {
-					"version": "1.0.0-pre.30",
-					"resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.30.tgz",
-					"integrity": "sha512-fo0+/D3tEcSOHdZ8HiCR7qOKl5Tkk6Nw6QJNNXSQ0ejlpP3HU4S2i0rb/tjHQ1EkUcWZfB3g2jzfL0ioQSEgGg==",
-					"requires": {
-						"@esfx/disposable": "^1.0.0-pre.30",
-						"@esfx/internal-deprecate": "^1.0.0-pre.24",
-						"@esfx/internal-guards": "^1.0.0-pre.23",
-						"@esfx/internal-tag": "^1.0.0-pre.19"
-					}
-				},
-				"@esfx/disposable": {
-					"version": "1.0.0-pre.30",
-					"resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.30.tgz",
-					"integrity": "sha512-njBGIQO+HW+lMqqMjURC+MWn+55ufulgebPLXzlxbwVSz5hZkoCsv6n9sIBQbnvg/PYQmWK5Dk6gDSmFfihTUg=="
-				}
+				"@esfx/cancelable": "^1.0.0",
+				"@esfx/canceltoken": "^1.0.0",
+				"@esfx/disposable": "^1.0.0",
+				"tslib": "^2.4.0"
 			}
 		},
 		"@esfx/cancelable": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.24.tgz",
-			"integrity": "sha512-4xDsmBKAK0rSMwO/5PvrHdzHuJksZAwNCeUVi88IX1TwvcFtXbGh496oPMoHoDSEhRqWAg94cO5Whvz+h4Kq1Q==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0.tgz",
+			"integrity": "sha512-2dry/TuOT9ydpw86f396v09cyi/gLeGPIZSH4Gx+V/qKQaS/OXCRurCY+Cn8zkBfTAgFsjk9NE15d+LPo2kt9A==",
 			"requires": {
-				"@esfx/disposable": "^1.0.0-pre.19",
-				"@esfx/internal-deprecate": "^1.0.0-pre.24",
-				"@esfx/internal-guards": "^1.0.0-pre.23",
-				"@esfx/internal-tag": "^1.0.0-pre.19"
+				"@esfx/disposable": "^1.0.0"
 			}
 		},
-		"@esfx/collection-core": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.24.tgz",
-			"integrity": "sha512-OIgMS91JmjSoRWD7u/DfnDzo8vDggeTeUPRi1p5WhyboY0+IwmetEqgeHZb8bpka/SsmtYX5qxqEjeqNXqh+pA==",
+		"@esfx/canceltoken": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/canceltoken/-/canceltoken-1.0.0.tgz",
+			"integrity": "sha512-/TgdzC5O89w5v0TgwE2wcdtampWNAFOxzurCtb4RxYVr3m72yk3Bg82vMdznx+H9nnf28zVDR0PtpZO9FxmOkw==",
 			"requires": {
-				"@esfx/internal-deprecate": "^1.0.0-pre.24",
-				"@esfx/internal-guards": "^1.0.0-pre.23"
-			}
-		},
-		"@esfx/collections-linkedlist": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.24.tgz",
-			"integrity": "sha512-Maya8jXH0xvzyfeSH88/j2b5gavO/mluslgIC2Ttdz8rh6+3o8/pVYriceH/Jinn4pgTEzDhO6Rn/aruZG0+Ug==",
-			"requires": {
-				"@esfx/collection-core": "^1.0.0-pre.24",
-				"@esfx/equatable": "^1.0.0-pre.19",
-				"@esfx/internal-guards": "^1.0.0-pre.23"
+				"@esfx/cancelable": "^1.0.0",
+				"@esfx/disposable": "^1.0.0",
+				"tslib": "^2.4.0"
 			}
 		},
 		"@esfx/disposable": {
-			"version": "1.0.0-pre.19",
-			"resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.19.tgz",
-			"integrity": "sha512-xNrDOKBzx49yXfQuAbWv5IN7dL1qL7DhLxmh9U6oC4uN0mLdlUHByMpyKonkHG98rEF43Q1xwuOAgEJd7C4eyw=="
-		},
-		"@esfx/equatable": {
-			"version": "1.0.0-pre.19",
-			"resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.19.tgz",
-			"integrity": "sha512-+f6Xm6GOigyGx7t0D0IyG9Z0AuYDhNWjwV49vs5uNG/+0VQAOSYjmnpSzTZRYcYwxW52DmWJWFYNY8bvCDD2ag=="
-		},
-		"@esfx/internal-deprecate": {
-			"version": "1.0.0-pre.24",
-			"resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.24.tgz",
-			"integrity": "sha512-TSU5k04+nuVQdyfYhaVXxyskdiwYQHgwN20J3cbyRrm/YFi2dOoFSLFvkMNh7LNOPGWSOg6pfAm3kd23ISR3Ow=="
-		},
-		"@esfx/internal-guards": {
-			"version": "1.0.0-pre.23",
-			"resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.23.tgz",
-			"integrity": "sha512-y2svuwRERA2eKF1T/Stq+O8kPjicFQcUTob5je3L6iloOHnOD0sX6aQLvheWmTXXS7hAnjlyMeSN/ec84BRyHg==",
-			"requires": {
-				"@esfx/type-model": "^1.0.0-pre.23"
-			}
-		},
-		"@esfx/internal-tag": {
-			"version": "1.0.0-pre.19",
-			"resolved": "https://registry.npmjs.org/@esfx/internal-tag/-/internal-tag-1.0.0-pre.19.tgz",
-			"integrity": "sha512-/v1D5LfvBnbvHzL22Vh6yobrOTVCBhsW/l9M+/GRA51eqCN27yTmWGaYUSd1QXp2vxHwNr0sfckVoNtTzeaIqQ=="
-		},
-		"@esfx/type-model": {
-			"version": "1.0.0-pre.23",
-			"resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.23.tgz",
-			"integrity": "sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0.tgz",
+			"integrity": "sha512-hu7EI+YxlEWEKrb2himbS13HNaq5mlUePASf99KeQqkiNeqiAZbKqG4w59uDcLZs8JrV3qJqS/NYib5ZMhbfTQ=="
 		},
 		"@eslint-community/eslint-utils": {
 			"version": "4.4.0",
@@ -5257,15 +5134,6 @@
 			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.2"
-			}
-		},
-		"prex": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/prex/-/prex-0.4.7.tgz",
-			"integrity": "sha512-ulhl3iyjmAW/GroRQJN4CG+pC6KJ+W+deNRBkEShQwe16wLP9k92+x6RmLJuLiVSGkbxhnAqHpGdJJCh3bRpUQ==",
-			"requires": {
-				"@esfx/cancelable": "^1.0.0-pre.13",
-				"@esfx/disposable": "^1.0.0-pre.13"
 			}
 		},
 		"promise-debounce": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	"author": "Brian Terlson",
 	"license": "MIT",
 	"dependencies": {
+		"@esfx/canceltoken": "^1.0.0",
 		"chalk": "^4.1.2",
 		"command-line-args": "^5.2.0",
 		"command-line-usage": "^6.1.1",
@@ -62,7 +63,6 @@
 		"jsdom": "^25.0.1",
 		"nwsapi": "2.2.0",
 		"parse5": "^6.0.1",
-		"prex": "^0.4.7",
 		"promise-debounce": "^1.0.1"
 	},
 	"devDependencies": {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -44,7 +44,7 @@ import {
   YES_CLAUSE_AUTOLINK,
 } from './autolinker';
 import { lint } from './lint/lint';
-import { CancellationToken } from 'prex';
+import { CancelToken } from '@esfx/canceltoken';
 import type { JSDOM } from 'jsdom';
 import { getProductions, rhsMatches, getLocationInGrammarFile } from './lint/utils';
 import type { AugmentedGrammarEle } from './Grammar';
@@ -314,7 +314,7 @@ export default class Spec {
   >; // map from re to its labeled nodes
   /** @internal */ labeledStepsToBeRectified: Set<string>;
   /** @internal */ replacementAlgorithms: { element: Element; target: string }[];
-  /** @internal */ cancellationToken: CancellationToken;
+  /** @internal */ cancellationToken: CancelToken;
 
   readonly log: (msg: string) => void;
   readonly warn: (err: Warning) => void | undefined;
@@ -337,15 +337,15 @@ export default class Spec {
   /** @internal */ refsByClause: { [refId: string]: [string] };
   /** @internal */ topLevelImportedNodes: Map<Node, EmuImportElement>;
 
-  private _fetch: (file: string, token: CancellationToken) => PromiseLike<string>;
+  private _fetch: (file: string, token: CancelToken) => PromiseLike<string>;
 
   constructor(
     rootPath: string,
-    fetch: (file: string, token: CancellationToken) => PromiseLike<string>,
+    fetch: (file: string, token: CancelToken) => PromiseLike<string>,
     dom: JSDOM,
     opts: Options = {},
     sourceText: string,
-    token = CancellationToken.none,
+    token = CancelToken.none,
   ) {
     this.spec = this;
     this.opts = {};
@@ -1343,7 +1343,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
   }
 
   private async loadBiblios() {
-    this.cancellationToken.throwIfCancellationRequested();
+    this.cancellationToken.throwIfSignaled();
     const biblioPaths = [];
     for (const biblioEle of this.doc.querySelectorAll('emu-biblio')) {
       const href = biblioEle.getAttribute('href');
@@ -1444,7 +1444,7 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
   }
 
   private buildBoilerplate() {
-    this.cancellationToken.throwIfCancellationRequested();
+    this.cancellationToken.throwIfSignaled();
     const status = this.opts.status!;
     const version = this.opts.version;
     const title = this.opts.title;

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -2,7 +2,7 @@ import type { BiblioEntry, ExportedBiblio } from './Biblio';
 
 import Spec from './Spec';
 import * as utils from './utils';
-import { CancellationToken } from 'prex';
+import { CancelToken } from '@esfx/canceltoken';
 
 export type { Spec, BiblioEntry };
 
@@ -52,9 +52,9 @@ export interface Options {
 
 export async function build(
   path: string,
-  fetch: (path: string, token: CancellationToken) => PromiseLike<string>,
+  fetch: (path: string, token: CancelToken) => PromiseLike<string>,
   opts?: Options,
-  token = CancellationToken.none,
+  token = CancelToken.none,
 ): Promise<Spec> {
   const html = await fetch(path, token);
   const dom = utils.htmlToDom(html);


### PR DESCRIPTION
Since [`prex`](https://www.npmjs.com/package/prex) is long deprecated, this migrates to [`@esfx/⁠canceltoken`](https://www.npmjs.com/package/@esfx/canceltoken), which is now at **v1.0**.

This is an **API** breaking change for code which makes use of `prex`’s `CancellationToken`s.