### PR TITLE
When formatting, replace inline ASCII quotes with typographic quotes

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -51,8 +51,8 @@ markEffects: true
       <tr><td>`--watch`</td><td></td><td>Rebuild when files change.</td></tr>
       <tr><td>`--verbose`</td><td></td><td>Print verbose logging info.</td></tr>
       <tr><td>`--write-biblio`</td><td></td><td>Emit a biblio file to the specified path.</td></tr>
-      <tr><td>`--assets`</td><td>`assets`</td><td>"none" for no CSS/JS/etc, "inline" for inline CSS/JS/etc, "external" for external CSS/JS/etc.</td></tr>
-      <tr><td>`--assets-dir`</td><td>`assetsDir`</td><td>Directory in which to place assets when using `--assets=external`. Defaults to "assets".</td></tr>
+      <tr><td>`--assets`</td><td>`assets`</td><td>“none” for no CSS/JS/etc, “inline” for inline CSS/JS/etc, “external” for external CSS/JS/etc.</td></tr>
+      <tr><td>`--assets-dir`</td><td>`assetsDir`</td><td>Directory in which to place assets when using `--assets=external`. Defaults to “assets”.</td></tr>
       <tr><td>`--lint-spec`</td><td>`lintSpec`</td><td>Enforce some style and correctness checks.</td></tr>
       <tr><td>`--error-formatter`</td><td></td><td>The <a href="https://eslint.org/docs/user-guide/formatters/">eslint formatter</a> to be used for printing warnings and errors when using `--verbose`. Either the name of a built-in eslint formatter or the package name of an installed eslint compatible formatter.</td></tr>
       <tr><td>`--max-clause-depth N`</td><td></td><td>Warn when clauses exceed a nesting depth of N, and cause those clauses to be numbered by incrementing their parent clause's number rather than by nesting a new number within their parent clause.</td></tr>
@@ -66,29 +66,29 @@ markEffects: true
     <emu-caption>Document options</emu-caption>
     <table>
       <tr><th>Command Line Option</th><th>Front-Matter Key</th><th>Description</th></tr>
-      <tr><td></td><td>`title`</td><td>Document title, for example "ECMAScript 2016" or "Async Functions".</td></tr>
-      <tr><td></td><td>`status`</td><td>Document status. Can be "proposal", "draft", or "standard". Defaults to "proposal".</td></tr>
-      <tr><td></td><td>`stage`</td><td><a href="https://tc39.es/process-document/">TC39 proposal stage</a>. If present and `status` is "proposal", `version` defaults to "Stage <var>stage</var> Draft".</td></tr>
-      <tr><td></td><td>`version`</td><td>Document version, for example "6&lt;sup>th&lt;/sup> Edition" (which renders like "6<sup>th</sup> Edition") or "Draft 1".</td></tr>
-      <tr><td></td><td>`date`</td><td>Timestamp of document rendering, used for various pieces of boilerplate. Defaults to the value of <a href="https://reproducible-builds.org/docs/source-date-epoch/">the `SOURCE_DATE_EPOCH` environment variable</a> (as a number of second since the POSIX epoch) if it exists, otherwise to the current date and time. Required for documents with "standard" status, should reflect adoption date.</td></tr>
-      <tr><td></td><td>`shortname`</td><td>Document shortname, for example "ECMA-262". If present and `status` is "draft", `version` defaults to "Draft <var>shortname</var>".</td></tr>
+      <tr><td></td><td>`title`</td><td>Document title, for example “ECMAScript 2016” or “Async Functions”.</td></tr>
+      <tr><td></td><td>`status`</td><td>Document status. Can be “proposal”, “draft”, or “standard”. Defaults to “proposal”.</td></tr>
+      <tr><td></td><td>`stage`</td><td><a href="https://tc39.es/process-document/">TC39 proposal stage</a>. If present and `status` is “proposal”, `version` defaults to “Stage <var>stage</var> Draft”.</td></tr>
+      <tr><td></td><td>`version`</td><td>Document version, for example “6&lt;sup>th&lt;/sup> Edition” (which renders like “6<sup>th</sup> Edition”) or “Draft 1”.</td></tr>
+      <tr><td></td><td>`date`</td><td>Timestamp of document rendering, used for various pieces of boilerplate. Defaults to the value of <a href="https://reproducible-builds.org/docs/source-date-epoch/">the `SOURCE_DATE_EPOCH` environment variable</a> (as a number of second since the POSIX epoch) if it exists, otherwise to the current date and time. Required for documents with “standard” status, should reflect adoption date.</td></tr>
+      <tr><td></td><td>`shortname`</td><td>Document shortname, for example “ECMA-262”. If present and `status` is “draft”, `version` defaults to “Draft <var>shortname</var>”.</td></tr>
       <tr><td></td><td>`description`</td><td>Brief description to be used for link previews in social media and the like.</td></tr>
       <tr><td></td><td>`location`</td><td>URL of this document. Used in conjunction with the biblio file to support inbound references from other documents.</td></tr>
       <tr><td></td><td>`copyright`</td><td>Emit copyright and software license information. Boolean, default true.</td></tr>
