### PR TITLE
fix: Multipage mode: `<script>` tag `src` attribute is incorrectly rewritten as `..`

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1056,7 +1056,7 @@ ${await utils.readFile(path.join(__dirname, '../js/multipage.js'))}
       }
 
       for (const script of allClones.flatMap(e => [...e.querySelectorAll('script')])) {
-        if (script.src != null && !/^(http:|https:|:|\/)/.test(script.src)) {
+        if (script.hasAttribute('src') && !/^(http:|https:|:|\/)/.test(script.src)) {
           script.src = path.relative('multipage', script.src);
         }
       }


### PR DESCRIPTION
#652 

Fix this
<img width="449" height="263" alt="image" src="https://github.com/user-attachments/assets/4326f651-c97d-450f-92cc-e619546f2e3b" />

