### PR TITLE
Simplify heading styles

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -799,153 +799,100 @@ emu-intro[id] {
   scroll-margin-top: 2ex;
 }
 
-emu-intro h1,
-emu-clause h1,
-emu-annex h1 {
-  font-size: 2em;
-}
-emu-intro h2,
-emu-clause h2,
-emu-annex h2 {
-  font-size: 1.56em;
-}
-emu-intro h3,
-emu-clause h3,
-emu-annex h3 {
-  font-size: 1.25em;
-}
-emu-intro h4,
-emu-clause h4,
-emu-annex h4 {
-  font-size: 1.11em;
-}
-emu-intro h5,
-emu-clause h5,
-emu-annex h5 {
-  font-size: 1em;
-}
-emu-intro h6,
-emu-clause h6,
-emu-annex h6 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro h1,
-emu-clause emu-clause h1,
-emu-annex emu-annex h1 {
-  font-size: 1.56em;
-}
-emu-intro emu-intro h2,
-emu-clause emu-clause h2,
-emu-annex emu-annex h2 {
-  font-size: 1.25em;
-}
-emu-intro emu-intro h3,
-emu-clause emu-clause h3,
-emu-annex emu-annex h3 {
-  font-size: 1.11em;
-}
-emu-intro emu-intro h4,
-emu-clause emu-clause h4,
-emu-annex emu-annex h4 {
-  font-size: 1em;
-}
-emu-intro emu-intro h5,
-emu-clause emu-clause h5,
-emu-annex emu-annex h5 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex h1 {
-  font-size: 1.25em;
-}
-emu-intro emu-intro emu-intro h2,
-emu-clause emu-clause emu-clause h2,
-emu-annex emu-annex emu-annex h2 {
-  font-size: 1.11em;
-}
-emu-intro emu-intro emu-intro h3,
-emu-clause emu-clause emu-clause h3,
-emu-annex emu-annex emu-annex h3 {
-  font-size: 1em;
-}
-emu-intro emu-intro emu-intro h4,
-emu-clause emu-clause emu-clause h4,
-emu-annex emu-annex emu-annex h4 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex emu-annex h1 {
-  font-size: 1.11em;
-}
-emu-intro emu-intro emu-intro emu-intro h2,
-emu-clause emu-clause emu-clause emu-clause h2,
-emu-annex emu-annex emu-annex emu-annex h2 {
-  font-size: 1em;
-}
-emu-intro emu-intro emu-intro emu-intro h3,
-emu-clause emu-clause emu-clause emu-clause h3,
-emu-annex emu-annex emu-annex emu-annex h3 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
-  font-size: 1em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro h2,
-emu-clause emu-clause emu-clause emu-clause emu-clause h2,
-emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
-  font-size: 0.9em;
+@media not print {
+  emu-intro h1,
+  emu-clause h1,
+  emu-annex h1 {
+    font-size: 2em;
+    margin-top: 2em;
+  }
+
+  emu-intro emu-intro h1,
+  emu-clause emu-clause h1,
+  emu-annex emu-annex h1,
+  emu-intro h2,
+  emu-clause h2,
+  emu-annex h2 {
+    font-size: 1.56em;
+  }
+
+  emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro h2,
+  emu-clause emu-clause h2,
+  emu-annex emu-annex h2,
+  emu-intro h3,
+  emu-clause h3,
+  emu-annex h3 {
+    font-size: 1.25em;
+  }
+
+  emu-intro emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro emu-intro h2,
+  emu-clause emu-clause emu-clause h2,
+  emu-annex emu-annex emu-annex h2,
+  emu-intro emu-intro h3,
+  emu-clause emu-clause h3,
+  emu-annex emu-annex h3,
+  emu-intro h4,
+  emu-clause h4,
+  emu-annex h4 {
+    font-size: 1.11em;
+  }
+
+  emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro emu-intro emu-intro h2,
+  emu-clause emu-clause emu-clause emu-clause h2,
+  emu-annex emu-annex emu-annex emu-annex h2,
+  emu-intro emu-intro emu-intro h3,
+  emu-clause emu-clause emu-clause h3,
+  emu-annex emu-annex emu-annex h3,
+  emu-intro emu-intro h4,
+  emu-clause emu-clause h4,
+  emu-annex emu-annex h4,
+  emu-intro h5,
+  emu-clause h5,
+  emu-annex h5 {
+    font-size: 1em;
+  }
+
+  emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+  emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+  emu-annex emu-annex emu-annex emu-annex emu-annex h2,
+  emu-intro emu-intro emu-intro emu-intro h3,
+  emu-clause emu-clause emu-clause emu-clause h3,
+  emu-annex emu-annex emu-annex emu-annex h3,
+  emu-intro emu-intro emu-intro h4,
+  emu-clause emu-clause emu-clause h4,
+  emu-annex emu-annex emu-annex h4,
+  emu-intro emu-intro h5,
+  emu-clause emu-clause h5,
+  emu-annex emu-annex h5,
+  emu-intro h6,
+  emu-clause h6,
+  emu-annex h6 {
+    font-size: 0.9em;
+  }
 }
 
 emu-clause,
 emu-intro,
 emu-annex {
   display: block;
+  margin-top: 0;
 }
 