-      <tr><td></td><td>`contributors`</td><td>Contributors to this specification, i.e. those who own the copyright. If your proposal includes text from any Ecma specification, this should include "Ecma International".</td></tr>
-      <tr><td></td><td>`committee`</td><td>Ecma Technical Committee number. Required for documents with "standard" status, expects e.g. "39". Appends adoption information to &lt;emu-intro> element.</td></tr>
+      <tr><td></td><td>`contributors`</td><td>Contributors to this specification, i.e. those who own the copyright. If your proposal includes text from any Ecma specification, this should include “Ecma International”.</td></tr>
+      <tr><td></td><td>`committee`</td><td>Ecma Technical Committee number. Required for documents with “standard” status, expects e.g. “39”. Appends adoption information to &lt;emu-intro> element.</td></tr>
       <tr><td>`--no-toc`</td><td>`toc`</td><td>Emit table of contents. Boolean, default true.</td></tr>
       <tr><td>`--printable`</td><td>`printable`</td><td>Make the output suitable for printing. Boolean, default false.</td></tr>
       <tr><td>`--load-biblio`</td><td>`extraBiblios`</td><td>Extra biblio.json file(s) to load. This should contain either an object as exported by `--write-biblio` or an array of such objects.</td></tr>
-      <tr><td></td><td>`boilerplate`</td><td>An object with `address` and/or `copyright` and/or `license` fields containing paths to files containing the corresponding content for populating an element with class "copyright-and-software-license" (or if not found, an appended <emu-xref href="#emu-annex" title></emu-xref> with that id) when `copyright` is true or set to `alternative`. Absent fields are assumed to reference files in a "boilerplate" directory sibling of the directory containing the ecmarkup executable.</td></tr>
-      <tr><td>`--mark-effects`</td><td>`markEffects`</td><td>Propagate and render <a href="#effects">effects</a> like "user code".</td></tr>
+      <tr><td></td><td>`boilerplate`</td><td>An object with `address` and/or `copyright` and/or `license` fields containing paths to files containing the corresponding content for populating an element with class “copyright-and-software-license” (or if not found, an appended <emu-xref href="#emu-annex" title></emu-xref> with that id) when `copyright` is true or set to `alternative`. Absent fields are assumed to reference files in a “boilerplate” directory sibling of the directory containing the ecmarkup executable.</td></tr>
+      <tr><td>`--mark-effects`</td><td>`markEffects`</td><td>Propagate and render <a href="#effects">effects</a> like “user code”.</td></tr>
     </table>
   </emu-table>
 </emu-clause>
 
 <emu-clause id="stylesheets-and-scripts">
   <h1>Stylesheets and other assets</h1>
-  <p>Ecmarkup requires CSS styles and other assets. By default all assets are inlined into the document. You can override this by setting assets to "none" (for example if you want to manually link to external assets) or "external". When using "external" the default directory for assets is `assets` in the same directory as the output file, but you can override this with `--assets-dir`.</p>
+  <p>Ecmarkup requires CSS styles and other assets. By default all assets are inlined into the document. You can override this by setting assets to “none” (for example if you want to manually link to external assets) or “external”. When using “external” the default directory for assets is `assets` in the same directory as the output file, but you can override this with `--assets-dir`.</p>
 </emu-clause>
 
 <emu-clause id="editorial-conventions">
@@ -188,14 +188,14 @@ markEffects: true
     <p><b>number:</b> Optional: An explicit clause number, overriding the default auto-incrementing number. Can be a nested number, as in `number="2.1"`.</p>
     <p><b>type:</b> Optional: Type of feature described by the clause.</p>
     <ul>
