### PR TITLE
Fix display of normative optional blocks used as algorithm steps

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -1572,7 +1572,6 @@ emu-normative-optional,
 [deprecated],
 [legacy] {
   border-left: 5px solid var(--normative-optional-border-color);
-  display: block;
   padding: 0.5em;
   background: var(--normative-optional-background-color);
 }

--- a/css/elements.css
+++ b/css/elements.css
@@ -1561,6 +1561,10 @@ li.menu-search-result-term::before {
   padding-right: 5px;
 }
 
+emu-normative-optional {
+  display: block;
+}
+
 emu-normative-optional::before {
   display: block;
   color: var(--attributes-tag-foreground-color);

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -3184,7 +3184,6 @@ emu-normative-optional,
 [deprecated],
 [legacy] {
   border-left: 5px solid var(--normative-optional-border-color);
-  display: block;
   padding: 0.5em;
   background: var(--normative-optional-background-color);
 }

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -3173,6 +3173,10 @@ li.menu-search-result-term::before {
   padding-right: 5px;
 }
 
+emu-normative-optional {
+  display: block;
+}
+
 emu-normative-optional::before {
   display: block;
   color: var(--attributes-tag-foreground-color);


### PR DESCRIPTION
Fixes #640.

Or at least, I hope it does—this reverts one line of #600, but I'm not sure what situation that line was meant to address. At a glance, this seems to fix the problem without having any effect on normative optional blocks which _aren't_ used as algorithm steps.