-/* these values are twice the font-size for the <h1> titles for clauses */
-emu-intro,
-emu-clause,
-emu-annex {
-  margin-top: 4em;
-}
-emu-intro emu-intro,
-emu-clause emu-clause,
-emu-annex emu-annex {
-  margin-top: 3.12em;
-}
-emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex {
-  margin-top: 2.5em;
-}
-emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 2.22em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 2em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 1.8em;
-}
-
-#spec-container > emu-intro:first-of-type,
-#spec-container > emu-clause:first-of-type,
-#spec-container > emu-annex:first-of-type {
+#spec-container > emu-intro:first-of-type h1,
+#spec-container > emu-clause:first-of-type h1,
+#spec-container > emu-annex:first-of-type h1 {
   margin-top: 0;
 }
 

--- a/css/print.css
+++ b/css/print.css
@@ -260,7 +260,7 @@ emu-figure:has(> figure > img) figure,
 
 p:has(+ .math-display),
 emu-table thead,
-h1,
+h1, h2, h3, h4, h5, h6,
 figcaption,
 emu-alg > ol > li:first-child,
 emu-grammar:has(+ emu-alg),
@@ -339,33 +339,46 @@ emu-intro emu-intro, emu-clause emu-clause, emu-annex emu-annex {
   margin-top: 3.5ex;
 }
 
-emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex,
-emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex,
-emu-intro emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 3.2ex;
-}
 
-emu-intro h1, emu-clause h1 , emu-annex h1 {
-  break-after: avoid;
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
+  margin-top: 3.2ex;
   font-size: 12pt;
   -prince-bookmark-level: 1;
   -prince-bookmark-label: content();
 }
 
-emu-clause emu-clause h1, emu-annex emu-annex h1 {
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1,
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
   -prince-bookmark-level: 2;
   -prince-bookmark-state: closed;
+  font-size: 11pt;
 }
 