-      <li>"abstract operation"</li>
-      <li>"built-in function"</li>
-      <li>"concrete method"</li>
-      <li>"host-defined abstract operation"</li>
-      <li>"implementation-defined abstract operation"</li>
-      <li>"internal method"</li>
-      <li>"numeric method"</li>
-      <li>"sdo" or "syntax-directed operation"</li>
+      <li>“abstract operation”</li>
+      <li>“built-in function”</li>
+      <li>“concrete method”</li>
+      <li>“host-defined abstract operation”</li>
+      <li>“implementation-defined abstract operation”</li>
+      <li>“internal method”</li>
+      <li>“numeric method”</li>
+      <li>“sdo” or “syntax-directed operation”</li>
     </ul>
 
     <emu-clause id="emu-clause-legacy-attributes" legacy>
@@ -207,16 +207,16 @@ markEffects: true
       <h1>Structured Headers</h1>
       <p>A clause describing an operation or method may have a <dfn>structured header</dfn> to document its signature and metadata. Such a structure consists of:</p>
       <ol>
-        <li>an <code>&lt;h1&gt;</code> element containing the name of the operation followed by a parenthesized list of parameters, each appearing on a comma-terminated line of its own and consisting of a name and value constraints separated by a colon and optionally preceded with "optional"</li>
+        <li>an <code>&lt;h1&gt;</code> element containing the name of the operation followed by a parenthesized list of parameters, each appearing on a comma-terminated line of its own and consisting of a name and value constraints separated by a colon and optionally preceded with “optional”</li>
         <li>
-          a <code>&lt;dl&gt;</code> element with class "header" and a collection of optional key-value pairs expressed using <code>&lt;dt&gt;</code> and <code>&lt;dd&gt;</code> elements:
+          a <code>&lt;dl&gt;</code> element with class “header” and a collection of optional key-value pairs expressed using <code>&lt;dt&gt;</code> and <code>&lt;dd&gt;</code> elements:
           <ul>
             <li><b>description:</b> An explanation of the operation's behaviour.</li>
-            <li><b>effects:</b> A list of "effects" associated with the clause (and transitively with those referencing it), separated by commas with optional whitespace. The only currently-known effect is "user-code", which indicates that the operation or method can evaluate non-implementation code (such as custom getters).</li>
-            <li><b>for:</b> The type of value to which a clause of type "concrete method" or "internal method" applies.</li>
-            <li><b>redefinition:</b> If "true", the name of the operation will not automatically link (i.e., it will not automatically be given an aoid).</li>
-            <li><b>skip global checks:</b> If "true", disables consistency checks for this AO which require knowing every callsite.</li>
-            <li><b>skip return checks:</b> If "true", disables checking that the returned values from this AO correspond to its declared return type. Adding this to an AO which does not require it will produce a warning.</li>
+            <li><b>effects:</b> A list of “effects” associated with the clause (and transitively with those referencing it), separated by commas with optional whitespace. The only currently-known effect is “user-code”, which indicates that the operation or method can evaluate non-implementation code (such as custom getters).</li>
+            <li><b>for:</b> The type of value to which a clause of type “concrete method” or “internal method” applies.</li>
+            <li><b>redefinition:</b> If “true”, the name of the operation will not automatically link (i.e., it will not automatically be given an aoid).</li>
+            <li><b>skip global checks:</b> If “true”, disables consistency checks for this AO which require knowing every callsite.</li>
+            <li><b>skip return checks:</b> If “true”, disables checking that the returned values from this AO correspond to its declared return type. Adding this to an AO which does not require it will produce a warning.</li>
           </ul>
         </li>
       </ol>
@@ -287,13 +287,13 @@ markEffects: true
   <h3>Result</h3>
   <aside class="result">
     <p>A <dfn id="swordfish" variants="swordfishes,Xiphias gladius">swordfish</dfn> is large fish characterized by a long, pointed bill.</p>
-    <p>The Latin name for swordfishes, <em>Xiphias gladius</em>, comes from the Greek word "ξίφος" (xiphos, "sword") and from the Latin word "gladius" ("sword").</p>
+    <p>The Latin name for swordfishes, <em>Xiphias gladius</em>, comes from the Greek word “ξίφος” (xiphos, “sword”) and from the Latin word “gladius” (“sword”).</p>
   </aside>
 </emu-clause>
 
 <emu-clause id="effects">
   <h1>Effects</h1>
