### PR TITLE
Update styles to cycle through decimal/alpha/roman until nesting level 9

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -487,7 +487,14 @@ emu-alg ol,
 emu-alg ol ol ol ol,
 emu-alg ol.nested-thrice,
 emu-alg ol.nested-twice ol,
-emu-alg ol.nested-once ol ol {
+emu-alg ol.nested-once ol ol,
+/* depth 7 */
+emu-alg ol ol ol ol ol ol ol,
+emu-alg ol.nested-lots ol,
+emu-alg ol.nested-four-times ol ol,
+emu-alg ol.nested-thrice ol ol ol,
+emu-alg ol.nested-twice ol ol ol ol,
+emu-alg ol.nested-once ol ol ol ol ol {
   list-style-type: decimal;
 }
 
@@ -499,7 +506,14 @@ emu-alg ol ol ol ol ol,
 emu-alg ol.nested-four-times,
 emu-alg ol.nested-thrice ol,
 emu-alg ol.nested-twice ol ol,
-emu-alg ol.nested-once ol ol ol {
+emu-alg ol.nested-once ol ol ol,
+/* depth 8 */
+emu-alg ol ol ol ol ol ol ol ol,
+emu-alg ol.nested-lots ol ol,
+emu-alg ol.nested-four-times ol ol ol,
+emu-alg ol.nested-thrice ol ol ol ol,
+emu-alg ol.nested-twice ol ol ol ol ol,
+emu-alg ol.nested-once ol ol ol ol ol ol {
   list-style-type: lower-alpha;
 }
 
@@ -514,8 +528,13 @@ emu-alg ol.nested-four-times ol,
 emu-alg ol.nested-thrice ol ol,
 emu-alg ol.nested-twice ol ol ol,
 emu-alg ol.nested-once ol ol ol ol,
-/* depth 7+ */
-emu-alg ol.nested-lots ol {
+/* depth 9+ */
+emu-alg ol ol ol ol ol ol ol ol ol,
+emu-alg ol.nested-lots ol ol ol,
+emu-alg ol.nested-four-times ol ol ol ol,
+emu-alg ol.nested-thrice ol ol ol ol ol,
+emu-alg ol.nested-twice ol ol ol ol ol ol,
+emu-alg ol.nested-once ol ol ol ol ol ol ol {
   list-style-type: lower-roman;
 }
 

--- a/test/baselines/generated-reference/assets-inline.html
+++ b/test/baselines/generated-reference/assets-inline.html
@@ -2102,7 +2102,14 @@ emu-alg ol,
 emu-alg ol ol ol ol,
 emu-alg ol.nested-thrice,
 emu-alg ol.nested-twice ol,
-emu-alg ol.nested-once ol ol {
+emu-alg ol.nested-once ol ol,
+/* depth 7 */
+emu-alg ol ol ol ol ol ol ol,
+emu-alg ol.nested-lots ol,
+emu-alg ol.nested-four-times ol ol,
+emu-alg ol.nested-thrice ol ol ol,
+emu-alg ol.nested-twice ol ol ol ol,
+emu-alg ol.nested-once ol ol ol ol ol {
   list-style-type: decimal;
 }
 
@@ -2114,7 +2121,14 @@ emu-alg ol ol ol ol ol,
 emu-alg ol.nested-four-times,
 emu-alg ol.nested-thrice ol,
 emu-alg ol.nested-twice ol ol,
-emu-alg ol.nested-once ol ol ol {
+emu-alg ol.nested-once ol ol ol,
+/* depth 8 */
+emu-alg ol ol ol ol ol ol ol ol,
+emu-alg ol.nested-lots ol ol,
+emu-alg ol.nested-four-times ol ol ol,
+emu-alg ol.nested-thrice ol ol ol ol,
+emu-alg ol.nested-twice ol ol ol ol ol,
+emu-alg ol.nested-once ol ol ol ol ol ol {
   list-style-type: lower-alpha;
 }
 
@@ -2129,8 +2143,13 @@ emu-alg ol.nested-four-times ol,
 emu-alg ol.nested-thrice ol ol,
 emu-alg ol.nested-twice ol ol ol,
 emu-alg ol.nested-once ol ol ol ol,
-/* depth 7+ */
-emu-alg ol.nested-lots ol {
+/* depth 9+ */
+emu-alg ol ol ol ol ol ol ol ol ol,
+emu-alg ol.nested-lots ol ol ol,
+emu-alg ol.nested-four-times ol ol ol ol,
+emu-alg ol.nested-thrice ol ol ol ol ol,
+emu-alg ol.nested-twice ol ol ol ol ol ol,
+emu-alg ol.nested-once ol ol ol ol ol ol ol {
   list-style-type: lower-roman;
 }
 


### PR DESCRIPTION
I'm told the current limit of using roman markers for any nesting level above 6 is from the MS Word days. Current day MS Word and Google Docs limit the nesting level of lists to 9 and fully cycle through decimal/alpha/roman until then.

ECMA-262's maximum nesting level is 8 at the moment (GDI, EDI), leading to repeated roman markers. Short of refactoring that out of existence it seems reasonable to add proper support for nesting levels up to 9 and use a generic fallback beyond that. If you ever end up there something went very wrong.

While this will break any reference like "GlobalDeclarationInstantiation step 12.b.ii.2.a.ii.ii.ii", those references have always been brittle unless a specific snapshot is referenced. Could be step 15.c.... next week without this change too.

Before (leading 12. cut off):

<img width="1800" height="1041" alt="image" src="https://github.com/user-attachments/assets/94567dae-d575-4221-a5ed-e98840859354" />

After:

<img width="1800" height="1041" alt="image" src="https://github.com/user-attachments/assets/ce5faefe-fb4b-4c08-8846-9f0b35cc4684" />
