### PR TITLE
support del params

### DIFF
--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -8,10 +8,10 @@ import { ParseError, TypeParser } from './type-parser';
 import Builder from './Builder';
 import type { ParsedHeader } from './header-parser';
 import {
-  formatPreamble,
-  parseStructuredHeaderDl,
   formatHeader,
-  parseHeader,
+  formatPreamble,
+  parseHeaderCached,
+  parseStructuredHeaderDl,
 } from './header-parser';
 import { offsetToLineAndColumn, traverseWhile, withOrdinalSuffix, zip } from './utils';
 import { dominates, serialize, typeFromExprType } from './type-logic';
@@ -244,8 +244,7 @@ export default class Clause extends Builder {
 
     const type = this.type;
 
-    const headerSource = getHeaderSource(header, this.spec);
-    const parseResult = parseHeader(headerSource);
+    const { source: headerSource, parseResult } = parseHeaderCached(header, this.spec);
     if (parseResult.type !== 'failure') {
       try {
         this.signature = parsedHeaderToSignature(parseResult);

--- a/src/Table.ts
+++ b/src/Table.ts
@@ -1,8 +1,8 @@
 import type Spec from './Spec';
 import type { Context } from './Context';
 
-import { getHeaderSource, parsedHeaderToSignature } from './Clause';
-import { formatHeader, parseHeader, warnAllErrors } from './header-parser';
+import { parsedHeaderToSignature } from './Clause';
+import { formatHeader, parseHeaderCached, warnAllErrors } from './header-parser';
 import type { PartialBiblioEntry, Signature } from './Biblio';
 import { ParseError } from './type-parser';
 import { offsetToLineAndColumn, traverseWhile } from './utils';
@@ -106,8 +106,7 @@ export default class Table extends Figure {
         continue;
       }
 
-      const headerSource = getHeaderSource(header, spec);
-      const parseResult = parseHeader(headerSource);
+      const { source: headerSource, parseResult } = parseHeaderCached(header, spec);
 
       if (parseResult.type === 'failure') {
         warnAllErrors(spec, header, parseResult);

--- a/src/header-parser.ts
+++ b/src/header-parser.ts
@@ -1,3 +1,4 @@
+import { getHeaderSource } from './Clause';
 import type Spec from './Spec';
 import { offsetToLineAndColumn, validateEffects } from './utils';
 
@@ -40,6 +41,23 @@ export type ParsedHeaderOrFailure =
       type: 'failure';
       errors: ParseError[];
     };
+
+const headerParseCache = new WeakMap<
+  Element,
+  { source: string; parseResult: ParsedHeaderOrFailure }
+>();
+export function parseHeaderCached(
+  header: Element,
+  spec: Spec,
+): { source: string; parseResult: ParsedHeaderOrFailure } {
+  let cached = headerParseCache.get(header);
+  if (cached == null) {
+    const source = getHeaderSource(header, spec);
+    cached = { source, parseResult: parseHeader(source) };
+    headerParseCache.set(header, cached);
+  }
+  return cached;
+}
 
 export function parseHeader(headerText: string): ParsedHeaderOrFailure {
   let offset = 0;

--- a/src/lint/collect-algorithm-diagnostics.ts
+++ b/src/lint/collect-algorithm-diagnostics.ts
@@ -120,6 +120,7 @@ export function collectAlgorithmDiagnostics(
       }
       if (allNodesParsedSuccessfully) {
         checkVariableUsage(
+          spec,
           algorithmSource,
           algorithm.element,
           tree.contents,

--- a/src/lint/collect-nodes.ts
+++ b/src/lint/collect-nodes.ts
@@ -2,6 +2,8 @@ import type { default as Spec, Warning } from '../Spec';
 
 import type { AlgorithmNode } from 'ecmarkdown';
 
+import { textContentExcludingDeleted } from '../utils';
+
 type CollectNodesReturnType =
   | {
       success: true;
@@ -164,16 +166,4 @@ export function collectNodes(
   }
 
   return { success: true, mainGrammar, headers, sdos, earlyErrors, algorithms };
-}
-
-function textContentExcludingDeleted(node: Node): string {
-  let retval = '';
-  node.childNodes.forEach(value => {
-    if (value.nodeType === 3) {
-      retval += value.nodeValue;
-    } else if (value.nodeType !== 1 || (value as Element).tagName !== 'DEL') {
-      retval += textContentExcludingDeleted(value);
-    }
-  });
-  return retval;
 }

--- a/src/lint/rules/variable-use-def.ts
+++ b/src/lint/rules/variable-use-def.ts
@@ -7,8 +7,15 @@ import type {
 } from 'ecmarkdown';
 import type { Reporter } from '../algorithm-error-reporter-type';
 import type { Seq } from '../../expr-parser';
+import type { default as Spec } from '../../Spec';
 import { walk as walkExpr } from '../../expr-parser';
-import { isAbstractClosureHeader, offsetToLineAndColumn } from '../../utils';
+import { extractStructuredHeader } from '../../Clause';
+import { parseHeaderCached } from '../../header-parser';
+import {
+  isAbstractClosureHeader,
+  offsetToLineAndColumn,
+  textContentExcludingDeleted,
+} from '../../utils';
 
 /*
 Ecmaspeak scope rules are a bit weird.
@@ -110,6 +117,7 @@ class Scope {
 }
 
 export function checkVariableUsage(
+  spec: Spec,
   algorithmSource: string,
   containingAlgorithm: Element,
   steps: OrderedListNode,
@@ -138,16 +146,25 @@ export function checkVariableUsage(
   // this is a little permissive, but it's hard to find a precise rule, and that's better than being too restrictive
   let preceding = previousOrParent(containingAlgorithm, parentClause);
   while (preceding != null) {
-    if (
+    const params = structuredHeaderParams(preceding, spec);
+    if (params != null) {
+      // duplicate params are already handled by `checkDuplicateParam` in header-parser
+      for (const param of params) {
+        scope.declare(param, null, 'parameter');
+      }
+    } else if (
       preceding.tagName !== 'EMU-ALG' &&
+      preceding.nodeName !== 'DEL' &&
       preceding.querySelector('emu-alg') == null &&
       preceding.textContent != null
     ) {
       const isParameter = preceding.nodeName === 'H1';
       const seen = new Set<string>();
-      // `__` is for <del>_x_</del><ins>_y_</ins>, which has textContent `_x__y_`
-      for (const name of preceding.textContent.matchAll(/(?<=\b|_)_([a-zA-Z0-9]+)_(?=\b|_)/g)) {
-        // We avoid dealing with parameter re-declaration here because tracking location information is annoying. It's handled in `checkDuplicateParam` in header-parser instead.
+      // `__` is for adjacent variables like <ins>_x_</ins><ins>_y_</ins>, whose text is `_x__y_`
+      for (const name of textContentExcludingDeleted(preceding).matchAll(
+        /(?<=\b|_)_([a-zA-Z0-9]+)_(?=\b|_)/g,
+      )) {
+        // as above, re-declaration of parameters is handled elsewhere
         if (seen.has(name[1])) continue;
         seen.add(name[1]);
         scope.declare(name[1], null, isParameter ? 'parameter' : undefined, !isParameter);
@@ -447,6 +464,24 @@ function walkAlgorithm(
     }
   }
   scope.strictScopes.pop();
+}
+
+function structuredHeaderParams(element: Element, spec: Spec): Iterable<string> | null {
+  if (element.nodeName !== 'H1' || extractStructuredHeader(element) == null) {
+    return null;
+  }
+  const { parseResult } = parseHeaderCached(element, spec);
+  if (parseResult.type === 'failure' || parseResult.wrappingTag === 'del') {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const param of [...parseResult.params, ...parseResult.optionalParams]) {
+    const match = param.wrappingTag === 'del' ? null : param.name.match(/^_([a-zA-Z0-9]+)_$/);
+    if (match != null) {
+      seen.add(match[1]);
+    }
+  }
+  return seen;
 }
 
 function isVariable(node: UnderscoreNode | { name: string } | null): node is UnderscoreNode {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -346,6 +346,18 @@ export function isAbstractClosureHeader(text: string): boolean {
   return acHeaderRe.test(text);
 }
 
+export function textContentExcludingDeleted(node: Node): string {
+  let retval = '';
+  node.childNodes.forEach(value => {
+    if (value.nodeType === 3) {
+      retval += value.nodeValue;
+    } else if (value.nodeType !== 1 || (value as Element).tagName !== 'DEL') {
+      retval += textContentExcludingDeleted(value);
+    }
+  });
+  return retval;
+}
+
 export function ownTextContent(el: Element): string {
   let text = '';
   for (const child of el.childNodes) {

--- a/test/lint-variable-use-def.ts
+++ b/test/lint-variable-use-def.ts
@@ -747,6 +747,26 @@ describe('variables cannot be redeclared', () => {
       },
     );
   });
+
+  it('deleted parameters can be redeclared', async () => {
+    await assertLintFree(
+      `
+        <emu-clause id="example" type="abstract operation">
+          <h1>
+            Example (
+              <del>_x_: ~foo~,</del>
+              <ins>_y_: ~foo~,</ins>
+            ): ~foo~ or ~bar~
+          </h1>
+          <dl class="header"></dl>
+          <emu-alg>
+            1. <ins>Let _x_ be _y_.</ins>
+            1. Return _x_.
+          </emu-alg>
+        </emu-clause>
+      `,
+    );
+  });
 });
 
 describe('closures must not capture reassigned variables', () => {


### PR DESCRIPTION
Uses the structured header parser (when possible) for determining which parameter names are in scope for an algorithm for the purposes of lint. Since that parser already accounts for `<del>` etc, this means that `<del>`'d parameter names are not considered in scope.

Fixes #720 cc @gibson042.