-  <p>Abstract operations can be marked as having effects that propagate to their invocation sites. Subject to the following rules, calls to such operations are given a class of the effect name prefixed with “e-”. When using `markEffects`, the CSS includes styling for the "user-code" effect via class name `e-user-code` that is off by default but can be togged by pressing <kbd>u</kbd>.</p>
+  <p>Abstract operations can be marked as having effects that propagate to their invocation sites. Subject to the following rules, calls to such operations are given a class of the effect name prefixed with “e-”. When using `markEffects`, the CSS includes styling for the “user-code” effect via class name `e-user-code` that is off by default but can be togged by pressing <kbd>u</kbd>.</p>
 
   <p>Within an algorithm, an `emu-meta` element enclosing an operation invocation can be used to indicate either the origination of effects or the absence of effects using a list of effect names separated by commas with optional whitespace in an <b>effects</b> or <b>suppress-effects</b> attribute (respectively).</p>
   <pre><code class="language-html">
@@ -469,7 +469,7 @@ markEffects: true
   <p>Non-normative explanatory text. Comes in two types - regular notes and Editor's notes. Regular notes are intended for the implementers and end users of this specification. Editor's notes are notes to and from the Editors and will generally be removed prior to a specification being finalized and ratified.</p>
 
   <h2>Attributes</h2>
-  <p><b>type:</b> The type of note, either blank or "editor".</p>
+  <p><b>type:</b> The type of note, either blank or “editor”.</p>
 
   <h2>Example</h2>
   <pre><code class="language-html">
@@ -617,7 +617,7 @@ markEffects: true
     <p>The first two columns are assumed to be the method signature and the method description respectively.</p>
 
     <h2>Attributes</h2>
-    <p><b>type:</b> Must be present with the value "abstract methods".</p>
+    <p><b>type:</b> Must be present with the value “abstract methods”.</p>
     <p><b>of:</b> Must be present; the value is the name of the type for which this table defines the methods.</p>
     <p><b>caption:</b> Optional: If not present, will be generated based on the type name</p>
 
@@ -871,8 +871,8 @@ markEffects: true
   <p><b>primary:</b> Optional: Deprecated in favor of type="definition".</p>
   <p><b>type:</b> Optional: Disposition of the grammar. If absent, it is considered to reference productions defined elsewhere.</p>
   <ul>
-    <li>"definition": The grammar is an authoritative source for productions which should be the target of references.</li>
-    <li>"example": Deprecated in favor of the <b>example</b> attribute.</li>
+    <li>“definition”: The grammar is an authoritative source for productions which should be the target of references.</li>
+    <li>“example”: Deprecated in favor of the <b>example</b> attribute.</li>
   </ul>
 
   <h2>Example</h2>
@@ -993,8 +993,8 @@ markEffects: true
     <p><b>primary:</b> Optional: The production is authoritative and should be the target of references.</p>
     <p><b>type:</b> Optional: Type of production. If absent, the production is considered syntactic.</p>
     <ul>
-      <li>"lexical": The production is part of a lexical grammar, and should render with the LHS and RHS separated by two colons “<b>::</b>”.</li>
-      <li>"regexp": Deprecated because the ECMAScript regular expression grammar is considered to be lexical. Productions with this type render with the LHS and RHS separated by three colons “<b>:::</b>”.</li>
+      <li>“lexical”: The production is part of a lexical grammar, and should render with the LHS and RHS separated by two colons “<b>::</b>”.</li>
+      <li>“regexp”: Deprecated because the ECMAScript regular expression grammar is considered to be lexical. Productions with this type render with the LHS and RHS separated by three colons “<b>:::</b>”.</li>
     </ul>
   </emu-clause>
 
@@ -1029,13 +1029,13 @@ markEffects: true
   <emu-clause id="emu-gmod">
     <h1>emu-gmod</h1>
 
-    <p>Contains well-known modifiers to a right-hand side of a production. The only well-known modifier at present is the "but not" modifier. See the Identifier example <emu-xref href="#grammar">above</emu-xref>.</p>
+    <p>Contains well-known modifiers to a right-hand side of a production. The only well-known modifier at present is the “but not” modifier. See the Identifier example <emu-xref href="#grammar">above</emu-xref>.</p>
   </emu-clause>
 
   <emu-clause id="emu-gann">
     <h1>emu-gann</h1>
 
