### PR TITLE
Decode target ID from location.hash rather than using it as an ID selector

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -326,9 +326,10 @@ Menu.prototype.documentKeydown = function (e) {
   } else if ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(parseInt(e.key))) {
     this.selectPin((e.keyCode - 9) % 10);
   } else if (e.key === '`') {
-    if (document.location.hash) {
-      document.querySelector(document.location.hash).scrollIntoView(true);
-    }
+    const hash = document.location.hash;
+    const id = decodeURIComponent(hash.slice(1));
+    const target = document.getElementById(id);
+    target?.scrollIntoView(true);
   }
 };
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -410,9 +410,10 @@ Menu.prototype.documentKeydown = function (e) {
   } else if ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(parseInt(e.key))) {
     this.selectPin((e.keyCode - 9) % 10);
   } else if (e.key === '`') {
-    if (document.location.hash) {
-      document.querySelector(document.location.hash).scrollIntoView(true);
-    }
+    const hash = document.location.hash;
+    const id = decodeURIComponent(hash.slice(1));
+    const target = document.getElementById(id);
+    target?.scrollIntoView(true);
   }
 };
 


### PR DESCRIPTION
Ref #645

Code hygiene—there's no guarantee that `location.hash` is a valid CSS selector, or that it actually corresponds with an element.