-emu-clause emu-clause h1, emu-annex emu-annex h1,
-emu-intro h2, emu-clause h2, emu-annex h2 {
-  font-size: 11pt;
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1,
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2,
+emu-intro h3,
+emu-clause h3,
+emu-annex h3,
+emu-intro h4,
+emu-clause h4,
+emu-annex h4,
+emu-intro h5,
+emu-clause h5,
+emu-annex h5,
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 10pt;
 }
 
 emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 {
@@ -382,17 +395,6 @@ emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex e
 
 emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
   -prince-bookmark-level: 6;
-}
-
-emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause h2, emu-annex emu-annex h2,
-emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2,
-emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2,
-emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
-  font-size: 10pt;
 }
 
 emu-clause ol, emu-clause ul, emu-clause dl, emu-annex ol, emu-annex ul, emu-annex dl {

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -2414,153 +2414,100 @@ emu-intro[id] {
   scroll-margin-top: 2ex;
 }
 
-emu-intro h1,
-emu-clause h1,
-emu-annex h1 {
-  font-size: 2em;
-}
-emu-intro h2,
-emu-clause h2,
-emu-annex h2 {
-  font-size: 1.56em;
-}
-emu-intro h3,
-emu-clause h3,
-emu-annex h3 {
-  font-size: 1.25em;
-}
-emu-intro h4,
-emu-clause h4,
-emu-annex h4 {
-  font-size: 1.11em;
-}
-emu-intro h5,
-emu-clause h5,
-emu-annex h5 {
-  font-size: 1em;
-}
-emu-intro h6,
-emu-clause h6,
-emu-annex h6 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro h1,
-emu-clause emu-clause h1,
-emu-annex emu-annex h1 {
-  font-size: 1.56em;
-}
-emu-intro emu-intro h2,
-emu-clause emu-clause h2,
-emu-annex emu-annex h2 {
-  font-size: 1.25em;
-}
-emu-intro emu-intro h3,
-emu-clause emu-clause h3,
-emu-annex emu-annex h3 {
-  font-size: 1.11em;
-}
-emu-intro emu-intro h4,
-emu-clause emu-clause h4,
-emu-annex emu-annex h4 {
-  font-size: 1em;
-}
-emu-intro emu-intro h5,
-emu-clause emu-clause h5,
-emu-annex emu-annex h5 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex h1 {
-  font-size: 1.25em;
-}
-emu-intro emu-intro emu-intro h2,
-emu-clause emu-clause emu-clause h2,
-emu-annex emu-annex emu-annex h2 {
-  font-size: 1.11em;
-}
-emu-intro emu-intro emu-intro h3,
-emu-clause emu-clause emu-clause h3,
-emu-annex emu-annex emu-annex h3 {
-  font-size: 1em;
-}
-emu-intro emu-intro emu-intro h4,
-emu-clause emu-clause emu-clause h4,
-emu-annex emu-annex emu-annex h4 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex emu-annex h1 {
-  font-size: 1.11em;
-}
-emu-intro emu-intro emu-intro emu-intro h2,
-emu-clause emu-clause emu-clause emu-clause h2,
-emu-annex emu-annex emu-annex emu-annex h2 {
-  font-size: 1em;
-}
-emu-intro emu-intro emu-intro emu-intro h3,
-emu-clause emu-clause emu-clause emu-clause h3,
-emu-annex emu-annex emu-annex emu-annex h3 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
-  font-size: 1em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro h2,
-emu-clause emu-clause emu-clause emu-clause emu-clause h2,
-emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
-  font-size: 0.9em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
-emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
-emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
-  font-size: 0.9em;
+@media not print {
+  emu-intro h1,
+  emu-clause h1,
+  emu-annex h1 {
+    font-size: 2em;
+    margin-top: 2em;
+  }
+
+  emu-intro emu-intro h1,
+  emu-clause emu-clause h1,
+  emu-annex emu-annex h1,
+  emu-intro h2,
+  emu-clause h2,
+  emu-annex h2 {
+    font-size: 1.56em;
+  }
+
+  emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro h2,
+  emu-clause emu-clause h2,
+  emu-annex emu-annex h2,
+  emu-intro h3,
+  emu-clause h3,
+  emu-annex h3 {
+    font-size: 1.25em;
+  }
+
+  emu-intro emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro emu-intro h2,
+  emu-clause emu-clause emu-clause h2,
+  emu-annex emu-annex emu-annex h2,
+  emu-intro emu-intro h3,
+  emu-clause emu-clause h3,
+  emu-annex emu-annex h3,
+  emu-intro h4,
+  emu-clause h4,
+  emu-annex h4 {
+    font-size: 1.11em;
+  }
+
+  emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro emu-intro emu-intro h2,
+  emu-clause emu-clause emu-clause emu-clause h2,
+  emu-annex emu-annex emu-annex emu-annex h2,
+  emu-intro emu-intro emu-intro h3,
+  emu-clause emu-clause emu-clause h3,
+  emu-annex emu-annex emu-annex h3,
+  emu-intro emu-intro h4,
+  emu-clause emu-clause h4,
+  emu-annex emu-annex h4,
+  emu-intro h5,
+  emu-clause h5,
+  emu-annex h5 {
+    font-size: 1em;
+  }
+
+  emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1,
+  emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1,
+  emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1,
+  emu-intro emu-intro emu-intro emu-intro emu-intro h2,
+  emu-clause emu-clause emu-clause emu-clause emu-clause h2,
+  emu-annex emu-annex emu-annex emu-annex emu-annex h2,
+  emu-intro emu-intro emu-intro emu-intro h3,
+  emu-clause emu-clause emu-clause emu-clause h3,
+  emu-annex emu-annex emu-annex emu-annex h3,
+  emu-intro emu-intro emu-intro h4,
+  emu-clause emu-clause emu-clause h4,
+  emu-annex emu-annex emu-annex h4,
+  emu-intro emu-intro h5,
+  emu-clause emu-clause h5,
+  emu-annex emu-annex h5,
+  emu-intro h6,
+  emu-clause h6,
+  emu-annex h6 {
+    font-size: 0.9em;
+  }
 }
 
 emu-clause,
 emu-intro,
 emu-annex {
   display: block;
+  margin-top: 0;
 }
 
-/* these values are twice the font-size for the <h1> titles for clauses */
-emu-intro,
-emu-clause,
-emu-annex {
-  margin-top: 4em;
-}
-emu-intro emu-intro,
-emu-clause emu-clause,
-emu-annex emu-annex {
-  margin-top: 3.12em;
-}
-emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex {
-  margin-top: 2.5em;
-}
-emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 2.22em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 2em;
-}
-emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 1.8em;
-}
-
-#spec-container > emu-intro:first-of-type,
-#spec-container > emu-clause:first-of-type,
-#spec-container > emu-annex:first-of-type {
+#spec-container > emu-intro:first-of-type h1,
+#spec-container > emu-clause:first-of-type h1,
+#spec-container > emu-annex:first-of-type h1 {
   margin-top: 0;
 }
 