-    <p>Contains well-known annotations to to a right-hand side of a production. The only well-known modifiers at present are "lookahead" and "empty". See the ExpressionStatement example <emu-xref href="#grammar">above</emu-xref>. Any text inside a gann element is wrapped in square brackets.</p>
+    <p>Contains well-known annotations to to a right-hand side of a production. The only well-known modifiers at present are “lookahead” and “empty”. See the ExpressionStatement example <emu-xref href="#grammar">above</emu-xref>. Any text inside a gann element is wrapped in square brackets.</p>
   </emu-clause>
 
   <emu-clause id="emu-gprose">
@@ -1071,7 +1071,7 @@ markEffects: true
 
   <emu-clause id="ins-del">
     <h1>Indicating Changes</h1>
-    <p>The `ins` and `del` HTML elements can be used to mark insertions and deletions respectively. When adding or removing block content (such as entire list items, paragraphs, clauses, grammar RHSes, etc.), use a class of "block".</p>
+    <p>The `ins` and `del` HTML elements can be used to mark insertions and deletions respectively. When adding or removing block content (such as entire list items, paragraphs, clauses, grammar RHSes, etc.), use a class of “block”.</p>
 
     <h2>Inline Example</h2>
     <pre><code class="language-html">ECMAScript &lt;del>6&lt;/del>&lt;ins>2015&lt;/ins> &lt;del>will be ratified&lt;/del>&lt;ins>was ratified&lt;/ins> in June, 2015.</code></pre>

--- a/src/formatter/ecmarkup.ts
+++ b/src/formatter/ecmarkup.ts
@@ -15,6 +15,7 @@ const RAW_CONTENT_ELEMENTS = new Set([
   'script',
   'style',
   'code',
+  'emu-val',
 ]);
 
 // https://html.spec.whatwg.org/multipage/syntax.html#void-elements
