### PR TITLE
Support non-ASCII characters in parameter/alias names

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
   },
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2020
+    "ecmaVersion": 2024
   },
   "overrides": [
     {

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -668,18 +668,18 @@ export function parseParams(params: string): ParsedParams | null {
 
   // Patterns with ..., &hellip;, or …
   if (
-    /^ (_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*(\.\.\.|&hellip;|…)(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_| )(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)* $/u.test(
+    /^ (_\p{ID_Start}[\p{ID_Continue}--_]*_, )*(\.\.\.|&hellip;|…)(_\p{ID_Start}[\p{ID_Continue}--_]*_| )(, _\p{ID_Start}[\p{ID_Continue}--_]*_)* $/v.test(
       params,
     )
   ) {
     // Trailing ..._rest_ with no params after it
     const restMatch = params.match(
-      /^ ((?:_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*)\.\.\.(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_) $/u,
+      /^ ((?:_\p{ID_Start}[\p{ID_Continue}--_]*_, )*)\.\.\.(_\p{ID_Start}[\p{ID_Continue}--_]*_) $/v,
     );
     if (restMatch) {
-      const required = [
-        ...restMatch[1].matchAll(/_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_/gu),
-      ].map(m => m[1]);
+      const required = [...restMatch[1].matchAll(/_(\p{ID_Start}[\p{ID_Continue}--_]*)_/gv)].map(
+        m => m[1],
+      );
       const rest = restMatch[2].slice(1, -1);
       return { type: 'normal', required, optional: [], rest };
     }
@@ -691,7 +691,7 @@ export function parseParams(params: string): ParsedParams | null {
   // Example ( [ _foo_ [ , _bar_ ] ] )
   // using this horrible regex and then a manual parse really is simpler than just parsing manually
   if (
-    /^ (\[ )?_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)*( \[ , _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)*)*( \])* $/u.test(
+    /^ (\[ )?_\p{ID_Start}[\p{ID_Continue}--_]*_(, _\p{ID_Start}[\p{ID_Continue}--_]*_)*( \[ , _\p{ID_Start}[\p{ID_Continue}--_]*_(, _\p{ID_Start}[\p{ID_Continue}--_]*_)*)*( \])* $/v.test(
       params,
     )
   ) {

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -668,12 +668,18 @@ export function parseParams(params: string): ParsedParams | null {
 
   // Patterns with ..., &hellip;, or …
   if (
-    /^ (_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*(\.\.\.|&hellip;|…)(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_| )(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)* $/u.test(params)
+    /^ (_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*(\.\.\.|&hellip;|…)(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_| )(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)* $/u.test(
+      params,
+    )
   ) {
     // Trailing ..._rest_ with no params after it
-    const restMatch = params.match(/^ ((?:_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*)\.\.\.(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_) $/u);
+    const restMatch = params.match(
+      /^ ((?:_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*)\.\.\.(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_) $/u,
+    );
     if (restMatch) {
-      const required = [...restMatch[1].matchAll(/_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_/gu)].map(m => m[1]);
+      const required = [
+        ...restMatch[1].matchAll(/_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_/gu),
+      ].map(m => m[1]);
       const rest = restMatch[2].slice(1, -1);
       return { type: 'normal', required, optional: [], rest };
     }

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -668,12 +668,12 @@ export function parseParams(params: string): ParsedParams | null {
 
   // Patterns with ..., &hellip;, or …
   if (
-    /^ (_[A-Za-z0-9]+_, )*(\.\.\.|&hellip;|…)(_[A-Za-z0-9]+_| )(, _[A-Za-z0-9]+_)* $/.test(params)
+    /^ (_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*(\.\.\.|&hellip;|…)(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_| )(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)* $/u.test(params)
   ) {
     // Trailing ..._rest_ with no params after it
-    const restMatch = params.match(/^ ((?:_[A-Za-z0-9]+_, )*)\.\.\.(_[A-Za-z0-9]+_) $/);
+    const restMatch = params.match(/^ ((?:_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_, )*)\.\.\.(_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_) $/u);
     if (restMatch) {
-      const required = [...restMatch[1].matchAll(/_([A-Za-z0-9]+)_/g)].map(m => m[1]);
+      const required = [...restMatch[1].matchAll(/_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_/gu)].map(m => m[1]);
       const rest = restMatch[2].slice(1, -1);
       return { type: 'normal', required, optional: [], rest };
     }
@@ -685,7 +685,7 @@ export function parseParams(params: string): ParsedParams | null {
   // Example ( [ _foo_ [ , _bar_ ] ] )
   // using this horrible regex and then a manual parse really is simpler than just parsing manually
   if (
-    /^ (\[ )?_[A-Za-z0-9]+_(, _[A-Za-z0-9]+_)*( \[ , _[A-Za-z0-9]+_(, _[A-Za-z0-9]+_)*)*( \])* $/.test(
+    /^ (\[ )?_\p{ID_Start}(?:(?!_)\p{ID_Continue})*_(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)*( \[ , _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_(, _\p{ID_Start}(?:(?!_)\p{ID_Continue})*_)*)*( \])* $/u.test(
       params,
     )
   ) {

--- a/src/formatter/header.ts
+++ b/src/formatter/header.ts
@@ -11,7 +11,7 @@ function printTypedParam(param: Param, optional: boolean) {
 }
 
 function ensureUnderscores(param: Param) {
-  if (!/^\p{ID_Start}(?:(?!_)\p{ID_Continue})*$/u.test(param.name)) {
+  if (!/^\p{ID_Start}[\p{ID_Continue}--_]*$/v.test(param.name)) {
     return param;
   }
   return {

--- a/src/formatter/header.ts
+++ b/src/formatter/header.ts
@@ -11,7 +11,7 @@ function printTypedParam(param: Param, optional: boolean) {
 }
 
 function ensureUnderscores(param: Param) {
-  if (!/^[a-zA-Z0-9]+$/.test(param.name)) {
+  if (!/^\p{ID_Start}(?:(?!_)\p{ID_Continue})*$/u.test(param.name)) {
     return param;
   }
   return {

--- a/src/header-parser.ts
+++ b/src/header-parser.ts
@@ -147,7 +147,7 @@ export function parseHeader(headerText: string): ParsedHeaderOrFailure {
         });
       }
 
-      ({ match, text } = eat(text, /^[A-Za-z0-9_]+ */i));
+      ({ match, text } = eat(text, /^\p{ID_Continue}+ */iu));
       if (!match) {
         errors.push({ message: 'expected parameter name', offset });
         return { type: 'failure', errors };
@@ -222,7 +222,7 @@ export function parseHeader(headerText: string): ParsedHeaderOrFailure {
         offset += match[0].length;
       }
 
-      ({ text, match } = eat(text, /^([A-Za-z0-9_]+)\s*/));
+      ({ text, match } = eat(text, /^(\p{ID_Continue}+)\s*/u));
       if (!match) {
         errors.push({ message: 'expected parameter name', offset });
         return { type: 'failure', errors };

--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -146,7 +146,9 @@ export function checkVariableUsage(
       const isParameter = preceding.nodeName === 'H1';
       const seen = new Set<string>();
       // `__` is for <del>_x_</del><ins>_y_</ins>, which has textContent `_x__y_`
-      for (const name of preceding.textContent.matchAll(/(?<=\b|_)_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_(?=\b|_)/gu)) {
+      for (const name of preceding.textContent.matchAll(
+        /(?<=\b|_)_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_(?=\b|_)/gu,
+      )) {
         // We avoid dealing with parameter re-declaration here because tracking location information is annoying. It's handled in `checkDuplicateParam` in header-parser instead.
         if (seen.has(name[1])) continue;
         seen.add(name[1]);

--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -146,7 +146,7 @@ export function checkVariableUsage(
       const isParameter = preceding.nodeName === 'H1';
       const seen = new Set<string>();
       // `__` is for <del>_x_</del><ins>_y_</ins>, which has textContent `_x__y_`
-      for (const name of preceding.textContent.matchAll(/(?<=\b|_)_([a-zA-Z0-9]+)_(?=\b|_)/g)) {
+      for (const name of preceding.textContent.matchAll(/(?<=\b|_)_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_(?=\b|_)/gu)) {
         // We avoid dealing with parameter re-declaration here because tracking location information is annoying. It's handled in `checkDuplicateParam` in header-parser instead.
         if (seen.has(name[1])) continue;
         seen.add(name[1]);

--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -147,7 +147,7 @@ export function checkVariableUsage(
       const seen = new Set<string>();
       // `__` is for <del>_x_</del><ins>_y_</ins>, which has textContent `_x__y_`
       for (const name of preceding.textContent.matchAll(
-        /(?<=\b|_)_(\p{ID_Start}(?:(?!_)\p{ID_Continue})*)_(?=\b|_)/gu,
+        /(?<=\b|_)_(\p{ID_Start}[\p{ID_Continue}--_]*)_(?=\b|_)/gv,
       )) {
         // We avoid dealing with parameter re-declaration here because tracking location information is annoying. It's handled in `checkDuplicateParam` in header-parser instead.
         if (seen.has(name[1])) continue;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src/**/*"],
     "compilerOptions": {
-        "target": "es2019",
+        "target": "esnext",
         "module": "commonjs",
         "moduleResolution": "node",
         "strict": true,


### PR DESCRIPTION
Fixes #718

`_` is not allowed in parameter/alias names because it delimits them, but this otherwise aligns with [UAX #31](https://www.unicode.org/reports/tr31/).

The initial state does not yet include test coverage; I wanted to get this up for discussion first.