### PR TITLE
Terms & Defs style rule

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -256,12 +256,12 @@
 
 html {
   background-color: var(--background-color);
+  font-size: 18px;
 }
 
 body {
   display: flex;
   word-wrap: break-word;
-  font-size: 18px;
   line-height: 1.5;
   font-family:
     'IBM Plex Serif',
@@ -918,6 +918,18 @@ emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
 #spec-container > emu-clause:first-of-type,
 #spec-container > emu-annex:first-of-type {
   margin-top: 0;
+}
+
+[id*="terms-and-definitions"] emu-clause h1 {
+  font-size: 1rem;
+}
+
+[id*="terms-and-definitions"] emu-clause h1 + p {
+  margin-top: 0;
+}
+
+[id*="terms-and-definitions"] emu-clause .secnum {
+  display: block;
 }
 
 /* Figures and tables */

--- a/css/elements.css
+++ b/css/elements.css
@@ -920,15 +920,15 @@ emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
   margin-top: 0;
 }
 
-[id*="terms-and-definitions"] emu-clause h1 {
+[id*='terms-and-definitions'] emu-clause h1 {
   font-size: 1rem;
 }
 
-[id*="terms-and-definitions"] emu-clause h1 + p {
+[id*='terms-and-definitions'] emu-clause h1 + p {
   margin-top: 0;
 }
 
-[id*="terms-and-definitions"] emu-clause .secnum {
+[id*='terms-and-definitions'] emu-clause .secnum {
   display: block;
 }
 

--- a/css/print.css
+++ b/css/print.css
@@ -660,19 +660,24 @@ p.ECMAaddress {
   margin: 0;
 }
 
-#sec-terms-and-definitions dfn {
+[id$=terms-and-definitions] dfn {
   font-style: normal;
 }
 
-#sec-terms-and-definitions h1 .secnum {
+[id$=terms-and-definitions] emu-clause h1 {
+  font-size: 10pt;
+  -prince-bookmark-level: none;
+}
+
+[id$=terms-and-definitions] h1 .secnum {
   display: block;
 }
 
-#sec-terms-and-definitions > h1 > .secnum {
+[id$=terms-and-definitions] > h1 > .secnum {
   display: inline;
 }
 
-#sec-terms-and-definitions h1 + p {
+[id$=terms-and-definitions] h1 + p {
   margin-top: 0;
 }
 

--- a/css/print.css
+++ b/css/print.css
@@ -188,11 +188,11 @@
 
 html, body {
   background-color: initial;
+  font-size: 10pt;
 }
 
 body {
   font-family: 'Arial Plus', Arial, Helvetica, sans-serif, "DejaVu Math TeX Gyre", Symbola, monospace;
-  font-size: 10pt;
   color: #000;
   line-height: 1.15;
 }
@@ -660,25 +660,13 @@ p.ECMAaddress {
   margin: 0;
 }
 
-[id$=terms-and-definitions] dfn {
+[id*=terms-and-definitions] dfn {
   font-style: normal;
 }
 
-[id$=terms-and-definitions] emu-clause h1 {
+[id*=terms-and-definitions] emu-clause h1 {
   font-size: 10pt;
   -prince-bookmark-level: none;
-}
-
-[id$=terms-and-definitions] h1 .secnum {
-  display: block;
-}
-
-[id$=terms-and-definitions] > h1 > .secnum {
-  display: inline;
-}
-
-[id$=terms-and-definitions] h1 + p {
-  margin-top: 0;
 }
 
 p.adoption-info {

--- a/css/print.css
+++ b/css/print.css
@@ -660,12 +660,11 @@ p.ECMAaddress {
   margin: 0;
 }
 
-[id*=terms-and-definitions] dfn {
+[id*='terms-and-definitions'] dfn {
   font-style: normal;
 }
 
-[id*=terms-and-definitions] emu-clause h1 {
-  font-size: 10pt;
+[id*='terms-and-definitions'] emu-clause h1 {
   -prince-bookmark-level: none;
 }
 

--- a/js/print.js
+++ b/js/print.js
@@ -30,7 +30,7 @@ PDF.subject = shortname.innerHTML + (version ? ', ' + version.innerHTML : '');
 /**
  * Terms and definitions section should not have every term listed in the table of contents.
  * */
-const terms = document.querySelector('#toc a[href*="terms-and-definitions"]');
+const terms = document.querySelector('#toc a[href*="#terms-and-definitions"]');
 
 if (terms) {
   (terms.parentElement.querySelector('ol.toc') || document.createElement('i')).remove();

--- a/js/print.js
+++ b/js/print.js
@@ -30,7 +30,7 @@ PDF.subject = shortname.innerHTML + (version ? ', ' + version.innerHTML : '');
 /**
  * Terms and definitions section should not have every term listed in the table of contents.
  * */
-const terms = document.querySelector('#toc a[href="#sec-terms-and-definitions"]');
+const terms = document.querySelector('#toc a[href*="terms-and-definitions"]');
 
 if (terms) {
   (terms.parentElement.querySelector('ol.toc') || document.createElement('i')).remove();

--- a/spec/index.html
+++ b/spec/index.html
@@ -164,7 +164,9 @@ markEffects: true
 
 <emu-clause id="clauses">
   <h1>Clauses</h1>
-  <p>Clauses are referenced using their id and are numbered automatically based on document position. Ecmarkdown syntax can be used in descendent text nodes as well. Text nodes are parsed as Ecmarkdown Fragments.</p>
+  <p>Clauses are referenced using their id and are numbered automatically based on document position. Ecmarkdown syntax can be used in descendent text nodes as well. Text nodes are parsed as Ecmarkdown Fragments. Clauses always begin with an `&lt;h1>` element.</p>
+
+  <!-- TODO Ecma house style supports clauses without a title (therefore numbered only) as long as all clauses as that level and lower are also numbered only. -->
 
   <emu-clause id="emu-intro">
     <h1>emu-intro</h1>
@@ -254,6 +256,42 @@ markEffects: true
         <p>This clause is normative optional.</p>
       </emu-clause>
     </aside>
+
+    <emu-clause id="terms">
+      <h1>Terms and definitions</h1>
+      <p>Ecmarkup produces special formatting behaviour for an `&lt;emu-clause>` with an ID ending in `terms-and-definitions`. No action is required on an editor's part to properly format that clause as long as it uses similar markup to any other clause, i.e. an `&lt;h1>` element followed by one or more `&lt;p>` or `&lt;emu-clause>` elements.</p>
+      <p>Using a `&lt;dfn>` element in the clause title is optional, and will allow ecmarkup to link back to the term anywhere it is used in the rest of the document. See <emu-xref href="#definitions">definitions</emu-xref>.</p>
+
+      <h2>Example</h2>
+      <pre><code class="language-html">
+      &lt;emu-clause id="sec-terms-and-definitions">
+        &lt;h1>Terms and definitions&lt;/h1>
+        &lt;emu-clause id="term-technical-definition">
+          &lt;h1>technical definition&lt;/h1>
+          &lt;p>descriptive text aligning with Ecma house style, providing text that could be swapped in for the term without impacting readability&lt;/p>
+        &lt;/emu-clause>
+        &lt;emu-clause id="term-ecma">
+          &lt;h1>&lt;dfn>Ecma International&lt;/dfn>&lt;/h1>
+          &lt;p>international standards organization responsible for technology-related standards since 1959&lt;/p>
+        &lt;/emu-clause>
+      &lt;/emu-clause></code></pre>
+
+      <h3>Result</h3>
+      <aside class="result">
+        <emu-clause id="sec-terms-and-definitions">
+          <h1>Terms and definitions</h1>
+          <emu-clause id="term-technical-definition">
+            <h1>technical definition</h1>
+            <p>descriptive text aligning with Ecma house style, providing text that could be swapped in for the term without impacting readability</p>
+          </emu-clause>
+
+          <emu-clause id="term-ecma">
+            <h1><dfn>Ecma International</dfn></h1>
+            <p>international standards organization responsible for technology-related standards since 1959</p>
+          </emu-clause>
+        </emu-clause>
+      </aside>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="emu-annex">
@@ -270,7 +308,7 @@ markEffects: true
 
 <emu-clause id="definitions">
   <h1>Definitions</h1>
-  <p>Terms can be defined using the `&lt;dfn>` element. Any uses of that term will be automatically linked to the clause containing the definition, or, if the `&lt;dfn>` element has an `id`, to the `&lt;dfn>` itself. This can be suppressed with the <a href="#emu-not-ref">`emu-not-ref`</a> element.</p>
+  <p>Terms can be defined <em>inline</em> using the `&lt;dfn>` element. Any uses of that term will be automatically linked to the clause containing the definition, or, if the `&lt;dfn>` element has an `id`, to the `&lt;dfn>` itself. This can be suppressed with the <a href="#emu-not-ref">`emu-not-ref`</a> element.</p>
   <p>When the term starts with a lowercase English letter, usages of the term with the first letter capitalized will also link.</p>
 
   <h2>Attributes</h2>
@@ -1103,3 +1141,47 @@ markEffects: true
     <p>Create a code listing using `&lt;pre>&lt;code>`. The `code` element takes a class of `javascript`, `html`, or any other language provided by <a href="https://highlightjs.org/">highlightjs</a>. Ecmarkup will trim any leading blank lines and also normalize the indentation based on the indentation of the first line.</p>
   </emu-clause>
 </emu-clause>
+
+<emu-annex id="document-structure">
+  <h1>Required structure for Ecma documents</h1>
+
+  <p>Ecmarkup supports producing a document aligned with Ecma house style. If the ecmarkup document is intended to be formally released by Ecma International, there are some structural requirements it shall follow.</p>
+  <p>Each `&lt;emu-intro>`, `&lt;emu-clause>`, and `&lt;emu-annex>` element shall have a unique ID, optionally beginning with the prefix `sec-`.</p>
+
+  <emu-annex id="technical-report">
+    <h1>Technical Reports</h1>
+
+    <emu-note>
+      <p>This section is a work in progress.</p>
+    </emu-note>
+
+    <p>Ecma technical reports begin with an unnumbered introduction (using a single `&lt;emu-intro>` element), then the following numbered clauses:</p>
+
+    <ol>
+      <li>Scope</li>
+      <li>References</li>
+      <li>Terms and definitions</li>
+    </ol>
+
+    <p>(Refer to the Ecma house style guide for more detailed information.)</p>
+  </emu-annex>
+
+  <emu-annex id="standard">
+    <h1>Standards</h1>
+
+    <emu-note>
+      <p>This section is a work in progress.</p>
+    </emu-note>
+
+    <p>Ecma standards conforming to Ecma house style begin with an unnumbered introduction clause (using a single `&lt;emu-intro>` element), followed by the following numbered clauses:</p>
+
+    <ol>
+      <li>Scope</li>
+      <li>Normative references</li>
+      <li>Informative references</li>
+      <li>Terms and definitions</li>
+    </ol>
+
+    <p>(Refer to the Ecma house style guide for more detailed information.)</p>
+  </emu-annex>
+</emu-annex>

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -3917,19 +3917,24 @@ p.ECMAaddress {
   margin: 0;
 }
 
-#sec-terms-and-definitions dfn {
+[id$=terms-and-definitions] dfn {
   font-style: normal;
 }
 
-#sec-terms-and-definitions h1 .secnum {
+[id$=terms-and-definitions] emu-clause h1 {
+  font-size: 10pt;
+  -prince-bookmark-level: none;
+}
+
+[id$=terms-and-definitions] h1 .secnum {
   display: block;
 }
 
-#sec-terms-and-definitions > h1 > .secnum {
+[id$=terms-and-definitions] > h1 > .secnum {
   display: inline;
 }
 
-#sec-terms-and-definitions h1 + p {
+[id$=terms-and-definitions] h1 + p {
   margin-top: 0;
 }
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -1872,12 +1872,12 @@ let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"se
 
 html {
   background-color: var(--background-color);
+  font-size: 18px;
 }
 
 body {
   display: flex;
   word-wrap: break-word;
-  font-size: 18px;
   line-height: 1.5;
   font-family:
     'IBM Plex Serif',
@@ -2534,6 +2534,18 @@ emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
 #spec-container > emu-clause:first-of-type,
 #spec-container > emu-annex:first-of-type {
   margin-top: 0;
+}
+
+[id*='terms-and-definitions'] emu-clause h1 {
+  font-size: 1rem;
+}
+
+[id*='terms-and-definitions'] emu-clause h1 + p {
+  margin-top: 0;
+}
+
+[id*='terms-and-definitions'] emu-clause .secnum {
+  display: block;
 }
 
 /* Figures and tables */
@@ -3445,11 +3457,11 @@ li.menu-search-result-term::before {
 
 html, body {
   background-color: initial;
+  font-size: 10pt;
 }
 
 body {
   font-family: 'Arial Plus', Arial, Helvetica, sans-serif, "DejaVu Math TeX Gyre", Symbola, monospace;
-  font-size: 10pt;
   color: #000;
   line-height: 1.15;
 }
@@ -3917,25 +3929,12 @@ p.ECMAaddress {
   margin: 0;
 }
 
-[id$=terms-and-definitions] dfn {
+[id*='terms-and-definitions'] dfn {
   font-style: normal;
 }
 
-[id$=terms-and-definitions] emu-clause h1 {
-  font-size: 10pt;
+[id*='terms-and-definitions'] emu-clause h1 {
   -prince-bookmark-level: none;
-}
-
-[id$=terms-and-definitions] h1 .secnum {
-  display: block;
-}
-
-[id$=terms-and-definitions] > h1 > .secnum {
-  display: inline;
-}
-
-[id$=terms-and-definitions] h1 + p {
-  margin-top: 0;
 }
 
 p.adoption-info {


### PR DESCRIPTION
- Not every Ecma standard prepends their claueses with `sec`, this should catch the rest.
- terms are 10pt font, not styled like section headers.