### PR TITLE
Disallow mutating variables after they are captured

### DIFF
--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -41,10 +41,12 @@ type VarKind =
 class Scope {
   declare vars: Map<string, { kind: VarKind; used: boolean; node: HasLocation | null }>;
   declare strictScopes: Set<string>[];
+  declare captured: Set<string>;
   declare report: Reporter;
   constructor(report: Reporter) {
     this.vars = new Map();
     this.strictScopes = [new Set()];
+    this.captured = new Set();
     this.report = report;
 
     // TODO remove this when regex state objects become less dumb
@@ -317,12 +319,14 @@ function walkAlgorithm(
             const name = v.contents;
             scope.use(v);
             acScope.declare(name, v, 'abstract closure capture');
+            scope.captured.add(name);
           }
         }
       }
 
       // we have a lint rule elsewhere which checks there are substeps for closures, but we can't guarantee that rule hasn't tripped this run, so we still need to guard
       if (step.sublist != null && step.sublist.name === 'ol') {
+        acScope.captured = new Set(scope.captured);
         walkAlgorithm(algorithmSource, step.sublist, parsed, acScope, report);
         for (const [name, { node, kind, used }] of acScope.vars) {
           if (kind === 'abstract closure capture' && !used) {
@@ -398,6 +402,29 @@ function walkAlgorithm(
             }
             continue;
           }
+        }
+      }
+    }
+
+    // detect "Set _x_ to" reassignments of variables captured by a closure
+    for (let i = 1; i < expr.items.length - 1; ++i) {
+      const prev = expr.items[i - 1];
+      const cur = expr.items[i];
+      const next = expr.items[i + 1];
+      if (
+        isVariable(cur) &&
+        prev.name === 'text' &&
+        /\bset $/i.test(prev.contents) &&
+        next.name === 'text' &&
+        /^ to\b/.test(next.contents)
+      ) {
+        if (scope.captured.has(cur.contents)) {
+          report({
+            ruleId: 'set-captured-variable',
+            message: `${JSON.stringify(cur.contents)} cannot be reassigned after being captured by a closure`,
+            line: cur.location.start.line,
+            column: cur.location.start.column,
+          });
         }
       }
     }

--- a/test/lint-variable-use-def.ts
+++ b/test/lint-variable-use-def.ts
@@ -700,3 +700,120 @@ describe('variables cannot be redeclared', () => {
     );
   });
 });
+
+describe('closures must not capture reassigned variables', () => {
+  it('set after capture is an error', async () => {
+    await assertLint(
+      positioned`
+        <emu-alg>
+          1. Let _x_ be 0.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Return _x_.
+          1. Set ${M}_x_ to 1.
+          1. Return _closure_.
+        </emu-alg>
+      `,
+      {
+        ruleId: 'set-captured-variable',
+        nodeType: 'emu-alg',
+        message: '"x" cannot be reassigned after being captured by a closure',
+      },
+    );
+  });
+
+  it('set before capture is not an error', async () => {
+    await assertLintFree(
+      `
+        <emu-alg>
+          1. Let _x_ be 0.
+          1. Set _x_ to 1.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Return _x_.
+          1. Return _closure_.
+        </emu-alg>
+      `,
+    );
+  });
+
+  it('set inside closure is an error', async () => {
+    await assertLint(
+      positioned`
+        <emu-alg>
+          1. Let _x_ be 0.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Set ${M}_x_ to 1.
+            1. Return _x_.
+          1. Return _closure_.
+        </emu-alg>
+      `,
+      {
+        ruleId: 'set-captured-variable',
+        nodeType: 'emu-alg',
+        message: '"x" cannot be reassigned after being captured by a closure',
+      },
+    );
+  });
+
+  it('set between two closures that capture is an error', async () => {
+    await assertLint(
+      positioned`
+        <emu-alg>
+          1. Let _x_ be 0.
+          1. Let _b_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Return _x_.
+          1. Set ${M}_x_ to 1.
+          1. Let _c_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Return _x_.
+          1. Do something with _b_ and _c_.
+        </emu-alg>
+      `,
+      {
+        ruleId: 'set-captured-variable',
+        nodeType: 'emu-alg',
+        message: '"x" cannot be reassigned after being captured by a closure',
+      },
+    );
+  });
+
+  it('capturing "constant" variables is not an error', async () => {
+    await assertLintFree(
+      `
+        <emu-alg>
+          1. Let _x_ be 0.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Return _x_.
+          1. Return _closure_.
+        </emu-alg>
+      `,
+    );
+  });
+
+  it('capturing variables whose values is mutated is not an error', async () => {
+    await assertLintFree(
+      `
+        <emu-alg>
+          1. Let _x_ be a new Record.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Return _x_.
+          1. Set _x_.[[Value]] to 1.
+          1. Return _closure_.
+        </emu-alg>
+      `,
+    );
+  });
+
+  it('reassignment of non-captured variable is fine', async () => {
+    await assertLintFree(
+      `
+        <emu-alg>
+          1. Let _x_ be 0.
+          1. Let _y_ be 1.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _x_ and performs the following steps when called:
+            1. Return _x_.
+          1. Set _y_ to 2.
+          1. Return _closure_.
+        </emu-alg>
+      `,
+    );
+  });
+});


### PR DESCRIPTION
This implements linting for these two new editorial conventions:

> - captured aliases in ACs should not be written to, even if the write is only observed within the AC
> - aliases that are captured by an AC should not be written to outside the AC after their capture

Note that with these conventions we don't catch all cases, e.g.
```
1. Let _curr_ be ~empty~.
2. For _item_ of _list_, do
   a. Set _curr_ to _item_.
   b. Let _ac_ be a new Abstract Closure that captures _curr_ ...
   c. Do something with _curr_.
```

If we want to catch all cases I have a separate patch that implements a more strict set of checks:
> - captured aliases in ACs should not be written to, even if the write is only observed within the AC
> - aliases that are captured by an AC should not be written to outside the AC ~~after their capture~~

the patch is at https://github.com/nicolo-ribaudo/ecmarkup/commit/9d3664d6c51e309ed8a95c3954b81a37b34e50b5, but it would require some tweaks to the spec because we capture reassigned variables 5 times (https://github.com/nicolo-ribaudo/ecma262/commit/d08010afe63bff6f575719d35b5168d13171b5f9).