### PR TITLE
fix issues with minify feature

### DIFF
--- a/src/minify.ts
+++ b/src/minify.ts
@@ -1,6 +1,6 @@
 import { minify as htmlMinify } from 'html-minifier-terser';
 import * as CleanCSS from 'clean-css';
-import { optimize as svgoOptimize, type Config as SvgoConfig, type PluginConfig } from 'svgo';
+import { optimize as svgoOptimize, type Config as SvgoConfig } from 'svgo';
 import { minify as terserMinify } from 'terser';
 import * as path from 'path';
 
@@ -30,10 +30,7 @@ const cleanCss = new CleanCSS({ level: 2 });
 
 const svgoConfig: SvgoConfig = {
   multipass: true,
-  plugins: [
-    { name: 'preset-default' },
-    'removeViewBox',
-  ],
+  plugins: [{ name: 'preset-default' }, 'removeViewBox'],
 };
 
 export async function minifyGeneratedFiles(


### PR DESCRIPTION
SVGO was complaining on stdout about the plugin list format, and html-minifier-terser was collapsing too much whitespace in some places. This fixes those issues.