### PR TITLE
add new keyboard shortcut to jump to the most recent link target

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -321,10 +321,14 @@ function Menu() {
 
 Menu.prototype.documentKeydown = function (e) {
   e.stopPropagation();
-  if (e.keyCode === 80) {
+  if (e.key === 'p') {
     this.togglePinEntry();
-  } else if (e.keyCode >= 48 && e.keyCode < 58) {
+  } else if ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(parseInt(e.key))) {
     this.selectPin((e.keyCode - 9) % 10);
+  } else if (e.key === '`') {
+    if (document.location.hash) {
+      document.querySelector(document.location.hash).scrollIntoView(true);
+    }
   }
 };
 

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1323,7 +1323,9 @@ ${await utils.readFile(path.join(__dirname, '../js/multipage.js'))}
 ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</code></li>` : ''}
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
-  <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
+  <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
+  <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
+  <li><span>Jump to the most recent link target</span><code>\`</code></li>
 </ul>`;
     return shortcutsHelp;
   }


### PR DESCRIPTION
This adds `` ` `` as a new keyboard shortcut to jump to the last place you jumped. I like to think of it as a kind of "dynamic pin". When I click a link to somewhere in the spec, I often scroll or Ctrl-F my way away without thinking of pinning it and want a quick way to get back to what I was just looking at. I chose `` ` `` for the key because it nicely aligns with the numbered pins on my keyboard and the above-stated mental model as another pin. Also, it's the same key used to jump to a mark in vim.