### PR TITLE
Make a sticky preference for single-page vs. multi-page views

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,6 +61,7 @@
         "multipageMap": "readonly",
         "isMultipage": "readonly",
         "idToSection": "readonly",
+        "toggleMultipage": "readonly",
         "sdoMap": "readonly",
         "biblio": "readonly",
         "debounce": "writable",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,7 +59,7 @@
       },
       "globals": {
         "multipageMap": "readonly",
-        "usesMultipage": "readonly",
+        "isMultipage": "readonly",
         "idToSection": "readonly",
         "sdoMap": "readonly",
         "biblio": "readonly",

--- a/css/elements.css
+++ b/css/elements.css
@@ -1675,3 +1675,10 @@ li.menu-search-result-term::before {
   background: var(--figure-background);
   width: 500px;
 }
+
+/* Other dynamic elements */
+:root[data-multipage-preference=''] [data-multipage-preference=''],
+:root[data-multipage-preference='single-page'] [data-multipage-preference='single-page'],
+:root[data-multipage-preference='multi-page'] [data-multipage-preference='multi-page'] {
+  font-weight: bold;
+}

--- a/css/elements.css
+++ b/css/elements.css
@@ -1677,8 +1677,8 @@ li.menu-search-result-term::before {
 }
 
 /* Other dynamic elements */
-:root[data-multipage-preference=''] [data-multipage-preference=''],
-:root[data-multipage-preference='single-page'] [data-multipage-preference='single-page'],
-:root[data-multipage-preference='multi-page'] [data-multipage-preference='multi-page'] {
+:root[data-multipage-preference=''] [data-set-multipage-preference=''],
+:root[data-multipage-preference='single-page'] [data-set-multipage-preference='single-page'],
+:root[data-multipage-preference='multi-page'] [data-set-multipage-preference='multi-page'] {
   font-weight: bold;
 }

--- a/css/print.css
+++ b/css/print.css
@@ -1,3 +1,7 @@
+.no-print {
+  display: none !important;
+}
+
 @font-face {
   font-family: 'Arial Plus';
   src: local('Arial');

--- a/js/menu.js
+++ b/js/menu.js
@@ -1169,9 +1169,8 @@ function doShortcut(e) {
   if (e.altKey || e.ctrlKey || e.metaKey) {
     return;
   }
-  if (e.key === 'm') {
-    // handled by multipage.js `maybeToggleMultipage`
-    return;
+  if (e.key === 'm' && typeof toggleMultipage !== 'undefined') {
+    toggleMultipage();
   } else if (e.key === 'u') {
     document.documentElement.classList.toggle('show-uc-annotations');
   } else if (e.key === 'e') {

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,4 +1,18 @@
 'use strict';
+
+// Duplicates multipage.js for fault tolerance.
+function parseSpecPath(url) {
+  let pathParts = url.pathname.split('/');
+  let partCount = pathParts.length;
+  let isMultipage = pathParts[partCount - 2] === 'multipage';
+  let section = isMultipage ? pathParts[partCount - 1].replace(/\.html$/, '') : undefined;
+  let pathPrefixEnd = isMultipage ? -2 : pathParts.findLastIndex(part => part !== '') + 1;
+  let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/') + '/';
+  return { pathParts, pathPrefix, isMultipage, section };
+}
+
+let { pathPrefix, isMultipage } = parseSpecPath(location);
+
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -538,26 +552,12 @@ Menu.prototype.pinListClick = function (event) {
 };
 
 // All per-document pins live in one storage entry, as an object of
-// { [documentKey]: { pins: string[], lastUsed: <ms epoch> } } (see #702).
+// { [pathPrefix]: { pins: string[], lastUsed: <ms epoch> } } (see #702).
 const PIN_STORAGE_KEY = 'pinEntries';
 // Forget a document's pins if it hasn't been visited in this long, so that the
 // unique-per-PR paths used by preview deployments don't grow localStorage without
 // bound.
 const PIN_TTL_MS = 180 * 24 * 60 * 60 * 1000; // 180 days
-
-// Return the key associated with the current document in the object persisted at
-// PIN_STORAGE_KEY (used to prevent pins in one spec/preview from clobbering those in
-// other documents served from the same origin).
-Menu.prototype.getDocumentKey = function () {
-  // Directory of the current document (drop any filename such as index.html / foo.html).
-  let dir = location.pathname.replace(/[^/]*$/, '');
-  // Multipage pages live at <root>/multipage/<page>.html; fold them onto the
-  // document root so every page of one spec shares a single set of pins.
-  if (isMultipage && dir.endsWith('/multipage/')) {
-    dir = dir.slice(0, -'multipage/'.length);
-  }
-  return dir;
-};
 
 // Parse the raw stored value into a store of { path: { pins, lastUsed } },
 // migrating the legacy global `pinEntries` array if present.
@@ -580,7 +580,7 @@ Menu.prototype.parsePinEntries = function (raw) {
     for (let spec of ['ecma262', 'ecma402', 'ecma404', 'ecma426']) {
       migrated['/' + spec + '/'] = { pins: parsed, lastUsed };
     }
-    migrated[this.getDocumentKey()] = { pins: parsed, lastUsed };
+    migrated[pathPrefix] = { pins: parsed, lastUsed };
     return migrated;
   }
   return parsed && typeof parsed === 'object' ? parsed : {};
@@ -589,10 +589,10 @@ Menu.prototype.parsePinEntries = function (raw) {
 // Drop documents not visited within PIN_TTL_MS. Mutates and returns `store`.
 Menu.prototype.prunePinStore = function (store) {
   let now = Date.now();
-  for (let path of Object.keys(store)) {
-    let entry = store[path];
+  for (let pathPrefix of Object.keys(store)) {
+    let entry = store[pathPrefix];
     if (!entry || typeof entry.lastUsed !== 'number' || now - entry.lastUsed > PIN_TTL_MS) {
-      delete store[path];
+      delete store[pathPrefix];
     }
   }
   return store;
@@ -609,7 +609,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   let store = this.prunePinStore(this.parsePinEntries(raw));
-  let key = this.getDocumentKey();
+  let key = pathPrefix;
   let ids = Object.keys(this._pinnedIds);
   if (ids.length === 0) {
     // Don't leave an empty entry lingering once the last pin is removed.
@@ -635,7 +635,7 @@ Menu.prototype.loadPinEntries = function () {
   }
 
   let store = this.parsePinEntries(raw);
-  let entry = store[this.getDocumentKey()] || { pins: [] };
+  let entry = store[pathPrefix] || { pins: [] };
   // Update in-memory state (including dropping missing ids) and the DOM.
   for (let i = 0; i < entry.pins.length; i++) {
     this.addPinEntry(entry.pins[i]);
@@ -1150,7 +1150,7 @@ function sortByClauseNumber(clause1, clause2) {
 
 function makeLinkToId(id) {
   let path = '';
-  if (typeof isMultipage !== 'undefined' && isMultipage) {
+  if (isMultipage) {
     let targetSec = typeof idToSection !== 'undefined' && idToSection[id];
     path = targetSec === 'index' ? './' : targetSec ? targetSec + '.html' : '';
   }

--- a/js/menu.js
+++ b/js/menu.js
@@ -1149,12 +1149,12 @@ function sortByClauseNumber(clause1, clause2) {
 }
 
 function makeLinkToId(id) {
-  let hash = '#' + id;
-  if (typeof isMultipage !== 'undefined' && isMultipage && idToSection[id]) {
-    let targetSec = idToSection[id];
-    return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+  let path = '';
+  if (typeof isMultipage !== 'undefined' && isMultipage) {
+    let targetSec = typeof idToSection !== 'undefined' && idToSection[id];
+    path = targetSec === 'index' ? './' : targetSec ? targetSec + '.html' : '';
   }
-  return hash;
+  return path + '#' + id;
 }
 
 function doShortcut(e) {

--- a/js/menu.js
+++ b/js/menu.js
@@ -553,7 +553,7 @@ Menu.prototype.getDocumentKey = function () {
   let dir = location.pathname.replace(/[^/]*$/, '');
   // Multipage pages live at <root>/multipage/<page>.html; fold them onto the
   // document root so every page of one spec shares a single set of pins.
-  if (usesMultipage && dir.endsWith('/multipage/')) {
+  if (isMultipage && dir.endsWith('/multipage/')) {
     dir = dir.slice(0, -'multipage/'.length);
   }
   return dir;
@@ -1150,11 +1150,11 @@ function sortByClauseNumber(clause1, clause2) {
 
 function makeLinkToId(id) {
   let hash = '#' + id;
-  if (typeof idToSection === 'undefined' || !idToSection[id]) {
-    return hash;
+  if (typeof isMultipage !== 'undefined' && isMultipage && idToSection[id]) {
+    let targetSec = idToSection[id];
+    return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
   }
-  let targetSec = idToSection[id];
-  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+  return hash;
 }
 
 function doShortcut(e) {
@@ -1169,23 +1169,9 @@ function doShortcut(e) {
   if (e.altKey || e.ctrlKey || e.metaKey) {
     return;
   }
-  if (e.key === 'm' && usesMultipage) {
-    let pathParts = location.pathname.split('/');
-    let hash = location.hash;
-    if (pathParts[pathParts.length - 2] === 'multipage') {
-      if (hash === '') {
-        let sectionName = pathParts[pathParts.length - 1];
-        if (sectionName.endsWith('.html')) {
-          sectionName = sectionName.slice(0, -5);
-        }
-        if (idToSection['sec-' + sectionName] !== undefined) {
-          hash = '#sec-' + sectionName;
-        }
-      }
-      location = pathParts.slice(0, -2).join('/') + '/' + hash;
-    } else {
-      location = 'multipage/' + hash;
-    }
+  if (e.key === 'm') {
+    // handled by multipage.js `maybeToggleMultipage`
+    return;
   } else if (e.key === 'u') {
     document.documentElement.classList.toggle('show-uc-annotations');
   } else if (e.key === 'e') {

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -53,3 +53,27 @@ let maybeToggleMultipage = e => {
   }
 };
 document.addEventListener('keypress', maybeToggleMultipage);
+
+let maybeSetMultipagePreference = e => {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let toggler = target.closest('[data-prefer-multipage]');
+  if (!toggler || target.isContentEditable) {
+    return;
+  }
+  switch (target.nodeName.toLowerCase()) {
+    case 'textarea':
+    case 'select':
+      return;
+    case 'input': {
+      let isCheckable = target.type === 'checkbox' || target.type === 'radio';
+      if (toggler !== target || !isCheckable || !target.checked) {
+        return;
+      }
+    }
+  }
+  storage.preferMultipage = toggler.dataset.preferMultipage;
+};
+document.addEventListener('click', maybeSetMultipagePreference);

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -7,13 +7,49 @@ for (let [section, ids] of Object.entries(multipageMap)) {
     }
   }
 }
-if (location.hash) {
-  let targetSec = idToSection[location.hash.substring(1)];
-  if (targetSec != null) {
-    let match = location.pathname.match(/([^/]+)\.html?$/);
-    if ((match != null && match[1] !== targetSec) || location.pathname.endsWith('/multipage/')) {
-      window.navigating = true;
-      location = (targetSec === 'index' ? './' : targetSec + '.html') + location.hash;
-    }
+let pathParts = location.pathname.split('/');
+let isMultipage = pathParts[pathParts.length - 2] === 'multipage';
+let activeSec = isMultipage ? pathParts[pathParts.length - 1].replace(/\.html$/, '') : undefined;
+let activeSecHash =
+  activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
+let storage = typeof localStorage !== 'undefined' ? localStorage : Object.create(null);
+
+{
+  let resolvedHash = location.hash || activeSecHash || '';
+  let targetSec = resolvedHash ? idToSection[resolvedHash.substring(1)] : undefined;
+  let preferMultipage = storage.preferMultipage;
+  if (isMultipage && preferMultipage === 'false') {
+    window.navigating = true;
+    location = pathParts.slice(0, -2).join('/') + '/' + resolvedHash;
+  } else if (
+    isMultipage
+      ? targetSec != null && (activeSec || 'index') !== targetSec
+      : preferMultipage === 'true'
+  ) {
+    window.navigating = true;
+    location = 'multipage/' + targetSec + '.html' + location.hash;
   }
 }
+let maybeToggleMultipage = e => {
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+  let target = e.target;
+  let name = target.nodeName.toLowerCase();
+  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
+    return;
+  }
+  if (e.altKey || e.ctrlKey || e.metaKey || e.key !== 'm') {
+    return;
+  }
+  let hash = location.hash;
+  if (isMultipage) {
+    storage.preferMultipage = 'false';
+    location = pathParts.slice(0, -2).join('/') + '/' + (hash || activeSecHash || '');
+  } else {
+    storage.preferMultipage = 'true';
+    let targetSec = hash ? idToSection[hash.substring(1)] : undefined;
+    location = 'multipage/' + (targetSec ? targetSec + '.html' : '') + hash;
+  }
+};
+document.addEventListener('keypress', maybeToggleMultipage);

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -100,6 +100,13 @@ function toggleMultipage() {
 
 // redirect to single-page/multi-page per preference
 (() => {
+  let { pathPrefix, isMultipage, section: activeSec } = parseSpecPath(location);
+  let activeSecHash =
+    activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
+  let hash = location.hash;
+  let resolvedHash = hash || activeSecHash || '';
+  let targetSec = resolvedHash ? idToSection[resolvedHash.substring(1)] : undefined;
+
   // ...except from internal links
   let referrer;
   try {
@@ -110,13 +117,6 @@ function toggleMultipage() {
   if (referrer && referrer.host === location.host) {
     if (parseSpecPath(referrer).pathPrefix === pathPrefix) return;
   }
-
-  let { pathPrefix, isMultipage, section: activeSec } = parseSpecPath(location);
-  let activeSecHash =
-    activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
-  let hash = location.hash;
-  let resolvedHash = hash || activeSecHash || '';
-  let targetSec = resolvedHash ? idToSection[resolvedHash.substring(1)] : undefined;
 
   let storage = window.localStorage || Object.create(null);
   let multipagePreference = getMultipagePreference(storage);

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -1,4 +1,6 @@
 'use strict';
+
+// initialize globals
 let idToSection = Object.create(null);
 for (let [section, ids] of Object.entries(multipageMap)) {
   for (let id of ids) {
@@ -13,67 +15,94 @@ let activeSec = isMultipage ? pathParts[pathParts.length - 1].replace(/\.html$/,
 let activeSecHash =
   activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
 let storage = typeof localStorage !== 'undefined' ? localStorage : Object.create(null);
+let toggleMultipage = () => {
+  let hash = location.hash;
+  if (isMultipage) {
+    location = pathParts.slice(0, -2).join('/') + '/' + (hash || activeSecHash || '');
+  } else {
+    let targetSec = hash ? idToSection[hash.substring(1)] : undefined;
+    location = 'multipage/' + (targetSec ? targetSec + '.html' : '') + hash;
+  }
+};
 
-{
+// redirect to single-page/multi-page per preference, except from internal links
+(() => {
+  let referrer;
+  try {
+    referrer = new URL(document.referrer);
+  } catch (_err) {
+    // ignore
+  }
+  if (referrer) {
+    let referrerPathParts = referrer.pathname.split('/');
+    let referrerPathPrefixEnd =
+      referrerPathParts[referrerPathParts.length - 2] === 'multipage'
+        ? -2
+        : referrerPathParts.findLastIndex(part => part !== '') + 1;
+    let referrerPathPrefix = referrerPathParts.slice(0, referrerPathPrefixEnd).join('/');
+    let pathPrefixEnd = isMultipage ? -2 : pathParts.findLastIndex(part => part !== '') + 1;
+    let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/');
+    if (referrer.host === location.host && referrerPathPrefix === pathPrefix) {
+      return;
+    }
+  }
   let resolvedHash = location.hash || activeSecHash || '';
   let targetSec = resolvedHash ? idToSection[resolvedHash.substring(1)] : undefined;
-  let preferMultipage = storage.preferMultipage;
-  if (isMultipage && preferMultipage === 'false') {
+  let multipagePreference = storage.multipagePreference;
+  if (isMultipage && multipagePreference === 'single-page') {
     window.navigating = true;
     location = pathParts.slice(0, -2).join('/') + '/' + resolvedHash;
   } else if (
     isMultipage
       ? targetSec != null && (activeSec || 'index') !== targetSec
-      : preferMultipage === 'true'
+      : multipagePreference === 'multi-page'
   ) {
     window.navigating = true;
-    location = 'multipage/' + targetSec + '.html' + location.hash;
+    location = 'multipage/' + (targetSec ? targetSec + '.html' : '') + location.hash;
   }
-}
-let maybeToggleMultipage = e => {
-  if (!(e.target instanceof HTMLElement)) {
-    return;
-  }
-  let target = e.target;
-  let name = target.nodeName.toLowerCase();
-  if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
-    return;
-  }
-  if (e.altKey || e.ctrlKey || e.metaKey || e.key !== 'm') {
-    return;
-  }
-  let hash = location.hash;
-  if (isMultipage) {
-    storage.preferMultipage = 'false';
-    location = pathParts.slice(0, -2).join('/') + '/' + (hash || activeSecHash || '');
-  } else {
-    storage.preferMultipage = 'true';
-    let targetSec = hash ? idToSection[hash.substring(1)] : undefined;
-    location = 'multipage/' + (targetSec ? targetSec + '.html' : '') + hash;
-  }
-};
-document.addEventListener('keypress', maybeToggleMultipage);
+})();
 
-let maybeSetMultipagePreference = e => {
-  if (!(e.target instanceof HTMLElement)) {
-    return;
+// enable preference togglers
+document.documentElement.dataset.multipagePreference = storage.multipagePreference || '';
+if (typeof localStorage !== 'undefined') {
+  let enableToggles = () => {
+    for (let el of document.querySelectorAll('[disabled][data-multipage-preference]')) {
+      el.disabled = false;
+    }
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', enableToggles);
+  } else {
+    enableToggles();
   }
-  let target = e.target;
-  let toggler = target.closest('[data-prefer-multipage]');
-  if (!toggler || target.isContentEditable) {
-    return;
-  }
-  switch (target.nodeName.toLowerCase()) {
-    case 'textarea':
-    case 'select':
+  document.addEventListener('click', e => {
+    if (!(e.target instanceof HTMLElement)) {
       return;
-    case 'input': {
-      let isCheckable = target.type === 'checkbox' || target.type === 'radio';
-      if (toggler !== target || !isCheckable || !target.checked) {
+    }
+    let target = e.target;
+    let toggler = target.closest('[data-multipage-preference]');
+    if (target.isContentEditable || !toggler || toggler === document.documentElement) {
+      return;
+    }
+    switch (target.nodeName.toLowerCase()) {
+      case 'textarea':
+      case 'select':
         return;
+      case 'input': {
+        let isCheckable = target.type === 'checkbox' || target.type === 'radio';
+        if (toggler !== target || !isCheckable || !target.checked) {
+          return;
+        }
       }
     }
-  }
-  storage.preferMultipage = toggler.dataset.preferMultipage;
-};
-document.addEventListener('click', maybeSetMultipagePreference);
+    let multipagePreference = toggler.dataset.multipagePreference;
+    if (multipagePreference !== (storage.multipagePreference || '')) {
+      storage.multipagePreference = multipagePreference;
+      document.documentElement.dataset.multipagePreference = multipagePreference;
+      if (multipagePreference === (isMultipage ? 'single-page' : 'multi-page')) {
+        toggleMultipage();
+      }
+    }
+    e.preventDefault();
+  });
+}

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -20,6 +20,70 @@ for (let [section, ids] of Object.entries(multipageMap)) {
   }
 }
 
+// Multipage preferences apply separately to each document, but are stored in a
+// single { [pathPrefix]: { preference: boolean, lastUsed: <ms epoch> } } object.
+const MULTIPAGE_PREFERENCE_STORAGE_KEY = 'multipagePreference';
+// Forget a document's preference if it hasn't been visited in this long, so that
+// the unique-per-PR paths used by preview deployments don't grow localStorage
+// without bound.
+const MULTIPAGE_PREFERENCE_TTL_MS = 180 * 24 * 60 * 60 * 1000; // 180 days
+
+function parseMultipagePreferences(storage) {
+  try {
+    let raw = storage[MULTIPAGE_PREFERENCE_STORAGE_KEY];
+    let preferencesByPathPrefix = JSON.parse(raw);
+    let now = Date.now();
+    for (let pathPrefix of Object.keys(preferencesByPathPrefix)) {
+      let entry = preferencesByPathPrefix[pathPrefix];
+      if (
+        !entry ||
+        typeof entry.lastUsed !== 'number' ||
+        now - entry.lastUsed > MULTIPAGE_PREFERENCE_TTL_MS
+      ) {
+        delete preferencesByPathPrefix[pathPrefix];
+      }
+    }
+    return preferencesByPathPrefix;
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function getMultipagePreference(storage) {
+  let preferencesByPathPrefix = parseMultipagePreferences(storage) || {};
+
+  // For PR previews, default to parent prefixes.
+  let { pathPrefix } = parseSpecPath(location);
+  while (pathPrefix) {
+    let entry = preferencesByPathPrefix[pathPrefix];
+    if (entry) {
+      entry.lastUsed = Date.now();
+      return entry.preference;
+    }
+    pathPrefix = pathPrefix.replace(/[^/]*\/$/, '');
+  }
+
+  return '';
+}
+
+function setMultipagePreference(storage, preference) {
+  let preferencesByPathPrefix = parseMultipagePreferences(storage) || {};
+  let oldPreference = getMultipagePreference(storage);
+
+  let { pathPrefix, isMultipage } = parseSpecPath(location);
+  preferencesByPathPrefix[pathPrefix] = { preference, lastUsed: Date.now() };
+  try {
+    storage[MULTIPAGE_PREFERENCE_STORAGE_KEY] = JSON.stringify(preferencesByPathPrefix);
+  } catch (e) {
+    // storage may be full or unavailable.
+  }
+
+  if (preference === oldPreference) return;
+  if (preference === (isMultipage ? 'single-page' : 'multi-page')) {
+    toggleMultipage();
+  }
+}
+
 function toggleMultipage() {
   let { pathPrefix, isMultipage, section: activeSec } = parseSpecPath(location);
   let activeSecHash =
@@ -55,7 +119,7 @@ function toggleMultipage() {
   let targetSec = resolvedHash ? idToSection[resolvedHash.substring(1)] : undefined;
 
   let storage = window.localStorage || Object.create(null);
-  let multipagePreference = storage.multipagePreference;
+  let multipagePreference = getMultipagePreference(storage);
   if (isMultipage && multipagePreference === 'single-page') {
     window.navigating = true;
     location = pathPrefix + resolvedHash;
@@ -102,14 +166,8 @@ if (window.localStorage) {
         }
       }
     }
-    let multipagePreference = toggler.dataset.multipagePreference;
-    if (multipagePreference !== (storage.multipagePreference || '')) {
-      storage.multipagePreference = multipagePreference;
-      document.documentElement.dataset.multipagePreference = multipagePreference;
-      if (multipagePreference === (isMultipage ? 'single-page' : 'multi-page')) {
-        toggleMultipage();
-      }
-    }
+    let newMultipagePreference = toggler.dataset.multipagePreference;
+    setMultipagePreference(storage, newMultipagePreference);
     e.preventDefault();
   });
 }

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -2,10 +2,12 @@
 
 function parseSpecPath(url) {
   let pathParts = url.pathname.split('/');
-  let isMultipage = pathParts[pathParts.length - 2] === 'multipage';
+  let partCount = pathParts.length;
+  let isMultipage = pathParts[partCount - 2] === 'multipage';
+  let section = isMultipage ? pathParts[partCount - 1].replace(/\.html$/, '') : undefined;
   let pathPrefixEnd = isMultipage ? -2 : pathParts.findLastIndex(part => part !== '') + 1;
   let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/');
-  return { pathParts, pathPrefix, isMultipage };
+  return { pathParts, pathPrefix, isMultipage, section };
 };
 
 // initialize globals
@@ -17,15 +19,14 @@ for (let [section, ids] of Object.entries(multipageMap)) {
     }
   }
 }
-let { pathParts, pathPrefix, isMultipage } = parseSpecPath(location);
-let activeSec = isMultipage ? pathParts[pathParts.length - 1].replace(/\.html$/, '') : undefined;
+let { pathPrefix, isMultipage, section: activeSec } = parseSpecPath(location);
 let activeSecHash =
   activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
-let storage = typeof localStorage !== 'undefined' ? localStorage : Object.create(null);
+let storage = window.localStorage || Object.create(null);
 let toggleMultipage = () => {
   let hash = location.hash;
   if (isMultipage) {
-    location = pathParts.slice(0, -2).join('/') + '/' + (hash || activeSecHash || '');
+    location = pathPrefix + '/' + (hash || activeSecHash || '');
   } else {
     let targetSec = hash ? idToSection[hash.substring(1)] : undefined;
     location = 'multipage/' + (targetSec ? targetSec + '.html' : '') + hash;
@@ -50,7 +51,7 @@ let toggleMultipage = () => {
   let multipagePreference = storage.multipagePreference;
   if (isMultipage && multipagePreference === 'single-page') {
     window.navigating = true;
-    location = pathParts.slice(0, -2).join('/') + '/' + resolvedHash;
+    location = pathPrefix + '/' + resolvedHash;
   } else if (
     isMultipage
       ? targetSec != null && (activeSec || 'index') !== targetSec
@@ -63,7 +64,7 @@ let toggleMultipage = () => {
 
 // enable preference togglers
 document.documentElement.dataset.multipagePreference = storage.multipagePreference || '';
-if (typeof localStorage !== 'undefined') {
+if (window.localStorage) {
   let enableToggles = () => {
     for (let el of document.querySelectorAll('[disabled][data-multipage-preference]')) {
       el.disabled = false;

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -27,6 +27,10 @@ const MULTIPAGE_PREFERENCE_STORAGE_KEY = 'multipagePreference';
 // the unique-per-PR paths used by preview deployments don't grow localStorage
 // without bound.
 const MULTIPAGE_PREFERENCE_TTL_MS = 180 * 24 * 60 * 60 * 1000; // 180 days
+// For styling, the document element exposes the current preference and buttons
+// for updating it expose their associated value (cf. css/elements.css).
+const MULTIPAGE_PREFERENCE_ATTR = 'data-multipage-preference';
+const SET_MULTIPAGE_PREFERENCE_ATTR = 'data-set-multipage-preference';
 
 function parseMultipagePreferences(storage) {
   try {
@@ -134,17 +138,37 @@ function toggleMultipage() {
 })();
 
 // enable preference togglers
-document.documentElement.dataset.multipagePreference = getMultipagePreference(window.localStorage);
+document.documentElement.setAttribute(
+  MULTIPAGE_PREFERENCE_ATTR,
+  getMultipagePreference(window.localStorage),
+);
 if (window.localStorage) {
   let storage = window.localStorage;
-  document.addEventListener('click', e => {
-    let target = e.target;
-    if (!target.matches?.('#shortcuts-help button[data-multipage-preference]')) {
-      return;
-    }
-    let preference = target.dataset.multipagePreference;
-    document.documentElement.dataset.multipagePreference = preference;
-    setMultipagePreference(storage, preference);
-    e.preventDefault();
-  });
+  let enableToggles = container => {
+    container.addEventListener('click', e => {
+      let target = e.target.closest?.(`[${SET_MULTIPAGE_PREFERENCE_ATTR}]`);
+      let preference = target?.getAttribute(SET_MULTIPAGE_PREFERENCE_ATTR);
+      if (typeof preference !== 'string') {
+        return;
+      }
+      document.documentElement.setAttribute(MULTIPAGE_PREFERENCE_ATTR, preference);
+      setMultipagePreference(storage, preference);
+    });
+    // Work around a bug where contents are sometimes empty.
+    setTimeout(() => {
+      for (let el of container.querySelectorAll(`[${SET_MULTIPAGE_PREFERENCE_ATTR}]`)) {
+        el.disabled = false;
+      }
+    }, 0);
+  };
+
+  let shortcuts = document.getElementById('shortcuts-help');
+  if (shortcuts) {
+    enableToggles(shortcuts);
+  } else {
+    document.addEventListener('DOMContentLoaded', () => {
+      shortcuts = document.getElementById('shortcuts-help');
+      if (shortcuts) enableToggles(shortcuts);
+    });
+  }
 }

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -1,16 +1,16 @@
 'use strict';
 
+// Duplicates menu.js for fault tolerance.
 function parseSpecPath(url) {
   let pathParts = url.pathname.split('/');
   let partCount = pathParts.length;
   let isMultipage = pathParts[partCount - 2] === 'multipage';
   let section = isMultipage ? pathParts[partCount - 1].replace(/\.html$/, '') : undefined;
   let pathPrefixEnd = isMultipage ? -2 : pathParts.findLastIndex(part => part !== '') + 1;
-  let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/');
+  let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/') + '/';
   return { pathParts, pathPrefix, isMultipage, section };
-};
+}
 
-// initialize globals
 let idToSection = Object.create(null);
 for (let [section, ids] of Object.entries(multipageMap)) {
   for (let id of ids) {
@@ -19,19 +19,20 @@ for (let [section, ids] of Object.entries(multipageMap)) {
     }
   }
 }
-let { pathPrefix, isMultipage, section: activeSec } = parseSpecPath(location);
-let activeSecHash =
-  activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
-let storage = window.localStorage || Object.create(null);
-let toggleMultipage = () => {
+
+function toggleMultipage() {
+  let { pathPrefix, isMultipage, section: activeSec } = parseSpecPath(location);
+  let activeSecHash =
+    activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
   let hash = location.hash;
+
   if (isMultipage) {
-    location = pathPrefix + '/' + (hash || activeSecHash || '');
+    location = pathPrefix + (hash || activeSecHash || '');
   } else {
     let targetSec = hash ? idToSection[hash.substring(1)] : undefined;
     location = 'multipage/' + (targetSec ? targetSec + '.html' : '') + hash;
   }
-};
+}
 
 // redirect to single-page/multi-page per preference
 (() => {
@@ -46,12 +47,18 @@ let toggleMultipage = () => {
     if (parseSpecPath(referrer).pathPrefix === pathPrefix) return;
   }
 
-  let resolvedHash = location.hash || activeSecHash || '';
+  let { pathPrefix, isMultipage, section: activeSec } = parseSpecPath(location);
+  let activeSecHash =
+    activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
+  let hash = location.hash;
+  let resolvedHash = hash || activeSecHash || '';
   let targetSec = resolvedHash ? idToSection[resolvedHash.substring(1)] : undefined;
+
+  let storage = window.localStorage || Object.create(null);
   let multipagePreference = storage.multipagePreference;
   if (isMultipage && multipagePreference === 'single-page') {
     window.navigating = true;
-    location = pathPrefix + '/' + resolvedHash;
+    location = pathPrefix + resolvedHash;
   } else if (
     isMultipage
       ? targetSec != null && (activeSec || 'index') !== targetSec
@@ -63,8 +70,8 @@ let toggleMultipage = () => {
 })();
 
 // enable preference togglers
-document.documentElement.dataset.multipagePreference = storage.multipagePreference || '';
 if (window.localStorage) {
+  let storage = window.localStorage;
   let enableToggles = () => {
     for (let el of document.querySelectorAll('[disabled][data-multipage-preference]')) {
       el.disabled = false;

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -1,5 +1,13 @@
 'use strict';
 
+function parseSpecPath(url) {
+  let pathParts = url.pathname.split('/');
+  let isMultipage = pathParts[pathParts.length - 2] === 'multipage';
+  let pathPrefixEnd = isMultipage ? -2 : pathParts.findLastIndex(part => part !== '') + 1;
+  let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/');
+  return { pathParts, pathPrefix, isMultipage };
+};
+
 // initialize globals
 let idToSection = Object.create(null);
 for (let [section, ids] of Object.entries(multipageMap)) {
@@ -9,8 +17,7 @@ for (let [section, ids] of Object.entries(multipageMap)) {
     }
   }
 }
-let pathParts = location.pathname.split('/');
-let isMultipage = pathParts[pathParts.length - 2] === 'multipage';
+let { pathParts, pathPrefix, isMultipage } = parseSpecPath(location);
 let activeSec = isMultipage ? pathParts[pathParts.length - 1].replace(/\.html$/, '') : undefined;
 let activeSecHash =
   activeSec && idToSection['sec-' + activeSec] != null ? '#sec-' + activeSec : undefined;
@@ -25,27 +32,19 @@ let toggleMultipage = () => {
   }
 };
 
-// redirect to single-page/multi-page per preference, except from internal links
+// redirect to single-page/multi-page per preference
 (() => {
+  // ...except from internal links
   let referrer;
   try {
     referrer = new URL(document.referrer);
   } catch (_err) {
     // ignore
   }
-  if (referrer) {
-    let referrerPathParts = referrer.pathname.split('/');
-    let referrerPathPrefixEnd =
-      referrerPathParts[referrerPathParts.length - 2] === 'multipage'
-        ? -2
-        : referrerPathParts.findLastIndex(part => part !== '') + 1;
-    let referrerPathPrefix = referrerPathParts.slice(0, referrerPathPrefixEnd).join('/');
-    let pathPrefixEnd = isMultipage ? -2 : pathParts.findLastIndex(part => part !== '') + 1;
-    let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/');
-    if (referrer.host === location.host && referrerPathPrefix === pathPrefix) {
-      return;
-    }
+  if (referrer && referrer.host === location.host) {
+    if (parseSpecPath(referrer).pathPrefix === pathPrefix) return;
   }
+
   let resolvedHash = location.hash || activeSecHash || '';
   let targetSec = resolvedHash ? idToSection[resolvedHash.substring(1)] : undefined;
   let multipagePreference = storage.multipagePreference;

--- a/js/multipage.js
+++ b/js/multipage.js
@@ -66,7 +66,7 @@ function getMultipagePreference(storage) {
   return '';
 }
 
-function setMultipagePreference(storage, preference) {
+function setMultipagePreference(storage, preference, skipNavigation) {
   let preferencesByPathPrefix = parseMultipagePreferences(storage) || {};
   let oldPreference = getMultipagePreference(storage);
 
@@ -78,7 +78,7 @@ function setMultipagePreference(storage, preference) {
     // storage may be full or unavailable.
   }
 
-  if (preference === oldPreference) return;
+  if (skipNavigation || preference === oldPreference) return;
   if (preference === (isMultipage ? 'single-page' : 'multi-page')) {
     toggleMultipage();
   }
@@ -134,40 +134,17 @@ function toggleMultipage() {
 })();
 
 // enable preference togglers
+document.documentElement.dataset.multipagePreference = getMultipagePreference(window.localStorage);
 if (window.localStorage) {
   let storage = window.localStorage;
-  let enableToggles = () => {
-    for (let el of document.querySelectorAll('[disabled][data-multipage-preference]')) {
-      el.disabled = false;
-    }
-  };
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', enableToggles);
-  } else {
-    enableToggles();
-  }
   document.addEventListener('click', e => {
-    if (!(e.target instanceof HTMLElement)) {
-      return;
-    }
     let target = e.target;
-    let toggler = target.closest('[data-multipage-preference]');
-    if (target.isContentEditable || !toggler || toggler === document.documentElement) {
+    if (!target.matches?.('#shortcuts-help button[data-multipage-preference]')) {
       return;
     }
-    switch (target.nodeName.toLowerCase()) {
-      case 'textarea':
-      case 'select':
-        return;
-      case 'input': {
-        let isCheckable = target.type === 'checkbox' || target.type === 'radio';
-        if (toggler !== target || !isCheckable || !target.checked) {
-          return;
-        }
-      }
-    }
-    let newMultipagePreference = toggler.dataset.multipagePreference;
-    setMultipagePreference(storage, newMultipagePreference);
+    let preference = target.dataset.multipagePreference;
+    document.documentElement.dataset.multipagePreference = preference;
+    setMultipagePreference(storage, preference);
     e.preventDefault();
   });
 }

--- a/spec/index.html
+++ b/spec/index.html
@@ -93,7 +93,7 @@ markEffects: true
 
 <emu-clause id="multipage">
   <h1>Multipage</h1>
-  <p>Multi-page builds support a sticky preference for accessing the resulting document as a single page or as multiple pages. It can be set by embedding elements (such as <code>&lt;a&gt;</code> or <code>&lt;button&gt;</code>) with attribute <code>data-multipage-preference</code> set to either an empty string (for the default lack of preference), "single-page", or "multi-page". When such an element is clicked, the corresponding preference is written into <code>localStorage</code> and a navigation is triggered if necessary. From that point forward, loading any page directly or from an external link will respect that preference and redirect as necessary.</p>
+  <p>Multi-page builds support a sticky preference for accessing the resulting document as a single page or as multiple pages, which is either an empty string (for the default lack of preference), “single-page”, or “multi-page”. It can be read from the <code>data-multipage-preference</code> attribute of the document element or by calling `getMultipagePreference(window.localStorage)`, and set by calling `setMultipagePreference(window.localStorage, preference)` (which also triggers a navigation as necessary unless provided with a truthy third argument). From that point forward, loading any page directly or from an external link will respect that preference and redirect as necessary.</p>
   <emu-note>Links <em>internal</em> to the document are not subject to such redirection, allowing free alternation between single-page and multi-page experiences.</emu-note>
 </emu-clause>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -91,6 +91,12 @@ markEffects: true
   <p>Ecmarkup requires CSS styles and other assets. By default all assets are inlined into the document. You can override this by setting assets to “none” (for example if you want to manually link to external assets) or “external”. When using “external” the default directory for assets is `assets` in the same directory as the output file, but you can override this with `--assets-dir`.</p>
 </emu-clause>
 
+<emu-clause id="multipage">
+  <h1>Multipage</h1>
+  <p>Multi-page builds support a sticky preference for accessing the resulting document as a single page or as multiple pages. It can be set by embedding elements (such as <code>&lt;a&gt;</code> or <code>&lt;button&gt;</code>) with attribute <code>data-multipage-preference</code> set to either an empty string (for the default lack of preference), "single-page", or "multi-page". When such an element is clicked, the corresponding preference is written into <code>localStorage</code> and a navigation is triggered if necessary. From that point forward, loading any page directly or from an external link will respect that preference and redirect as necessary.</p>
+  <emu-note>Links <em>internal</em> to the document are not subject to such redirection, allowing free alternation between single-page and multi-page experiences.</emu-note>
+</emu-clause>
+
 <emu-clause id="editorial-conventions">
   <h1>Editorial Conventions</h1>
   <p>There are a large number of features in Ecmarkup. Detailed documentation can be found in later sections. This section provides a high-level overview of what capabilities are available and when to use them.</p>

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1335,7 +1335,13 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>\`</code></li>
-</ul>`;
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" data-multipage-preference="">No preference</button>
+  <button type="button" data-multipage-preference="single-page">Always single-page</button>
+  <button type="button" data-multipage-preference="multi-page">Always multi-page</button>
+</fieldset>`;
     return shortcutsHelp;
   }
 

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -687,8 +687,7 @@ export default class Spec {
       this.doc.body.insertBefore(ele, this.doc.body.firstChild);
     }
 
-    const jsContents =
-      (await concatJs(sdoJs, tocJs)) + `\n;let usesMultipage = ${!!this.opts.multipage}`;
+    const jsContents = await concatJs(sdoJs, tocJs);
     const jsSha = sha(jsContents);
 
     await this.buildAssets(jsContents, jsSha);
@@ -1010,8 +1009,6 @@ export default class Spec {
       htmlEle = src.substring(0, src.length - '<head></head><body></body></html>'.length);
     }
 
-    const head = this.doc.head.cloneNode(true) as HTMLHeadElement;
-
     const containedMap = JSON.stringify(Object.fromEntries(sectionToContainedIds)).replace(
       /[\\`$]/g,
       '\\$&',
@@ -1035,9 +1032,12 @@ ${await utils.readFile(path.join(__dirname, '../js/multipage.js'))}
         path.relative(this.opts.outfile!, multipageLocationOnDisk) +
         '?cache=' +
         sha(multipageJsContents);
-      multipageScript.setAttribute('defer', '');
-      head.insertBefore(multipageScript, head.querySelector('script'));
+      // fetch in parallel, but evaluate ASAP in case of redirect
+      multipageScript.setAttribute('async', '');
+      this.doc.head.insertBefore(multipageScript, this.doc.head.querySelector('script'));
     }
+
+    const head = this.doc.head.cloneNode(true) as HTMLHeadElement;
 
     for (const { name, eles } of sections) {
       this.log(`Generating section ${name}...`);

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -1338,9 +1338,9 @@ ${this.opts.multipage ? `<li><span>Navigate to/from multipage</span><code>m</cod
 </ul>
 <fieldset>
   <legend>Multipage preference</legend>
-  <button type="button" data-multipage-preference="">No preference</button>
-  <button type="button" data-multipage-preference="single-page">Always single-page</button>
-  <button type="button" data-multipage-preference="multi-page">Always multi-page</button>
+  <button type="button" disabled data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled data-set-multipage-preference="multi-page">Always multi-page</button>
 </fieldset>`;
     return shortcutsHelp;
   }

--- a/test/baselines/generated-reference/abstract-methods.html
+++ b/test/baselines/generated-reference/abstract-methods.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-table type="abstract methods" of="Module Record" id="table-abstract-methods-of-module-records" caption="Abstract Methods of Module Record"><figure><figcaption>Table 1: Abstract Methods of <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.es/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref></figcaption>
   <table>
     <thead>

--- a/test/baselines/generated-reference/algorithm-replacements.html
+++ b/test/baselines/generated-reference/algorithm-replacements.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-clause id="test">
   <h1><span class="secnum">1</span> Title</h1>

--- a/test/baselines/generated-reference/algorithms.html
+++ b/test/baselines/generated-reference/algorithms.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-alg><ol><li>Can call <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> in this spec: <emu-xref aoid="Internal" id="_ref_0"><a href="#sec-internal">Internal</a></emu-xref>();</li><li>Can call <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> in ES6: <emu-xref aoid="ReturnIfAbrupt"><a href="https://tc39.es/ecma262/#sec-returnifabrupt">ReturnIfAbrupt</a></emu-xref>(<var>completion</var>);</li><li>Can call <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> in a biblio file: <emu-xref aoid="Biblio"><a href="http://example.com/fooSite.html#sec-biblio">Biblio</a></emu-xref>();</li><li>Unfound <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> just don't link: Unfound();</li><li>Can prefix with !&nbsp;and ?.<ol><li class="exit">Let <var>foo</var> be ?&nbsp;<emu-xref aoid="Internal" id="_ref_1"><a href="#sec-internal">Internal</a></emu-xref>();</li><li>Set <var>foo</var> to !&nbsp;<emu-xref aoid="Internal" id="_ref_2"><a href="#sec-internal">Internal</a></emu-xref>();</li><li>Set <var>foo</var> to !&nbsp;SDO of <var>operation</var>.</li><li>Set <var>foo</var> to !&nbsp;<var>operation</var>.<var class="field">[[MOP]]</var>().</li></ol></li><li>A <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> looks like this: <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { <var class="field">[[Key]]</var>: 0&nbsp;}.</li><li>A <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> looks like this: « 0, 1&nbsp;».</li></ol></emu-alg>
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -83,6 +83,20 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 'use strict';
+
+// Duplicates multipage.js for fault tolerance.
+function parseSpecPath(url) {
+  let pathParts = url.pathname.split('/');
+  let partCount = pathParts.length;
+  let isMultipage = pathParts[partCount - 2] === 'multipage';
+  let section = isMultipage ? pathParts[partCount - 1].replace(/\.html$/, '') : undefined;
+  let pathPrefixEnd = isMultipage ? -2 : pathParts.findLastIndex(part => part !== '') + 1;
+  let pathPrefix = pathParts.slice(0, pathPrefixEnd).join('/') + '/';
+  return { pathParts, pathPrefix, isMultipage, section };
+}
+
+let { pathPrefix, isMultipage } = parseSpecPath(location);
+
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
@@ -622,26 +636,12 @@ Menu.prototype.pinListClick = function (event) {
 };
 
 // All per-document pins live in one storage entry, as an object of
-// { [documentKey]: { pins: string[], lastUsed: <ms epoch> } } (see #702).
+// { [pathPrefix]: { pins: string[], lastUsed: <ms epoch> } } (see #702).
 const PIN_STORAGE_KEY = 'pinEntries';
 // Forget a document's pins if it hasn't been visited in this long, so that the
 // unique-per-PR paths used by preview deployments don't grow localStorage without
 // bound.
 const PIN_TTL_MS = 180 * 24 * 60 * 60 * 1000; // 180 days
-
-// Return the key associated with the current document in the object persisted at
-// PIN_STORAGE_KEY (used to prevent pins in one spec/preview from clobbering those in
-// other documents served from the same origin).
-Menu.prototype.getDocumentKey = function () {
-  // Directory of the current document (drop any filename such as index.html / foo.html).
-  let dir = location.pathname.replace(/[^/]*$/, '');
-  // Multipage pages live at <root>/multipage/<page>.html; fold them onto the
-  // document root so every page of one spec shares a single set of pins.
-  if (usesMultipage && dir.endsWith('/multipage/')) {
-    dir = dir.slice(0, -'multipage/'.length);
-  }
-  return dir;
-};
 
 // Parse the raw stored value into a store of { path: { pins, lastUsed } },
 // migrating the legacy global `pinEntries` array if present.
@@ -664,7 +664,7 @@ Menu.prototype.parsePinEntries = function (raw) {
     for (let spec of ['ecma262', 'ecma402', 'ecma404', 'ecma426']) {
       migrated['/' + spec + '/'] = { pins: parsed, lastUsed };
     }
-    migrated[this.getDocumentKey()] = { pins: parsed, lastUsed };
+    migrated[pathPrefix] = { pins: parsed, lastUsed };
     return migrated;
   }
   return parsed && typeof parsed === 'object' ? parsed : {};
@@ -673,10 +673,10 @@ Menu.prototype.parsePinEntries = function (raw) {
 // Drop documents not visited within PIN_TTL_MS. Mutates and returns `store`.
 Menu.prototype.prunePinStore = function (store) {
   let now = Date.now();
-  for (let path of Object.keys(store)) {
-    let entry = store[path];
+  for (let pathPrefix of Object.keys(store)) {
+    let entry = store[pathPrefix];
     if (!entry || typeof entry.lastUsed !== 'number' || now - entry.lastUsed > PIN_TTL_MS) {
-      delete store[path];
+      delete store[pathPrefix];
     }
   }
   return store;
@@ -693,7 +693,7 @@ Menu.prototype.persistPinEntries = function () {
   }
 
   let store = this.prunePinStore(this.parsePinEntries(raw));
-  let key = this.getDocumentKey();
+  let key = pathPrefix;
   let ids = Object.keys(this._pinnedIds);
   if (ids.length === 0) {
     // Don't leave an empty entry lingering once the last pin is removed.
@@ -719,7 +719,7 @@ Menu.prototype.loadPinEntries = function () {
   }
 
   let store = this.parsePinEntries(raw);
-  let entry = store[this.getDocumentKey()] || { pins: [] };
+  let entry = store[pathPrefix] || { pins: [] };
   // Update in-memory state (including dropping missing ids) and the DOM.
   for (let i = 0; i < entry.pins.length; i++) {
     this.addPinEntry(entry.pins[i]);
@@ -1233,12 +1233,12 @@ function sortByClauseNumber(clause1, clause2) {
 }
 
 function makeLinkToId(id) {
-  let hash = '#' + id;
-  if (typeof idToSection === 'undefined' || !idToSection[id]) {
-    return hash;
+  let path = '';
+  if (isMultipage) {
+    let targetSec = typeof idToSection !== 'undefined' && idToSection[id];
+    path = targetSec === 'index' ? './' : targetSec ? targetSec + '.html' : '';
   }
-  let targetSec = idToSection[id];
-  return (targetSec === 'index' ? './' : targetSec + '.html') + hash;
+  return path + '#' + id;
 }
 
 function doShortcut(e) {
@@ -1253,23 +1253,8 @@ function doShortcut(e) {
   if (e.altKey || e.ctrlKey || e.metaKey) {
     return;
   }
-  if (e.key === 'm' && usesMultipage) {
-    let pathParts = location.pathname.split('/');
-    let hash = location.hash;
-    if (pathParts[pathParts.length - 2] === 'multipage') {
-      if (hash === '') {
-        let sectionName = pathParts[pathParts.length - 1];
-        if (sectionName.endsWith('.html')) {
-          sectionName = sectionName.slice(0, -5);
-        }
-        if (idToSection['sec-' + sectionName] !== undefined) {
-          hash = '#sec-' + sectionName;
-        }
-      }
-      location = pathParts.slice(0, -2).join('/') + '/' + hash;
-    } else {
-      location = 'multipage/' + hash;
-    }
+  if (e.key === 'm' && typeof toggleMultipage !== 'undefined') {
+    toggleMultipage();
   } else if (e.key === 'u') {
     document.documentElement.classList.toggle('show-uc-annotations');
   } else if (e.key === 'e') {
@@ -1693,8 +1678,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{}`);
-let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"sec-intro","titleHTML":"Intro","number":""},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
-;let usesMultipage = false</script><style>:root {
+let biblio = JSON.parse(`{"refsByClause":{},"entries":[{"type":"clause","id":"sec-intro","titleHTML":"Intro","number":""},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);</script><style>:root {
   --foreground-color: #111;
   --background-color: #fff;
 
@@ -3371,7 +3355,18 @@ li.menu-search-result-term::before {
   background: var(--figure-background);
   width: 500px;
 }
+
+/* Other dynamic elements */
+:root[data-multipage-preference=''] [data-set-multipage-preference=''],
+:root[data-multipage-preference='single-page'] [data-set-multipage-preference='single-page'],
+:root[data-multipage-preference='multi-page'] [data-set-multipage-preference='multi-page'] {
+  font-weight: bold;
+}
 </style><style>@media print {
+.no-print {
+  display: none !important;
+}
+
 @font-face {
   font-family: 'Arial Plus';
   src: local('Arial');
@@ -4144,7 +4139,13 @@ p.adoption-info {
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
     </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intro" title="Intro">Intro</a></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License">Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container">

--- a/test/baselines/generated-reference/autolinking.html
+++ b/test/baselines/generated-reference/autolinking.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="sec-foo">
   <h1><span class="secnum">1</span> Autolinking</h1>
   <p>Type, type, <emu-xref aoid="Type"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(), type()</p>

--- a/test/baselines/generated-reference/boilerplate-address.html
+++ b/test/baselines/generated-reference/boilerplate-address.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-all.html
+++ b/test/baselines/generated-reference/boilerplate-all.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-copyright.html
+++ b/test/baselines/generated-reference/boilerplate-copyright.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/boilerplate-license.html
+++ b/test/baselines/generated-reference/boilerplate-license.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/charset-absent.html
+++ b/test/baselines/generated-reference/charset-absent.html
@@ -10,5 +10,11 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 </div></body>

--- a/test/baselines/generated-reference/charset-present.html
+++ b/test/baselines/generated-reference/charset-present.html
@@ -11,6 +11,12 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 </div></body>

--- a/test/baselines/generated-reference/code.html
+++ b/test/baselines/generated-reference/code.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <link rel="stylesheet" href="css/elements.css">
 <emu-clause id="foo">
   <h1><span class="secnum">1</span> Test Clause</h1>

--- a/test/baselines/generated-reference/copyright.html
+++ b/test/baselines/generated-reference/copyright.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="version">Draft 1 / September 26, 2014</h1><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="version">Draft 1 / September 26, 2014</h1><h1 class="title">test title!</h1>
 <emu-clause id="sec-clause">
   <h1><span class="secnum">1</span> Test Clause</h1>
 </emu-clause><emu-annex id="sec-copyright-and-software-license" back-matter="">

--- a/test/baselines/generated-reference/date.html
+++ b/test/baselines/generated-reference/date.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="title">test title!</h1>
 
 <p>Some body content</p>
 

--- a/test/baselines/generated-reference/dfn.html
+++ b/test/baselines/generated-reference/dfn.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-intro id="sec-intro">
   <h1>Intro</h1>
   <p>Forward references to <emu-xref href="#sec-dfn" id="_ref_0"><a href="#sec-dfn">dfn</a></emu-xref> work.</p>

--- a/test/baselines/generated-reference/duplicate-ids.html
+++ b/test/baselines/generated-reference/duplicate-ids.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="sec-a">
   <h1><span class="secnum">1</span> A</h1>
   <!-- EXPECT_WARNING { "ruleId": "duplicate-id", "message": "<emu-clause> has duplicate id \"sec-a\"" } -->

--- a/test/baselines/generated-reference/duplicate-productions.html
+++ b/test/baselines/generated-reference/duplicate-productions.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-production name="Prod"><emu-nt><a href="#prod-Prod">Prod</a></emu-nt> <emu-geq>:</emu-geq> </emu-production>
 <emu-grammar><emu-production name="GMD" type="lexical">
     <emu-nt><a href="#prod-GMD">GMD</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="opbw7lol">

--- a/test/baselines/generated-reference/ecmarkdown.html
+++ b/test/baselines/generated-reference/ecmarkdown.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="sec-foo">
   <h1><span class="secnum">1</span> ecmarkdown basics</h1>
   <p>ecmarkdown like <var>v</var> works before <!-- a comment --> and after comments <var>v</var>.</p>

--- a/test/baselines/generated-reference/effect-user-code.html
+++ b/test/baselines/generated-reference/effect-user-code.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-clause id="sec-user-code" type="abstract operation" aoid="UserCode">
   <h1><span class="secnum">1</span> UserCode ( )</h1>

--- a/test/baselines/generated-reference/emd-in-grammar.html
+++ b/test/baselines/generated-reference/emd-in-grammar.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-clause id="sec-example">
   <h1><span class="secnum">1</span> Example</h1>

--- a/test/baselines/generated-reference/eqn.html
+++ b/test/baselines/generated-reference/eqn.html
@@ -11,7 +11,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="sec-example">
   <h1><span class="secnum">1</span> Header</h1>
   <p>Can refer to eqns inside paragraph text via autolinking: <emu-xref aoid="DateValue" id="_ref_0"><a href="#eqn-DateValue">DateValue</a></emu-xref>.</p>

--- a/test/baselines/generated-reference/escaping.html
+++ b/test/baselines/generated-reference/escaping.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="blah">
 <h1><span class="secnum">1</span> blah</h1>
 <p>U+200C (ZERO WIDTH NON-JOINER) is abbreviated "&lt;ZWNJ&gt;"</p>

--- a/test/baselines/generated-reference/example.html
+++ b/test/baselines/generated-reference/example.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <p>Examples outside of clauses aren't processed specially.</p>
 <emu-example>
   This is an example.

--- a/test/baselines/generated-reference/exit-steps.html
+++ b/test/baselines/generated-reference/exit-steps.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-clause id="sec-marked-exits" type="abstract operation" aoid="MarkedExits">
   <h1><span class="secnum">1</span> MarkedExits ( )</h1>

--- a/test/baselines/generated-reference/figure.html
+++ b/test/baselines/generated-reference/figure.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <link rel="stylesheet" href="css/elements.css">
 <emu-figure id="figure-1"><figure><figcaption>Figure 1</figcaption>
   this is a figure!

--- a/test/baselines/generated-reference/grammar.html
+++ b/test/baselines/generated-reference/grammar.html
@@ -11,7 +11,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-grammar type="definition"><emu-production name="FooTerminal" id="prod-FooTerminal">
     <emu-nt><a href="#prod-FooTerminal">FooTerminal</a></emu-nt> <emu-geq>:</emu-geq> <ins><emu-rhs a="vcktfnt9">

--- a/test/baselines/generated-reference/html-element-attributes.html
+++ b/test/baselines/generated-reference/html-element-attributes.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 Content
 
 </div></body></html>

--- a/test/baselines/generated-reference/imports.html
+++ b/test/baselines/generated-reference/imports.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="Baz" aoid="Baz">
   <h1><span class="secnum">1</span> Header</h1>
   <p>text</p>

--- a/test/baselines/generated-reference/ins-nonterminal.html
+++ b/test/baselines/generated-reference/ins-nonterminal.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-production name="A" type="lexical" oneof="" primary="" id="prod-A">
     <emu-nt><a href="#prod-A">A</a></emu-nt> <emu-geq>::</emu-geq> <emu-oneof>one of</emu-oneof> <emu-rhs><del><emu-t>a</emu-t></del> <emu-t>b</emu-t> <emu-t>c</emu-t> <mark><emu-t>d</emu-t></mark>  <ins><emu-t>e</emu-t> <emu-t>f</emu-t></ins></emu-rhs>

--- a/test/baselines/generated-reference/max-clause-depth.html
+++ b/test/baselines/generated-reference/max-clause-depth.html
@@ -14,7 +14,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
     </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#one" title="One"><span class="secnum">1</span> One</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#two" title="Two"><span class="secnum">1.1</span> Two</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#three" title="Three"><span class="secnum">1.2</span> Three</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#four" title="four"><span class="secnum">1.3</span> four</a></li></ol></li><li><span class="item-toggle">+</span><a href="#three-again" title="Three Again"><span class="secnum">1.4</span> Three Again</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#four-again" title="Four Again"><span class="secnum">1.5</span> Four Again</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#two-again" title="Two Again"><span class="secnum">1.6</span> Two Again</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#one-again" title="One Again"><span class="secnum">2</span> One Again</a></li></ol></div></div><div id="spec-container">

--- a/test/baselines/generated-reference/multipage.html/index.html
+++ b/test/baselines/generated-reference/multipage.html/index.html
@@ -14,7 +14,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
     </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intro" title="Intro">Intro</a></li><li><span class="item-toggle-none"></span><a href="#sec-second" title="Second Clause"><span class="secnum">1</span> Second Clause</a></li><li><span class="item-toggle">+</span><a href="#sec-third" title="Third Clause"><span class="secnum">2</span> Third Clause</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-alg" title="Algorithm"><span class="secnum">2.1</span> Algorithm</a></li></ol></li></ol></div></div><div id="spec-container">

--- a/test/baselines/generated-reference/multipage.html/multipage/index.html
+++ b/test/baselines/generated-reference/multipage.html/multipage/index.html
@@ -19,7 +19,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id='spec-container'><emu-intro id="sec-intro">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id='spec-container'><emu-intro id="sec-intro">
   <h1>Intro</h1>
   <p>Some text.</p>
 </emu-intro></div></body>

--- a/test/baselines/generated-reference/multipage.html/multipage/second.html
+++ b/test/baselines/generated-reference/multipage.html/multipage/second.html
@@ -19,7 +19,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id='spec-container'><emu-clause id="sec-second">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id='spec-container'><emu-clause id="sec-second">
   <h1><span class="secnum">1</span> Second Clause</h1>
   <p>A cross-section reference: <emu-xref aoid="Alg" id="_ref_0"><a href="third.html#sec-alg">Alg</a></emu-xref>.</p>
   <p>A relative image: <img src="../example.png">.</p>

--- a/test/baselines/generated-reference/multipage.html/multipage/third.html
+++ b/test/baselines/generated-reference/multipage.html/multipage/third.html
@@ -19,7 +19,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id='spec-container'><emu-clause id="sec-third">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id='spec-container'><emu-clause id="sec-third">
   <h1><span class="secnum">2</span> Third Clause</h1>
   <p>Some text.</p>
   <emu-clause id="sec-alg" aoid="Alg">

--- a/test/baselines/generated-reference/namespaces-productions.html
+++ b/test/baselines/generated-reference/namespaces-productions.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-intro id="intro" namespace="intro">
   <h1>Intro</h1>
   <emu-grammar type="definition"><emu-production name="Foo" type="lexical" id="prod-intro-Foo">

--- a/test/baselines/generated-reference/namespaces.html
+++ b/test/baselines/generated-reference/namespaces.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-intro namespace="intro" aoid="SomeAlg" id="i1">
   <h1>Intro</h1>
   <emu-grammar type="definition"><emu-production name="Foo" type="lexical" id="prod-intro-Foo">

--- a/test/baselines/generated-reference/nonterminal-used-before-definition.html
+++ b/test/baselines/generated-reference/nonterminal-used-before-definition.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="sec-example-sdo">
   <h1><span class="secnum">1</span> Example SDO</h1>
   <emu-grammar><emu-production name="Example" collapsed="">

--- a/test/baselines/generated-reference/notes.html
+++ b/test/baselines/generated-reference/notes.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-note>This is a note. Since it is outside a clause it is unstyled.</emu-note>
 
 <emu-clause id="sec-this">

--- a/test/baselines/generated-reference/oldids.html
+++ b/test/baselines/generated-reference/oldids.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-clause id="c1" oldids="old1,old2"><span id="old2"></span><span id="old1"></span>
   <h1><span class="secnum">1</span> c1</h1>
   <p>This is some <dfn id="content" oldids="olddfn" tabindex="-1"><span id="olddfn"></span>content</dfn> and such.</p>

--- a/test/baselines/generated-reference/optional-parts.html
+++ b/test/baselines/generated-reference/optional-parts.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 <emu-note>This is a note. Since it is outside a clause it is unstyled.</emu-note>
 
 <emu-clause id="conformance">

--- a/test/baselines/generated-reference/proposal-copyright.html
+++ b/test/baselines/generated-reference/proposal-copyright.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="version">Stage 0 Draft / September 26, 2014</h1><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="version">Stage 0 Draft / September 26, 2014</h1><h1 class="title">test title!</h1>
 
 <emu-annex id="sec-copyright-and-software-license" back-matter="">
         <h1>Copyright &amp; Software License</h1>

--- a/test/baselines/generated-reference/shortname.html
+++ b/test/baselines/generated-reference/shortname.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="shortname"><span class="status">Draft</span> ECMA-000</h1><h1 class="version">Draft 1 / September 26, 2015</h1><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="shortname"><span class="status">Draft</span> ECMA-000</h1><h1 class="version">Draft 1 / September 26, 2015</h1><h1 class="title">test title!</h1>
 
 <p>Some body content</p>
 </div></body>

--- a/test/baselines/generated-reference/step-xrefs.html
+++ b/test/baselines/generated-reference/step-xrefs.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-clause id="test">
   <h1><span class="secnum">1</span> Title</h1>

--- a/test/baselines/generated-reference/structured-headers.html
+++ b/test/baselines/generated-reference/structured-headers.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-clause id="sec-exampleao" type="abstract operation" aoid="ExampleAO">
   <h1><span class="secnum">1</span> ExampleAO ( param [ , param2 ] )</h1>

--- a/test/baselines/generated-reference/test.html
+++ b/test/baselines/generated-reference/test.html
@@ -15,7 +15,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
     </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#i1" title="Intro">Intro</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#i2" title="Sub Intro">Sub Intro</a></li></ol></li><li><span class="item-toggle">+</span><a href="#c1" title="Clause Foo(a, b)"><span class="secnum">1</span> Clause Foo(<var>a</var>, <var>b</var>)</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#Foo" title="Sub Clause"><span class="secnum">1.1</span> Sub Clause</a></li><li><span class="item-toggle-none"></span><a href="#Bar" title="Sub Clause"><span class="secnum">1.2</span> Sub Clause</a></li><li><span class="item-toggle">+</span><a href="#Baz" title="Header"><span class="secnum">1.3</span> Header</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#import3" title="Import 3"><span class="secnum">1.3.1</span> Import 3</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#a1" title="Annex"><span class="secnum">Annex A <span class="annex-kind">(informative)</span></span> Annex</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft 1 / September 26, 2015</h1><h1 class="title">Ecmarkup Test Document</h1>

--- a/test/baselines/generated-reference/title.html
+++ b/test/baselines/generated-reference/title.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container"><h1 class="version">Draft 1 / September 26, 2015</h1><h1 class="title">test title!</h1>
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container"><h1 class="version">Draft 1 / September 26, 2015</h1><h1 class="title">test title!</h1>
 
 <p>Some body content</p>
 </div></body>

--- a/test/baselines/generated-reference/toc.html
+++ b/test/baselines/generated-reference/toc.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
     </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#test" title="Example Link Header"><span class="secnum">1</span> Example Link Header</a></li></ol></div></div><div id="spec-container">

--- a/test/baselines/generated-reference/xref.html
+++ b/test/baselines/generated-reference/xref.html
@@ -10,7 +10,13 @@
   <li><span>Jump to the <i>n</i><sup>th</sup> pin</span><code>1-9</code></li>
   <li><span>Jump to the 10<sup>th</sup> pin</span><code>0</code></li>
   <li><span>Jump to the most recent link target</span><code>`</code></li>
-</ul></div><div id="spec-container">
+</ul>
+<fieldset>
+  <legend>Multipage preference</legend>
+  <button type="button" disabled="" data-set-multipage-preference="">No preference</button>
+  <button type="button" disabled="" data-set-multipage-preference="single-page">Always single-page</button>
+  <button type="button" disabled="" data-set-multipage-preference="multi-page">Always multi-page</button>
+</fieldset></div><div id="spec-container">
 
 <emu-clause id="sec-clause-id">
   <h1><span class="secnum">1</span> Clause Title</h1>


### PR DESCRIPTION
Fixes #631

Expose buttons in the shortcuts popup for setting a localStorage "multipagePreference" entry to either empty or "single-page" or "multi-page" (and a way for similar `data-multipage-preference="…"` controls to be embedded in documents, necessary for mobile and other keyboard-free interactions), and check for that preference when loading any page to perform a prompt redirect if needed (e.g., before loading an entire single-page spec).

Redirects are not applied when following internal links, so using toggling between single-page and multi-page views _without_ changing the preference still works.