### PR TITLE
treat enums as never members of unknown types

### DIFF
--- a/src/type-logic.ts
+++ b/src/type-logic.ts
@@ -4,6 +4,7 @@ import type { Expr, NonSeq } from './expr-parser';
 
 export type Type =
   | { kind: 'unknown' } // top
+  | { kind: 'unknown-non-enum' } // anything except an enum value
   | { kind: 'never' } // bottom
   | { kind: 'union'; of: NonUnion[] } // constraint: nothing in the union dominates anything else in the union
   | { kind: 'list'; of: Type }
@@ -34,6 +35,7 @@ export type Type =
 type NonUnion = Exclude<Type, { kind: 'union' }>;
 const simpleKinds = new Set<Type['kind']>([
   'unknown',
+  'unknown-non-enum',
   'never',
   'record',
   'abrupt completion',
@@ -97,12 +99,18 @@ export function dominates(a: Type, b: Type): boolean {
   if (a.kind === 'unknown' || b.kind === 'never') {
     return true;
   }
+  if (b.kind === 'unknown') {
+    return false;
+  }
   if (b.kind === 'union') {
     return b.of.every(t => dominates(a, t));
   }
   if (a.kind === 'union') {
-    // not necessarily true for arbitrary lattices, but true for ours
+    // not necessarily true for arbitrary lattices, but true for ours: our non-union types are join-prime, i.e., a union dominates such a type only if one of the members of the union dominates it
     return a.of.some(t => dominates(t, b));
+  }
+  if (a.kind === 'unknown-non-enum') {
+    return b.kind !== 'enum value';
   }
   if (
     (a.kind === 'list' && b.kind === 'list') ||
@@ -232,6 +240,9 @@ export function serialize(type: Type): string {
   switch (type.kind) {
     case 'unknown': {
       return 'unknown';
+    }
+    case 'unknown-non-enum': {
+      return 'unknown-non-enum';
     }
     case 'never': {
       return 'never';
@@ -614,7 +625,7 @@ export function typeFromExprType(type: BiblioType): Type {
       return { kind: 'enum value', value: 'unused' };
     }
   }
-  return { kind: 'unknown' };
+  return { kind: 'unknown-non-enum' };
 }
 
 export function isCompletion(

--- a/test/type-logic.ts
+++ b/test/type-logic.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { dominates, join } from '../lib/type-logic.js';
+
+describe('type lattice', () => {
+  it('unknown-non-enum remains distinct from enums and genuine unknown', () => {
+    const unknown = { kind: 'unknown' } as const;
+    const unknownNonEnum = { kind: 'unknown-non-enum' } as const;
+    const empty = { kind: 'enum value', value: 'empty' } as const;
+    const unused = { kind: 'enum value', value: 'unused' } as const;
+    const unknownNonEnumOrEmpty = join(unknownNonEnum, empty);
+
+    assert(dominates(unknown, unknownNonEnumOrEmpty));
+    assert(!dominates(unknownNonEnumOrEmpty, unknown));
+    assert(dominates(unknownNonEnumOrEmpty, unknownNonEnum));
+    assert(dominates(unknownNonEnumOrEmpty, empty));
+    assert(!dominates(unknownNonEnumOrEmpty, unused));
+  });
+});

--- a/test/typecheck.ts
+++ b/test/typecheck.ts
@@ -1751,8 +1751,16 @@ describe('type system', () => {
       "returned value (~iterate-strings~) does not look plausibly assignable to algorithm's return type (~sync~ or ~async~)",
     );
 
+    await assertTypeError(
+      'either a PrivateElement or ~empty~',
+      '~unused~',
+      'argument (~unused~) does not look plausibly assignable to parameter type (unknown-non-enum or ~empty~)',
+      "returned value (~unused~) does not look plausibly assignable to algorithm's return type (unknown-non-enum or ~empty~)",
+    );
+
     await assertNoTypeError('~sync~ or ~async~', '~sync~');
     await assertNoTypeError('~sync~ or ~async~', '~async~');
+    await assertNoTypeError('either a PrivateElement or ~empty~', '~empty~');
   });
 
   it('boolean', async () => {


### PR DESCRIPTION
The type lattice is deliberately conservative; when it encounters a type name it doesn't recognize, like `PrivateElement`, it assumes that could hold anything and as such it is never an error to assign any value to something of that type.

This heuristic is generally necessary; e.g. a [property key](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#property-key) is a String or a Symbol, and "property key" is an unknown type, so it is good that ecmarkup does not regard it as an error to assign a String to an unknown type.

However, we don't and (I weakly believe) shouldn't define any types that hold enums. This means we can assume a type name we don't recognize cannot hold an enum, and so assigning an enum specifically to such a type is an error.