@@ -84,7 +85,7 @@ export async function printDocument(src: string): Promise<string> {
   output.appendLine(`<!DOCTYPE html>`);
 
   for (const comment of leadingComments) {
-    output.append(await printChildNodes(src, [comment], false, false, 0));
+    output.append(await printChildNodes(src, [comment], 'block', false, false, 0));
     output.linebreak();
   }
 
@@ -119,8 +120,8 @@ export async function printDocument(src: string): Promise<string> {
     output.append(await printElement(src, head, 0));
     output.append(await printElement(src, body, 0));
   } else {
-    output.append(await printChildNodes(src, head.childNodes, false, false, 0));
-    output.append(await printChildNodes(src, body.childNodes, false, false, 0));
+    output.append(await printChildNodes(src, head.childNodes, 'block', false, false, 0));
+    output.append(await printChildNodes(src, body.childNodes, 'block', false, false, 0));
   }
   while (output.lines[0] === '') {
     output.lines.shift();
@@ -166,7 +167,7 @@ export async function printElement(
   if (PARAGRAPH_LIKE_ELEMENTS.has(node.tagName)) {
     output.firstLineIsPartial = false;
     output.appendText(printStartTag(node));
-    const body = await printChildNodes(src, childNodes, false, false, indent + 1);
+    const body = await printChildNodes(src, childNodes, 'block', false, false, indent + 1);
     body.trim();
     if (body.lines.length > 1) {
       output.linebreak();
@@ -288,7 +289,14 @@ export async function printElement(
         const type = node.attrs.find(a => a.name === 'type')?.value ?? null;
         const printedHeader = printHeader(parseResult, type, indent + 2);
         output.append(
-          await printChildNodes(src, childNodes.slice(0, maybeH1Index), true, true, indent + 1),
+          await printChildNodes(
+            src,
+            childNodes.slice(0, maybeH1Index),
+            'block',
+            true,
+            true,
+            indent + 1,
+          ),
         );
         if (output.last !== '') {
           output.linebreak();
@@ -301,7 +309,9 @@ export async function printElement(
         dropLeadingLinebreaks = false;
       }
     }
-    output.append(await printChildNodes(src, childNodes, dropLeadingLinebreaks, true, indent + 1));
+    output.append(
+      await printChildNodes(src, childNodes, 'block', dropLeadingLinebreaks, true, indent + 1),
+    );
     --output.indent;
     output.appendLine(`</${node.tagName}>`);
 
@@ -360,13 +370,14 @@ export async function printElement(
   if (block) {
     output.appendLine(printStartTag(node));
     ++output.indent;
-    output.append(await printChildNodes(src, childNodes, true, true, indent + 1));
+    output.append(await printChildNodes(src, childNodes, 'block', true, true, indent + 1));
     --output.indent;
     output.appendLine(`</${node.nodeName}>`);
   } else {
     output.appendText(printStartTag(node));
     ++output.indent;
-    output.append(await printChildNodes(src, childNodes, false, true, indent + 1));
+    const flowContext = node.tagName === 'emu-note' ? 'block' : 'inline';
+    output.append(await printChildNodes(src, childNodes, flowContext, false, true, indent + 1));
     --output.indent;
     const trailingSpace = output.last.endsWith(' ');
     if (trailingSpace) {
@@ -383,12 +394,14 @@ export async function printElement(
 async function printChildNodes(
   src: string,
   nodes: Node[],
+  flowContext: 'block' | 'inline',
   dropLeadingLinebreaks: boolean,
   dropTrailingLinebreaks: boolean,
   indent: number,
 ): Promise<LineBuilder> {
   const output = new LineBuilder(indent);
   let skipNextElement = false;
+  let inlineRunFirstLine = 0;
   for (let i = 0; i < nodes.length; ++i) {
     const node = nodes[i];
     if (node.nodeName === '#comment') {
@@ -464,12 +477,83 @@ async function printChildNodes(
           }
         }
       } else {
+        const inlineRunEnded = flowContext === 'block' && isBlockElement(ele);
+        if (inlineRunEnded) {
+          fixAsciiQuotes(output.lines, inlineRunFirstLine);
+        }
         output.append(await printElement(src, ele, indent));
+        if (inlineRunEnded) {
+          inlineRunFirstLine = output.lines.length;
+        }
       }
     }
   }
+  if (flowContext === 'block') {
+    fixAsciiQuotes(output.lines, inlineRunFirstLine);
+  }
 
   return output;
+}
+
+// this regular expression is not perfect, but generally follows
+// https://html.spec.whatwg.org/multipage/parsing.html#tokenization
+// (and spec source text tends to avoid the sort of edge cases that would
+// reveal its flaws)
+const rHtmlTag = (() => {
+  const SPACE_CHAR = '[\\t\\n\\f ]';
+  const TOKEN_CHAR = '[^\\t\\n\\f />]';
+  const ATTR = `(?=${TOKEN_CHAR}|=)${TOKEN_CHAR}*(?:=${SPACE_CHAR}*(?:"[^"]*"|'[^']*'|(?!"|')${TOKEN_CHAR}*)?)?`;
+  return new RegExp(
+    String.raw`(</?([a-z]${TOKEN_CHAR}*))((?:${SPACE_CHAR}*${ATTR})*)${SPACE_CHAR}*/?>`,
+    'gi',
+  );
+})();
+
+const rMaybeAsciiQuoted = new RegExp(
+  String.raw`${'`'}(?:[^${'`'}\\]|\\.)*${'`'}|<(${[...RAW_CONTENT_ELEMENTS].join('|')})\b[^>]*>.*?</\1\b[^>]*>|=".*?"|\*".*?"\*|"(.*?)"`,
+  'gi',
+);
+
+function fixAsciiQuotes(lines: string[], i: number = 0) {
+  for (let inComment = false; i < lines.length; i++) {
+    let line = lines[i];
+
+    // handle multi-line comments
+    const preservedPrefix = inComment ? line.match(/^.*?-->/)?.[0] || line : '';
+    if (preservedPrefix) {
+      inComment = false;
+      line = line.substring(preservedPrefix.length);
+    } else if (inComment) {
+      continue;
+    }
+
+    // replace escapes/comments and tags with placeholders (in that order)
+    const placeholders: string[] = [];
+    line = line.replace(/&\d|<!--.*?-->/g, c => `&${placeholders.push(c) - 1};`);
+    line = line.replace(rHtmlTag, (tag, prefix, name, attrs) => {
+      if (RAW_CONTENT_ELEMENTS.has(name)) {
+        // keep the tag name but replace any attributes with a placeholder
+        return attrs ? `${prefix}&${placeholders.push(tag.slice(prefix.length, -1)) - 1};>` : tag;
+      }
+      return `&${placeholders.push(tag) - 1};`;
+    });
+
+    const preservedSuffix = line.match(/<!--.*/)?.[0] || '';
+    if (preservedSuffix) {
+      inComment = true;
+      line = line.slice(0, -preservedSuffix.length);
+    }
+
+    // replace remaining ASCII quotes
+    line = line.replace(rMaybeAsciiQuoted, (m, _tagName, asciiQuoted) =>
+      asciiQuoted === undefined ? m : `“${asciiQuoted}”`,
+    );
+
+    // replace the line, with placeholders restored in reverse order
+    line = line.replace(/&(\d+);/g, (_m, i) => placeholders[i]);
+    line = line.replace(/&(\d+);/g, (_m, i) => placeholders[i]);
+    lines[i] = preservedPrefix + line + preservedSuffix;
+  }
 }
 
 function isBlockElement(element: Element) {

--- a/src/formatter/ecmarkup.ts
+++ b/src/formatter/ecmarkup.ts
@@ -193,7 +193,9 @@ export async function printElement(
       bad(node, 'failed to parse algorithm');
     }
     output.appendLine(printStartTag(node));
-    output.append(await printAlgorithm(contents, parsed, indent + 1));
+    const steps = await printAlgorithm(contents, parsed, indent + 1);
+    fixAsciiQuotes(steps.lines);
+    output.append(steps);
     output.appendLine(`</${node.tagName}>`);
     return output;
   }

--- a/test/formatter.ts
+++ b/test/formatter.ts
@@ -261,16 +261,18 @@ describe('document formatting', () => {
     );
   });
 
-  it('<script>, <style>, and <pre> whitespace is preserved', async () => {
+  it('whitespace and inner ASCII quotes are preserved inside <script>, <style>, and <pre>', async () => {
     await assertRoundTrips(
       `<script>
     content
+    "quoted content"
 </script>
 <style>
     content
+    "quoted content"
 </style>
 <pre>
-    content
+    "content"
 </pre>
 `,
     );
@@ -322,6 +324,39 @@ describe('document formatting', () => {
 <P> this   does   not </P>
 <p>this also gets formatted</p>
 `,
+    );
+  });
+
+  it('replaces ASCII quotes', async () => {
+    await assertDocFormatsAs(
+      `
+      <div>
+        "quotes" can span "<em class="foo">inline elements</em>"
+        <!-- ...but <comment> contents are "left alone" -->
+        <!--
+          (even when "multi-line")
+        --> and quotes can "follow comments"
+      </div>
+      <emu-alg>
+        1. [x="a"] Assert: Quotes are also "detected" in "algorithm steps".
+      </emu-alg>
+      `,
+      dedentKeepingTrailingNewline`
+      <div>
+        “quotes” can span “<em class="foo">inline elements</em>”
+        <!-- ...but <comment> contents are "left alone" -->
+        <!-- (even when "multi-line") --> and quotes can “follow comments”
+      </div>
+      <emu-alg>
+        1. [x="a"] Assert: Quotes are also “detected” in “algorithm steps”.
+      </emu-alg>
+      `,
+    );
+  });
+
+  it('preserves ASCII quotes that are code', async () => {
+    await assertRoundTrips(
+      `<p>ASCII quotes are not replaced in <code data-media-type="text/plain">"code elements"</code>, <emu-val>"emu-val elements"</emu-val>, ${'`'}"backtick spans"${'`'}, or *"inline language strings"*.</p>\n`,
     );
   });
 });


### PR DESCRIPTION
Ref https://github.com/tc39/ecma262/pull/3861#pullrequestreview-4412001453
Ref #173
Ref #317

Note that this processing cannot be scoped to individual text nodes because logical quotations can span across those, e.g. <tt><ins>a "</ins>\<a href="…"><ins>binary64</ins>\</a><ins> value"</ins></tt> should get rewritten into <tt><ins>a “</ins>\<a href="…"><ins>binary64</ins>\</a><ins> value”</ins></tt> (but the same would not be true if the medial element were block-level rather than inline).

ASCII quotes are not replaced inside of HTML comments, `<code>`/`<emu-val>` elements, backtick spans (e.g., ``` `code` ```), asterisk spans (e.g., `*"string"*`), or after equals signs (as in HTML element attributes).

This approach is not perfect, but spec source text tends to strongly avoid the sort of edge cases that would reveal its flaws (_e.g., using it as an automated analog of https://github.com/tc39/ecma262/pull/3861 finds only one line to change, in [substring](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#substring)—from «If the <del>"to"</del> suffix is omitted» to «If the **“to”** suffix is omitted»_).