@@ -3545,7 +3492,7 @@ emu-figure:has(> figure > img) figure,
 
 p:has(+ .math-display),
 emu-table thead,
-h1,
+h1, h2, h3, h4, h5, h6,
 figcaption,
 emu-alg > ol > li:first-child,
 emu-grammar:has(+ emu-alg),
@@ -3624,33 +3571,46 @@ emu-intro emu-intro, emu-clause emu-clause, emu-annex emu-annex {
   margin-top: 3.5ex;
 }
 
-emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex,
-emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex,
-emu-intro emu-intro emu-intro emu-intro emu-intro,
-emu-clause emu-clause emu-clause emu-clause emu-clause,
-emu-annex emu-annex emu-annex emu-annex emu-annex {
-  margin-top: 3.2ex;
-}
 
-emu-intro h1, emu-clause h1 , emu-annex h1 {
-  break-after: avoid;
+emu-intro h1,
+emu-clause h1,
+emu-annex h1 {
   font-size: 12pt;
+  margin-top: 3.2ex;
   -prince-bookmark-level: 1;
   -prince-bookmark-label: content();
 }
 
-emu-clause emu-clause h1, emu-annex emu-annex h1 {
+emu-intro emu-intro h1,
+emu-clause emu-clause h1,
+emu-annex emu-annex h1,
+emu-intro h2,
+emu-clause h2,
+emu-annex h2 {
+  font-size: 11pt;
   -prince-bookmark-level: 2;
   -prince-bookmark-state: closed;
 }
 
-emu-clause emu-clause h1, emu-annex emu-annex h1,
-emu-intro h2, emu-clause h2, emu-annex h2 {
-  font-size: 11pt;
+emu-intro emu-intro emu-intro h1,
+emu-clause emu-clause emu-clause h1,
+emu-annex emu-annex emu-annex h1,
+emu-intro emu-intro h2,
+emu-clause emu-clause h2,
+emu-annex emu-annex h2,
+emu-intro h3,
+emu-clause h3,
+emu-annex h3,
+emu-intro h4,
+emu-clause h4,
+emu-annex h4,
+emu-intro h5,
+emu-clause h5,
+emu-annex h5,
+emu-intro h6,
+emu-clause h6,
+emu-annex h6 {
+  font-size: 10pt;
 }
 
 emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 {
@@ -3667,17 +3627,6 @@ emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex e
 
 emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 {
   -prince-bookmark-level: 6;
-}
-
-emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause h2, emu-annex emu-annex h2,
-emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2,
-emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2,
-emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1,
-emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 {
-  font-size: 10pt;
 }
 
 emu-clause ol, emu-clause ul, emu-clause dl, emu-annex ol, emu-annex ul, emu-annex dl {


### PR DESCRIPTION
Because somehow this is simpler.

**What this PR does**

1. combine styles for nested clauses' h1s with the same level of nesting heading. i.e. `emu-clause > emu-clause > h1` will use the same style rule `emu-clause > h2`
2. restricts font sizes for nested headings to not-print styles
3. removes manually calculated clause margin-top (2 ⨉ h1's font size)
4. adds margin-top to all headings inside of clauses as a straightforward `2em`
5. reduces levels of nesting for heading styles in print stylesheet

Screenshot, end result with some xscope-supplied visual guides. I spot-checked about a dozen places, including clauses I consider finicky. This screenshot is just one example.

(left side is tc39.es, right side is localhost rendered with this branch of ecmarkup)

<img width="1470" height="739" alt="Screenshot 2026-05-11 at 16 52 34" src="https://github.com/user-attachments/assets/956f6ac8-4252-4125-815b-22679e7edc7a" />
